### PR TITLE
fix(state): correct next-phase pointer (Phase 2, not backlog 999.2) a…

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,14 +4,14 @@ milestone: v1.1
 milestone_name: "Backtest Trustworthiness: Breadth"
 status: ready_to_plan
 last_updated: 2026-06-09T08:12:45.594Z
-last_activity: 2026-06-09 -- Phase 01 execution started
+last_activity: 2026-06-09 -- Phase 01 complete (2/2), verified
 progress:
-  total_phases: 12
-  completed_phases: 0
+  total_phases: 9
+  completed_phases: 1
   total_plans: 2
   completed_plans: 2
-  percent: 0
-stopped_at: Phase 01 complete (2/2) — ready to discuss Phase 999.2
+  percent: 11
+stopped_at: Phase 01 complete (2/2) — ready to discuss/plan Phase 2 (Data Ingestion)
 ---
 
 # Project State
@@ -21,14 +21,14 @@ stopped_at: Phase 01 complete (2/2) — ready to discuss Phase 999.2
 See: .planning/PROJECT.md (updated 2026-06-09)
 
 **Core value:** A single backtest run of `SMA_MACD` on the golden BTCUSD CSV produces correct, deterministic, cross-validated numbers — the backtest path must import, run, and yield trustworthy results.
-**Current focus:** Phase 999.2 — nplus2 persistence and performance
+**Current focus:** Phase 2 — Data Ingestion (next active v1.1 phase; ready to plan)
 
 ## Current Position
 
-Phase: 999.2
+Phase: 2 of 9 — Data Ingestion (not started)
 Plan: Not started
 Status: Ready to plan
-Last activity: 2026-06-09
+Last activity: 2026-06-09 -- Phase 01 complete (2/2), verified
 
 ## Performance Metrics
 


### PR DESCRIPTION
This pull request updates the project milestone tracking for "Backtest Trustworthiness: Breadth" in `.planning/STATE.md` to reflect the completion and verification of Phase 01 and prepares for the planning of Phase 2 (Data Ingestion). The milestone's progress metrics and current focus have been updated accordingly.

Milestone progress and status updates:

* Updated `last_activity` to indicate Phase 01 is complete and verified, and increased the `completed_phases` count from 0 to 1. Adjusted `total_phases` from 12 to 9, and updated `percent` completion from 0 to 11. The `stopped_at` field now points to readiness for Phase 2 planning.

* Changed the current focus and position sections to reflect the transition from Phase 999.2 to Phase 2 (Data Ingestion), clarifying that Phase 2 is the next active phase and is ready to be planned.…nd phase counts