### PR TITLE
V1.5/phase 6 bar feed window copies

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -66,7 +66,7 @@ Held throughout: `mypy --strict` clean; Decimal end-to-end (no new float-for-mon
 - [ ] **PERF-05**: SMA & MACD indicators compute incrementally (rolling/memoized) instead of a
   full-window `ta` rebuild every bar, reproducing `[BYTE-EXACT]` output. **Oracle-gated, done LAST.**
   *(Hotspots #2+#7, ~24% CPU — highest-care item.)*
-- [ ] **PERF-06** *(optional)*: Per-tick bar-feed window `iloc` frame copies are reduced (reusable
+- [x] **PERF-06** *(optional)*: Per-tick bar-feed window `iloc` frame copies are reduced (reusable
   view / cached slice bounds), preserving the look-ahead bar-timing contract (the 7 rules in
   `feed/bar_feed.py`). *(Hotspot #5, ~4% W1 / ~22% W2 — scales with symbol count.)*
 
@@ -115,7 +115,7 @@ Every v1 requirement maps to exactly one phase (100% coverage). See `ROADMAP.md`
 | PERF-03 | Phase 4 — Hot-Path Discipline | Complete |
 | PERF-04 | Phase 4 — Hot-Path Discipline | Complete |
 | PERF-05 | Phase 5 — Incremental Indicators (FRAGILE, LAST) | Pending |
-| PERF-06 | Phase 6 — Bar-Feed Window Copies (OPTIONAL) | Pending |
+| PERF-06 | Phase 6 — Bar-Feed Window Copies (OPTIONAL) | Complete |
 
 **Coverage:**
 - v1 requirements: 9 total (TOOL ×3 + PERF ×6; PERF-06 optional) — TOOL-03 dropped 2026-06-23

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -214,7 +214,7 @@ contract-gated item.
   4. **Gate (b):** the clean W1 benchmark shows a measurable improvement vs the prior re-frozen
      baseline, re-frozen as the new locked reference (most visible in the W2 symbol sweep).
 **Plans**: 2 plans
-  - [ ] 06-01-PLAN.md — view-returning window() + memoized _offset_alias + read-only master frames at build sites (D-01/D-06/D-07/D-09) + D-08 drift/equivalence test + Gate (a) (PERF-06)
+  - [x] 06-01-PLAN.md — view-returning window() + memoized _offset_alias + read-only master frames at build sites (D-01/D-06/D-07/D-09) + D-08 drift/equivalence test + Gate (a) (PERF-06)
   - [ ] 06-02-PLAN.md — Gate (b): perf-w2 --check/--baseline-out (>=10% at 50 symbols, D-05) + commit W2-BASELINE.json + re-freeze W1-BASELINE.json (D-04) (PERF-06)
 
 <details>
@@ -318,7 +318,7 @@ in [`milestones/v1.2-ROADMAP.md`](./milestones/v1.2-ROADMAP.md).
 | 3. Running PnL Accumulator | 2/2 | Complete   | 2026-06-24 |
 | 4. Hot-Path Discipline | 3/3 | Complete   | 2026-06-24 |
 | 5. Incremental Indicators (FRAGILE) | 0/TBD | Not started | - |
-| 6. Bar-Feed Window Copies (OPTIONAL) | 0/2 | Planned | - |
+| 6. Bar-Feed Window Copies (OPTIONAL) | 1/2 | In Progress|  |
 
 **Shipped milestones** (full per-phase detail archived under `milestones/`):
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -321,7 +321,7 @@ in [`milestones/v1.2-ROADMAP.md`](./milestones/v1.2-ROADMAP.md).
 | 3. Running PnL Accumulator | 2/2 | Complete   | 2026-06-24 |
 | 4. Hot-Path Discipline | 3/3 | Complete   | 2026-06-24 |
 | 5. Incremental Indicators (FRAGILE) | 0/TBD | Not started | - |
-| 6. Bar-Feed Window Copies (OPTIONAL) | 1/4 active (post-pivot) | In Progress|  |
+| 6. Bar-Feed Window Copies (OPTIONAL) | 2/5 | In Progress|  |
 
 **Shipped milestones** (full per-phase detail archived under `milestones/`):
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -218,7 +218,7 @@ contract-gated item.
   - [~] 06-02-PLAN.md — Task 1 (run_w2_sweep --check/--baseline-out harness + Makefile, f51d7c6) COMMITTED + reused as-is; Tasks 2/3 (cool-machine freeze + verify) SUPERSEDED by 06-05 post-pivot (PERF-06)
   - [x] 06-03-PLAN.md — D-13 denominator cleanup (prep): remove per-bar TIME EVENT debug log + de-time run_w2_sweep two-pass; Gate (a) held (PERF-06)
   - [x] 06-04-PLAN.md — D-10 monotonic int64 cursor in window() (replaces per-tick searchsorted) + D-16 drift-test extension; D-11 recorded infeasible (iloc kept, cursor-only); D-12 builds on kept 06-01; Gate (a) byte-exact (PERF-06)
-  - [ ] 06-05-PLAN.md — D-14/D-15 gate (b): re-freeze BOTH baselines on the cleaned engine (cool machine) + cursor-alone ≥10% W2 verdict (or D-15 ship-and-reframe); absorbs 06-02 Tasks 2/3 (PERF-06)
+  - [x] 06-05-PLAN.md — D-14/D-15 gate (b): re-freeze BOTH baselines on the cleaned engine (cool machine) + cursor-alone ≥10% W2 verdict (or D-15 ship-and-reframe); absorbs 06-02 Tasks 2/3 (PERF-06)
 
 <details>
 <summary>✅ v1.4 — Margin, Leverage, Shorts & Trailing Stops (Phases 1-6 + 5.1) — SHIPPED 2026-06-22</summary>
@@ -321,7 +321,7 @@ in [`milestones/v1.2-ROADMAP.md`](./milestones/v1.2-ROADMAP.md).
 | 3. Running PnL Accumulator | 2/2 | Complete   | 2026-06-24 |
 | 4. Hot-Path Discipline | 3/3 | Complete   | 2026-06-24 |
 | 5. Incremental Indicators (FRAGILE) | 0/TBD | Not started | - |
-| 6. Bar-Feed Window Copies (OPTIONAL) | 4/5 | In Progress|  |
+| 6. Bar-Feed Window Copies (OPTIONAL) | 5/5 | Complete   | 2026-06-24 |
 
 **Shipped milestones** (full per-phase detail archived under `milestones/`):
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -213,9 +213,12 @@ contract-gated item.
      suite is green; `mypy --strict` clean; determinism double-run byte-identical.
   4. **Gate (b):** the clean W1 benchmark shows a measurable improvement vs the prior re-frozen
      baseline, re-frozen as the new locked reference (most visible in the W2 symbol sweep).
-**Plans**: 2 plans
+**Plans**: 4 active plans (post-pivot — 06-01 kept; 06-02 Task 1 harness reused, its freeze/verify absorbed into 06-05)
   - [x] 06-01-PLAN.md — view-returning window() + memoized _offset_alias + read-only master frames at build sites (D-01/D-06/D-07/D-09) + D-08 drift/equivalence test + Gate (a) (PERF-06)
-  - [ ] 06-02-PLAN.md — Gate (b): perf-w2 --check/--baseline-out (>=10% at 50 symbols, D-05) + commit W2-BASELINE.json + re-freeze W1-BASELINE.json (D-04) (PERF-06)
+  - [~] 06-02-PLAN.md — Task 1 (run_w2_sweep --check/--baseline-out harness + Makefile, f51d7c6) COMMITTED + reused as-is; Tasks 2/3 (cool-machine freeze + verify) SUPERSEDED by 06-05 post-pivot (PERF-06)
+  - [ ] 06-03-PLAN.md — D-13 denominator cleanup (prep): remove per-bar TIME EVENT debug log + de-time run_w2_sweep two-pass; Gate (a) held (PERF-06)
+  - [ ] 06-04-PLAN.md — D-10 monotonic int64 cursor in window() (replaces per-tick searchsorted) + D-16 drift-test extension; D-11 recorded infeasible (iloc kept, cursor-only); D-12 builds on kept 06-01; Gate (a) byte-exact (PERF-06)
+  - [ ] 06-05-PLAN.md — D-14/D-15 gate (b): re-freeze BOTH baselines on the cleaned engine (cool machine) + cursor-alone ≥10% W2 verdict (or D-15 ship-and-reframe); absorbs 06-02 Tasks 2/3 (PERF-06)
 
 <details>
 <summary>✅ v1.4 — Margin, Leverage, Shorts & Trailing Stops (Phases 1-6 + 5.1) — SHIPPED 2026-06-22</summary>
@@ -318,7 +321,7 @@ in [`milestones/v1.2-ROADMAP.md`](./milestones/v1.2-ROADMAP.md).
 | 3. Running PnL Accumulator | 2/2 | Complete   | 2026-06-24 |
 | 4. Hot-Path Discipline | 3/3 | Complete   | 2026-06-24 |
 | 5. Incremental Indicators (FRAGILE) | 0/TBD | Not started | - |
-| 6. Bar-Feed Window Copies (OPTIONAL) | 1/2 | In Progress|  |
+| 6. Bar-Feed Window Copies (OPTIONAL) | 1/4 active (post-pivot) | In Progress|  |
 
 **Shipped milestones** (full per-phase detail archived under `milestones/`):
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -217,7 +217,7 @@ contract-gated item.
   - [x] 06-01-PLAN.md — view-returning window() + memoized _offset_alias + read-only master frames at build sites (D-01/D-06/D-07/D-09) + D-08 drift/equivalence test + Gate (a) (PERF-06)
   - [~] 06-02-PLAN.md — Task 1 (run_w2_sweep --check/--baseline-out harness + Makefile, f51d7c6) COMMITTED + reused as-is; Tasks 2/3 (cool-machine freeze + verify) SUPERSEDED by 06-05 post-pivot (PERF-06)
   - [x] 06-03-PLAN.md — D-13 denominator cleanup (prep): remove per-bar TIME EVENT debug log + de-time run_w2_sweep two-pass; Gate (a) held (PERF-06)
-  - [ ] 06-04-PLAN.md — D-10 monotonic int64 cursor in window() (replaces per-tick searchsorted) + D-16 drift-test extension; D-11 recorded infeasible (iloc kept, cursor-only); D-12 builds on kept 06-01; Gate (a) byte-exact (PERF-06)
+  - [x] 06-04-PLAN.md — D-10 monotonic int64 cursor in window() (replaces per-tick searchsorted) + D-16 drift-test extension; D-11 recorded infeasible (iloc kept, cursor-only); D-12 builds on kept 06-01; Gate (a) byte-exact (PERF-06)
   - [ ] 06-05-PLAN.md — D-14/D-15 gate (b): re-freeze BOTH baselines on the cleaned engine (cool machine) + cursor-alone ≥10% W2 verdict (or D-15 ship-and-reframe); absorbs 06-02 Tasks 2/3 (PERF-06)
 
 <details>
@@ -321,7 +321,7 @@ in [`milestones/v1.2-ROADMAP.md`](./milestones/v1.2-ROADMAP.md).
 | 3. Running PnL Accumulator | 2/2 | Complete   | 2026-06-24 |
 | 4. Hot-Path Discipline | 3/3 | Complete   | 2026-06-24 |
 | 5. Incremental Indicators (FRAGILE) | 0/TBD | Not started | - |
-| 6. Bar-Feed Window Copies (OPTIONAL) | 3/5 | In Progress|  |
+| 6. Bar-Feed Window Copies (OPTIONAL) | 4/5 | In Progress|  |
 
 **Shipped milestones** (full per-phase detail archived under `milestones/`):
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -216,7 +216,7 @@ contract-gated item.
 **Plans**: 4 active plans (post-pivot — 06-01 kept; 06-02 Task 1 harness reused, its freeze/verify absorbed into 06-05)
   - [x] 06-01-PLAN.md — view-returning window() + memoized _offset_alias + read-only master frames at build sites (D-01/D-06/D-07/D-09) + D-08 drift/equivalence test + Gate (a) (PERF-06)
   - [~] 06-02-PLAN.md — Task 1 (run_w2_sweep --check/--baseline-out harness + Makefile, f51d7c6) COMMITTED + reused as-is; Tasks 2/3 (cool-machine freeze + verify) SUPERSEDED by 06-05 post-pivot (PERF-06)
-  - [ ] 06-03-PLAN.md — D-13 denominator cleanup (prep): remove per-bar TIME EVENT debug log + de-time run_w2_sweep two-pass; Gate (a) held (PERF-06)
+  - [x] 06-03-PLAN.md — D-13 denominator cleanup (prep): remove per-bar TIME EVENT debug log + de-time run_w2_sweep two-pass; Gate (a) held (PERF-06)
   - [ ] 06-04-PLAN.md — D-10 monotonic int64 cursor in window() (replaces per-tick searchsorted) + D-16 drift-test extension; D-11 recorded infeasible (iloc kept, cursor-only); D-12 builds on kept 06-01; Gate (a) byte-exact (PERF-06)
   - [ ] 06-05-PLAN.md — D-14/D-15 gate (b): re-freeze BOTH baselines on the cleaned engine (cool machine) + cursor-alone ≥10% W2 verdict (or D-15 ship-and-reframe); absorbs 06-02 Tasks 2/3 (PERF-06)
 
@@ -321,7 +321,7 @@ in [`milestones/v1.2-ROADMAP.md`](./milestones/v1.2-ROADMAP.md).
 | 3. Running PnL Accumulator | 2/2 | Complete   | 2026-06-24 |
 | 4. Hot-Path Discipline | 3/3 | Complete   | 2026-06-24 |
 | 5. Incremental Indicators (FRAGILE) | 0/TBD | Not started | - |
-| 6. Bar-Feed Window Copies (OPTIONAL) | 2/5 | In Progress|  |
+| 6. Bar-Feed Window Copies (OPTIONAL) | 3/5 | In Progress|  |
 
 **Shipped milestones** (full per-phase detail archived under `milestones/`):
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -213,7 +213,9 @@ contract-gated item.
      suite is green; `mypy --strict` clean; determinism double-run byte-identical.
   4. **Gate (b):** the clean W1 benchmark shows a measurable improvement vs the prior re-frozen
      baseline, re-frozen as the new locked reference (most visible in the W2 symbol sweep).
-**Plans**: TBD
+**Plans**: 2 plans
+  - [ ] 06-01-PLAN.md — view-returning window() + memoized _offset_alias + read-only master frames at build sites (D-01/D-06/D-07/D-09) + D-08 drift/equivalence test + Gate (a) (PERF-06)
+  - [ ] 06-02-PLAN.md — Gate (b): perf-w2 --check/--baseline-out (>=10% at 50 symbols, D-05) + commit W2-BASELINE.json + re-freeze W1-BASELINE.json (D-04) (PERF-06)
 
 <details>
 <summary>✅ v1.4 — Margin, Leverage, Shorts & Trailing Stops (Phases 1-6 + 5.1) — SHIPPED 2026-06-22</summary>
@@ -316,7 +318,7 @@ in [`milestones/v1.2-ROADMAP.md`](./milestones/v1.2-ROADMAP.md).
 | 3. Running PnL Accumulator | 2/2 | Complete   | 2026-06-24 |
 | 4. Hot-Path Discipline | 3/3 | Complete   | 2026-06-24 |
 | 5. Incremental Indicators (FRAGILE) | 0/TBD | Not started | - |
-| 6. Bar-Feed Window Copies (OPTIONAL) | 0/TBD | Not started | - |
+| 6. Bar-Feed Window Copies (OPTIONAL) | 0/2 | Planned | - |
 
 **Shipped milestones** (full per-phase detail archived under `milestones/`):
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: Backtest Performance Optimization
-status: executing
-stopped_at: Completed 06-04-PLAN.md (D-10 monotonic int64 cursor); ready to execute 06-05 gate-(b) re-freeze
-last_updated: "2026-06-24T15:07:46.999Z"
+status: ready_to_plan
+stopped_at: Phase 06 complete (5/5) — ready to discuss Phase 999.2
+last_updated: 2026-06-24T15:42:12.372Z
 last_activity: 2026-06-24
 progress:
   total_phases: 8
   completed_phases: 4
   total_plans: 14
-  completed_plans: 13
+  completed_plans: 14
   percent: 50
 ---
 
@@ -21,13 +21,13 @@ progress:
 See: .planning/PROJECT.md (updated 2026-06-23 — v1.5 Backtest Performance Optimization STARTED; Persistence split out to a following milestone)
 
 **Core value:** A single backtest run of `SMA_MACD` on the golden BTCUSD CSV produces correct, deterministic, cross-validated numbers. v1.5 makes that run **faster** — profiler-ranked, oracle-gated hot-path optimizations against the frozen W1 baseline (240.8 s / 167.3 MB), changing the numbers nowhere.
-**Current focus:** Phase 06 — bar-feed-window-copies-optional-slip-able
+**Current focus:** Phase 999.2 — nplus2 persistence and performance
 
 ## Current Position
 
-Phase: 06 (bar-feed-window-copies-optional-slip-able) — EXECUTING
-Plan: 3 of 5
-Status: Ready to execute
+Phase: 999.2
+Plan: Not started
+Status: Ready to plan
 Last activity: 2026-06-24
 
 ## Milestone Gate (v1.5 — behavior-preserving performance; applies to EVERY optimization phase)
@@ -99,7 +99,7 @@ gate (b)); P2-P6 are otherwise independent subsystems sequenced by payoff.
 
 **Velocity (v1.3):**
 
-- Total plans completed: 65
+- Total plans completed: 70
 - Average duration: — min
 - Total execution time: 0.0 hours
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,14 +2,14 @@
 gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: Backtest Performance Optimization
-status: "Gate (b) ≥10% W2 win NOT met by 06-01 (~0%, profile-confirmed). Next: plan incremental-cursor window() that replaces per-tick searchsorted. See 06-PROFILE-FINDINGS.md."
+status: executing
 stopped_at: Phase 06 context PIVOTED to incremental-cursor window() (D-10–D-16); ready to replan cursor fix
-last_updated: "2026-06-24T14:15:37.660Z"
-last_activity: 2026-06-24 -- Gate (b) measurement + Scalene profile; user chose to plan the cursor fix
+last_updated: "2026-06-24T14:48:31.315Z"
+last_activity: 2026-06-24 -- Phase 06 planning complete
 progress:
   total_phases: 8
   completed_phases: 4
-  total_plans: 11
+  total_plans: 14
   completed_plans: 10
   percent: 50
 ---
@@ -27,8 +27,8 @@ See: .planning/PROJECT.md (updated 2026-06-23 — v1.5 Backtest Performance Opti
 
 Phase: 06 (bar-feed-window-copies-optional-slip-able) — PAUSED (re-plan pending)
 Plan: 06-01 complete (safety win); 06-02 Task 1 complete (gate harness); 06-02 Task 2/3 deferred
-Status: Gate (b) ≥10% W2 win NOT met by 06-01 (~0%, profile-confirmed). Next: plan incremental-cursor window() that replaces per-tick searchsorted. See 06-PROFILE-FINDINGS.md.
-Last activity: 2026-06-24 -- Gate (b) measurement + Scalene profile; user chose to plan the cursor fix
+Status: Ready to execute
+Last activity: 2026-06-24 -- Phase 06 planning complete
 
 ## Milestone Gate (v1.5 — behavior-preserving performance; applies to EVERY optimization phase)
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,8 +4,8 @@ milestone: v1.5
 milestone_name: Backtest Performance Optimization
 status: executing
 stopped_at: Phase 6 context gathered
-last_updated: "2026-06-24T12:54:33.014Z"
-last_activity: 2026-06-24 -- Phase 06 planning complete
+last_updated: "2026-06-24T12:56:58.826Z"
+last_activity: 2026-06-24 -- Phase 06 execution started
 progress:
   total_phases: 8
   completed_phases: 4
@@ -21,14 +21,14 @@ progress:
 See: .planning/PROJECT.md (updated 2026-06-23 — v1.5 Backtest Performance Optimization STARTED; Persistence split out to a following milestone)
 
 **Core value:** A single backtest run of `SMA_MACD` on the golden BTCUSD CSV produces correct, deterministic, cross-validated numbers. v1.5 makes that run **faster** — profiler-ranked, oracle-gated hot-path optimizations against the frozen W1 baseline (240.8 s / 167.3 MB), changing the numbers nowhere.
-**Current focus:** Phase 6 — Bar-Feed Window Copies (PERF-06, OPTIONAL/slip-able) — taken before Phase 5 by owner decision (2026-06-24); Phase 5 (Incremental Indicators, FRAGILE) deferred to LAST.
+**Current focus:** Phase 06 — bar-feed-window-copies-optional-slip-able
 
 ## Current Position
 
-Phase: 6
-Plan: Not started
-Status: Ready to execute
-Last activity: 2026-06-24 -- Phase 06 planning complete
+Phase: 06 (bar-feed-window-copies-optional-slip-able) — EXECUTING
+Plan: 1 of 2
+Status: Executing Phase 06
+Last activity: 2026-06-24 -- Phase 06 execution started
 
 ## Milestone Gate (v1.5 — behavior-preserving performance; applies to EVERY optimization phase)
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,10 +2,10 @@
 gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: Backtest Performance Optimization
-status: ready_to_plan
-stopped_at: Phase 04 complete (3/3), verified — ready to discuss Phase 6 (deliberate reorder: 6 before 5; Phase 5 kept LAST per its FRAGILE/oracle-gated designation; Phase 6 is independent of 2-5)
-last_updated: 2026-06-24T11:29:32.075Z
-last_activity: 2026-06-24 -- Phase 04 complete & verified (PERF-03 + PERF-04, gate (b) PASS)
+status: planning
+stopped_at: Phase 6 context gathered
+last_updated: "2026-06-24T12:24:04.979Z"
+last_activity: 2026-06-24
 progress:
   total_phases: 8
   completed_phases: 4
@@ -338,9 +338,9 @@ files under `milestones/`.
 
 ## Session Continuity
 
-Last session: 2026-06-24T09:42:45.458Z
-Stopped at: Phase 4 context gathered
-Resume file: .planning/phases/04-hot-path-discipline/04-CONTEXT.md
+Last session: 2026-06-24T12:24:04.970Z
+Stopped at: Phase 6 context gathered
+Resume file: .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-CONTEXT.md
 
 ## Operator Next Steps
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,14 +2,14 @@
 gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: Backtest Performance Optimization
-status: planning
+status: executing
 stopped_at: Phase 6 context gathered
-last_updated: "2026-06-24T12:24:04.979Z"
-last_activity: 2026-06-24
+last_updated: "2026-06-24T12:54:33.014Z"
+last_activity: 2026-06-24 -- Phase 06 planning complete
 progress:
   total_phases: 8
   completed_phases: 4
-  total_plans: 9
+  total_plans: 11
   completed_plans: 9
   percent: 50
 ---
@@ -27,8 +27,8 @@ See: .planning/PROJECT.md (updated 2026-06-23 — v1.5 Backtest Performance Opti
 
 Phase: 6
 Plan: Not started
-Status: Ready to plan
-Last activity: 2026-06-24
+Status: Ready to execute
+Last activity: 2026-06-24 -- Phase 06 planning complete
 
 ## Milestone Gate (v1.5 — behavior-preserving performance; applies to EVERY optimization phase)
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: Backtest Performance Optimization
-status: executing
-stopped_at: 06 PAUSED for re-plan — Gate (b) measured ~0% W2 win (06-01's alias/copy levers negligible); Scalene shows real hotspot is per-tick searchsorted; planning incremental-cursor window()
-last_updated: "2026-06-24T13:45:00.000Z"
-last_activity: 2026-06-24 -- Gate (b) A/B + Scalene profile (see 06-PROFILE-FINDINGS.md); 06-01 safe but ~0% W2 win; user chose to plan incremental-cursor fix
+status: "Gate (b) ≥10% W2 win NOT met by 06-01 (~0%, profile-confirmed). Next: plan incremental-cursor window() that replaces per-tick searchsorted. See 06-PROFILE-FINDINGS.md."
+stopped_at: Phase 06 context PIVOTED to incremental-cursor window() (D-10–D-16); ready to replan cursor fix
+last_updated: "2026-06-24T14:15:37.660Z"
+last_activity: 2026-06-24 -- Gate (b) measurement + Scalene profile; user chose to plan the cursor fix
 progress:
   total_phases: 8
   completed_phases: 4
   total_plans: 11
-  completed_plans: 9
+  completed_plans: 10
   percent: 50
 ---
 
@@ -338,9 +338,9 @@ files under `milestones/`.
 
 ## Session Continuity
 
-Last session: 2026-06-24T13:22:11.000Z
-Stopped at: 06-02 Task 1 committed (f51d7c6); BLOCKING human-verify checkpoint (Task 2 — cool-machine W2 before/after capture + W1/W1-baseline re-freeze)
-Resume file: .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-02-PLAN.md
+Last session: 2026-06-24T14:15:37.651Z
+Stopped at: Phase 06 context PIVOTED to incremental-cursor window() (D-10–D-16); ready to replan cursor fix
+Resume file: .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-CONTEXT.md
 
 ## Operator Next Steps
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,9 +3,9 @@ gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: Backtest Performance Optimization
 status: executing
-stopped_at: Phase 6 context gathered
-last_updated: "2026-06-24T12:56:58.826Z"
-last_activity: 2026-06-24 -- Phase 06 execution started
+stopped_at: 06-02 Task 1 committed; paused at blocking human-verify checkpoint (Task 2 — cool-machine W2 before/after capture)
+last_updated: "2026-06-24T13:22:11.000Z"
+last_activity: 2026-06-24 -- 06-02 Task 1 (W2 gate-b mechanization) committed f51d7c6; awaiting human thermal measurement
 progress:
   total_phases: 8
   completed_phases: 4
@@ -338,9 +338,9 @@ files under `milestones/`.
 
 ## Session Continuity
 
-Last session: 2026-06-24T12:24:04.970Z
-Stopped at: Phase 6 context gathered
-Resume file: .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-CONTEXT.md
+Last session: 2026-06-24T13:22:11.000Z
+Stopped at: 06-02 Task 1 committed (f51d7c6); BLOCKING human-verify checkpoint (Task 2 — cool-machine W2 before/after capture + W1/W1-baseline re-freeze)
+Resume file: .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-02-PLAN.md
 
 ## Operator Next Steps
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,7 +3,7 @@ gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: Backtest Performance Optimization
 status: ready_to_plan
-stopped_at: Phase 06 complete (5/5) — ready to discuss Phase 999.2
+stopped_at: Phase 06 complete (D-15 ship-and-reframe) — Phase 5 (Incremental Indicators) is the LAST remaining v1.5 phase (6-before-5 reorder); 999.2 jump is the phase.complete backlog-scan artifact, corrected
 last_updated: 2026-06-24T15:42:12.372Z
 last_activity: 2026-06-24
 progress:
@@ -21,14 +21,19 @@ progress:
 See: .planning/PROJECT.md (updated 2026-06-23 — v1.5 Backtest Performance Optimization STARTED; Persistence split out to a following milestone)
 
 **Core value:** A single backtest run of `SMA_MACD` on the golden BTCUSD CSV produces correct, deterministic, cross-validated numbers. v1.5 makes that run **faster** — profiler-ranked, oracle-gated hot-path optimizations against the frozen W1 baseline (240.8 s / 167.3 MB), changing the numbers nowhere.
-**Current focus:** Phase 999.2 — nplus2 persistence and performance
+**Current focus:** Phase 5 — Incremental Indicators (FRAGILE, oracle-gated, LAST) — the final remaining v1.5 phase
 
 ## Current Position
 
-Phase: 999.2
-Plan: Not started
+Phase: 5 (Incremental Indicators — PERF-05; deferred to run AFTER Phase 6 per the 6-before-5 reorder)
+Plan: Not started (no Phase 5 dir yet — needs discuss/plan)
 Status: Ready to plan
 Last activity: 2026-06-24
+
+> NOTE: `phase.complete` advanced Current Position to the `999.2` backlog placeholder because no
+> `05-*` phase dir exists yet (scanner artifact — see memory `phase-complete-jumps-to-backlog`).
+> Corrected manually: the next v1.5 phase is **Phase 5 (Incremental Indicators)**, not 999.2.
+> 999.2/999.3 remain FUTURE-milestone backlog seeds. v1.5 = Phases 1-4 + 6 done; Phase 5 remaining.
 
 ## Milestone Gate (v1.5 — behavior-preserving performance; applies to EVERY optimization phase)
 
@@ -343,8 +348,9 @@ files under `milestones/`.
 ## Session Continuity
 
 Last session: 2026-06-24T15:06:52.157Z
-Stopped at: Completed 06-04-PLAN.md (D-10 monotonic int64 cursor); ready to execute 06-05 gate-(b) re-freeze
+Stopped at: Phase 06 COMPLETE — all 5 plans done (06-02 closed-out-superseded; 06-03 cleanup; 06-04 cursor; 06-05 D-15 ship-and-reframe verdict +1.9% W2). Verification passed 6/6. Next: Phase 5 (Incremental Indicators), the last v1.5 phase.
 Resume file: None
+Carried todo: re-freeze W1-BASELINE.json on a verified-cool isolated run (the 06-05 W1 re-freeze was thermally inflated to 259.1s and deferred; baseline kept at 238.5s). See 06-05-SUMMARY.md.
 
 ## Operator Next Steps
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,14 +3,14 @@ gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: Backtest Performance Optimization
 status: executing
-stopped_at: Completed 06-03-PLAN.md (D-13 denominator cleanup); ready to plan/execute 06-04 cursor
-last_updated: "2026-06-24T14:59:18.085Z"
+stopped_at: Completed 06-04-PLAN.md (D-10 monotonic int64 cursor); ready to execute 06-05 gate-(b) re-freeze
+last_updated: "2026-06-24T15:07:46.999Z"
 last_activity: 2026-06-24
 progress:
   total_phases: 8
   completed_phases: 4
   total_plans: 14
-  completed_plans: 12
+  completed_plans: 13
   percent: 50
 ---
 
@@ -26,7 +26,7 @@ See: .planning/PROJECT.md (updated 2026-06-23 — v1.5 Backtest Performance Opti
 ## Current Position
 
 Phase: 06 (bar-feed-window-copies-optional-slip-able) — EXECUTING
-Plan: 2 of 5
+Plan: 3 of 5
 Status: Ready to execute
 Last activity: 2026-06-24
 
@@ -206,6 +206,7 @@ scope decisions:
 - [Phase ?]: [Phase 02]: 02-01 (PERF-01) — InMemoryOrderStorage gained derived active-by-portfolio + active-only by-status indexes (dict[oid,None]) over a _last_indexed_status shadow registry (D-03) atop the flat _by_id source of truth (D-20); shared _index_apply diff-on-write at all 5 write seams; active queries/scanners rerouted (None scan-fallback keeps GLOBAL order byte-identical, Pitfall 1); ABC UNCHANGED (D-05) + D-05a SQL-expressibility audit in-code; gate (a) PASSED (oracle 134/46189.87730727451, determinism 9/9, mypy strict 187). Gate (b) perf = Plan 02.
 - [Phase 03]: 03-01 (PERF-02) — running Decimal realised-PnL accumulator on PositionManager (_realised_pnl_accumulator, seed Decimal('0.00'), no mid-sum quantize) replaces the per-bar dual open+closed re-sum in get_total_realized_pnl (now a bare `return self._realised_pnl_accumulator`, D-01/D-04 dead-loop collapse). Fed via apply_realised_increment from BOTH Portfolio settle arms — the SPOT arm (SMA_MACD oracle path) had NO explicit realised_increment today and was wired with pre/post capture (audit finding, 03-INVARIANT-AUDIT.md §5); MARGIN arm reuses the existing increment on the CLOSE branch only (D-02). Three-layer correctness lock: written single-funnel invariant audit (03-INVARIANT-AUDIT.md) + byte-exact oracle/determinism + dedicated equivalence regression test (accumulator == fresh full re-sum, D-03). Gate (a) byte-exact 134/46189.87730727451, mypy --strict clean (187 files), full suite 1241 passed, determinism double-run byte-identical. Gate (b) W1 wall-clock re-freeze = Plan 02.
 - [Phase ?]: [Phase 06]: 06-03 (PERF-06 / D-13 denominator cleanup, PREP before the cursor) — removed the per-bar TIME EVENT debug block from EventHandler._dispatch (eager f-string every bar, discarded at INFO, ~22% W2 CPU) and de-timed run_w2_sweep._run_point into two passes (clean perf_counter wall-clock, NO tracemalloc in the timed region + separate fresh-wired tracemalloc peak-mem, same seed=42); _wire_system helper factored, return dict shape + 06-02 --check/--baseline-out flags unchanged. Behavior-neutral: gate (a) byte-exact 134/46189.87730727451, mypy --strict clean (187 files); re-baselines NOTHING numeric (cleaned baselines re-freeze 06-05). Commits 15834d7 + 43e5e72.
+- [Phase 06]: 06-04 (PERF-06 / D-10 monotonic cursor) — BacktestBarFeed.window() resolves the cutoff via a per-(ticker,alias) forward int64 cursor over frame.index.asi8 (`iv_i8[pos] <= cutoff_i8`, `cutoff_i8 = pd.Timestamp(cutoff).value`) replacing the per-tick searchsorted (13.2% W2); byte-identical to searchsorted(side="right"). Cold key OR `cutoff_i8 < last_cut` → silent safe searchsorted rebuild (never leak a future bar, D-10 reset-safety). The `iloc[start:pos]` read-only view + D-06 empty short-circuit are KEPT cursor-only (D-11 cheaper-slice empirically infeasible — every candidate slower than iloc, D-07 forbids reconstruction; D-12 built on 06-01 9168cae, NOT reverted). D-16: cursor==searchsorted + no-future-bar proven in the EXTENDED D-08 test suite only, NO hot-loop runtime assert. Deviation (Rule 3): `cutoff.value` → `pd.Timestamp(cutoff).value` for mypy --strict (asof typed `datetime`, no `.value`). Gate (a) byte-exact 134/46189.87730727451, determinism double-run identical (SHA-256), mypy --strict clean (187 files), full suite 1262 passed. Commits d034ea3 + 00c5480. Gate (b) W2/W1 re-freeze deferred to 06-05 (cool machine, D-14).
 
 ### Pending Todos
 
@@ -299,6 +300,7 @@ records archived under `milestones/v1.1-phases/`, `milestones/v1.2-phases/`, `mi
 | Phase 02 P01 | 4 | 3 tasks | 2 files |
 | Phase 03 P01 | 5 | 3 tasks | 4 files |
 | Phase 06 P03 | 2 | 2 tasks | 2 files |
+| Phase 06 P04 | 5 | 2 tasks | 2 files |
 
 ## Bookkeeping
 
@@ -340,8 +342,8 @@ files under `milestones/`.
 
 ## Session Continuity
 
-Last session: 2026-06-24T14:59:18.077Z
-Stopped at: Completed 06-03-PLAN.md (D-13 denominator cleanup); ready to plan/execute 06-04 cursor
+Last session: 2026-06-24T15:06:52.157Z
+Stopped at: Completed 06-04-PLAN.md (D-10 monotonic int64 cursor); ready to execute 06-05 gate-(b) re-freeze
 Resume file: None
 
 ## Operator Next Steps

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,9 +3,9 @@ gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: Backtest Performance Optimization
 status: executing
-stopped_at: 06-02 Task 1 committed; paused at blocking human-verify checkpoint (Task 2 — cool-machine W2 before/after capture)
-last_updated: "2026-06-24T13:22:11.000Z"
-last_activity: 2026-06-24 -- 06-02 Task 1 (W2 gate-b mechanization) committed f51d7c6; awaiting human thermal measurement
+stopped_at: 06 PAUSED for re-plan — Gate (b) measured ~0% W2 win (06-01's alias/copy levers negligible); Scalene shows real hotspot is per-tick searchsorted; planning incremental-cursor window()
+last_updated: "2026-06-24T13:45:00.000Z"
+last_activity: 2026-06-24 -- Gate (b) A/B + Scalene profile (see 06-PROFILE-FINDINGS.md); 06-01 safe but ~0% W2 win; user chose to plan incremental-cursor fix
 progress:
   total_phases: 8
   completed_phases: 4
@@ -25,10 +25,10 @@ See: .planning/PROJECT.md (updated 2026-06-23 — v1.5 Backtest Performance Opti
 
 ## Current Position
 
-Phase: 06 (bar-feed-window-copies-optional-slip-able) — EXECUTING
-Plan: 1 of 2
-Status: Executing Phase 06
-Last activity: 2026-06-24 -- Phase 06 execution started
+Phase: 06 (bar-feed-window-copies-optional-slip-able) — PAUSED (re-plan pending)
+Plan: 06-01 complete (safety win); 06-02 Task 1 complete (gate harness); 06-02 Task 2/3 deferred
+Status: Gate (b) ≥10% W2 win NOT met by 06-01 (~0%, profile-confirmed). Next: plan incremental-cursor window() that replaces per-tick searchsorted. See 06-PROFILE-FINDINGS.md.
+Last activity: 2026-06-24 -- Gate (b) measurement + Scalene profile; user chose to plan the cursor fix
 
 ## Milestone Gate (v1.5 — behavior-preserving performance; applies to EVERY optimization phase)
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,14 +3,14 @@ gsd_state_version: 1.0
 milestone: v1.5
 milestone_name: Backtest Performance Optimization
 status: executing
-stopped_at: Phase 06 context PIVOTED to incremental-cursor window() (D-10–D-16); ready to replan cursor fix
-last_updated: "2026-06-24T14:54:31.136Z"
-last_activity: 2026-06-24 -- Phase 06 execution started
+stopped_at: Completed 06-03-PLAN.md (D-13 denominator cleanup); ready to plan/execute 06-04 cursor
+last_updated: "2026-06-24T14:59:18.085Z"
+last_activity: 2026-06-24
 progress:
   total_phases: 8
   completed_phases: 4
   total_plans: 14
-  completed_plans: 10
+  completed_plans: 12
   percent: 50
 ---
 
@@ -26,9 +26,9 @@ See: .planning/PROJECT.md (updated 2026-06-23 — v1.5 Backtest Performance Opti
 ## Current Position
 
 Phase: 06 (bar-feed-window-copies-optional-slip-able) — EXECUTING
-Plan: 1 of 5
-Status: Executing Phase 06
-Last activity: 2026-06-24 -- Phase 06 execution started
+Plan: 2 of 5
+Status: Ready to execute
+Last activity: 2026-06-24
 
 ## Milestone Gate (v1.5 — behavior-preserving performance; applies to EVERY optimization phase)
 
@@ -205,6 +205,7 @@ scope decisions:
 - [Phase 01]: 01-01 (TOOL-01/02): perf tooling surface built — make perf-w1/w2/baseline/profile (+ user-added perf-view) in the root Makefile; perf-w1 is PROFILER-FREE and perf-profile is the ONLY Scalene path (two-step run->view; user switched the viewer from --html to native `scalene view` local-server, approved deviation 4fa61d1/4d50996, TOOL-02 split intact). run_w1_benchmark.py gained --json/--check/--baseline-out (D-06 human-stdout default) + _to_baseline_schema/_write_baseline/_check_regression (soft guard fails ONLY on >+5% slowdown, no abs(), Pitfall 3); run_w2_sweep.py gained --json. D-07: _START_DATE default pinned 2025-12-24->2026-04-23 (env-overridable). final_equity stored as STRING constant 46189.87730727451 (OQ-1/A1 provenance, not W1-derived). Narrow .gitignore (scalene-profile.html + perf/results/scalene-*.json) keeps W1-BASELINE.json trackable (Pitfall 4). Gate (a) green 134/46189.87730727451; NO itrader/ engine code touched. Scalene hotspot confirmed: in_memory_storage 48% (P2), position_manager 17% (P3), indicators/catalog 18% (P5).
 - [Phase ?]: [Phase 02]: 02-01 (PERF-01) — InMemoryOrderStorage gained derived active-by-portfolio + active-only by-status indexes (dict[oid,None]) over a _last_indexed_status shadow registry (D-03) atop the flat _by_id source of truth (D-20); shared _index_apply diff-on-write at all 5 write seams; active queries/scanners rerouted (None scan-fallback keeps GLOBAL order byte-identical, Pitfall 1); ABC UNCHANGED (D-05) + D-05a SQL-expressibility audit in-code; gate (a) PASSED (oracle 134/46189.87730727451, determinism 9/9, mypy strict 187). Gate (b) perf = Plan 02.
 - [Phase 03]: 03-01 (PERF-02) — running Decimal realised-PnL accumulator on PositionManager (_realised_pnl_accumulator, seed Decimal('0.00'), no mid-sum quantize) replaces the per-bar dual open+closed re-sum in get_total_realized_pnl (now a bare `return self._realised_pnl_accumulator`, D-01/D-04 dead-loop collapse). Fed via apply_realised_increment from BOTH Portfolio settle arms — the SPOT arm (SMA_MACD oracle path) had NO explicit realised_increment today and was wired with pre/post capture (audit finding, 03-INVARIANT-AUDIT.md §5); MARGIN arm reuses the existing increment on the CLOSE branch only (D-02). Three-layer correctness lock: written single-funnel invariant audit (03-INVARIANT-AUDIT.md) + byte-exact oracle/determinism + dedicated equivalence regression test (accumulator == fresh full re-sum, D-03). Gate (a) byte-exact 134/46189.87730727451, mypy --strict clean (187 files), full suite 1241 passed, determinism double-run byte-identical. Gate (b) W1 wall-clock re-freeze = Plan 02.
+- [Phase ?]: [Phase 06]: 06-03 (PERF-06 / D-13 denominator cleanup, PREP before the cursor) — removed the per-bar TIME EVENT debug block from EventHandler._dispatch (eager f-string every bar, discarded at INFO, ~22% W2 CPU) and de-timed run_w2_sweep._run_point into two passes (clean perf_counter wall-clock, NO tracemalloc in the timed region + separate fresh-wired tracemalloc peak-mem, same seed=42); _wire_system helper factored, return dict shape + 06-02 --check/--baseline-out flags unchanged. Behavior-neutral: gate (a) byte-exact 134/46189.87730727451, mypy --strict clean (187 files); re-baselines NOTHING numeric (cleaned baselines re-freeze 06-05). Commits 15834d7 + 43e5e72.
 
 ### Pending Todos
 
@@ -297,6 +298,7 @@ records archived under `milestones/v1.1-phases/`, `milestones/v1.2-phases/`, `mi
 | v1.5 Phase 01 P02 | ~18 (3× ~240s benchmark runs) | 2 tasks (both auto) | 1 file |
 | Phase 02 P01 | 4 | 3 tasks | 2 files |
 | Phase 03 P01 | 5 | 3 tasks | 4 files |
+| Phase 06 P03 | 2 | 2 tasks | 2 files |
 
 ## Bookkeeping
 
@@ -338,9 +340,9 @@ files under `milestones/`.
 
 ## Session Continuity
 
-Last session: 2026-06-24T14:15:37.651Z
-Stopped at: Phase 06 context PIVOTED to incremental-cursor window() (D-10–D-16); ready to replan cursor fix
-Resume file: .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-CONTEXT.md
+Last session: 2026-06-24T14:59:18.077Z
+Stopped at: Completed 06-03-PLAN.md (D-13 denominator cleanup); ready to plan/execute 06-04 cursor
+Resume file: None
 
 ## Operator Next Steps
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,8 +4,8 @@ milestone: v1.5
 milestone_name: Backtest Performance Optimization
 status: executing
 stopped_at: Phase 06 context PIVOTED to incremental-cursor window() (D-10–D-16); ready to replan cursor fix
-last_updated: "2026-06-24T14:48:31.315Z"
-last_activity: 2026-06-24 -- Phase 06 planning complete
+last_updated: "2026-06-24T14:54:31.136Z"
+last_activity: 2026-06-24 -- Phase 06 execution started
 progress:
   total_phases: 8
   completed_phases: 4
@@ -25,10 +25,10 @@ See: .planning/PROJECT.md (updated 2026-06-23 — v1.5 Backtest Performance Opti
 
 ## Current Position
 
-Phase: 06 (bar-feed-window-copies-optional-slip-able) — PAUSED (re-plan pending)
-Plan: 06-01 complete (safety win); 06-02 Task 1 complete (gate harness); 06-02 Task 2/3 deferred
-Status: Ready to execute
-Last activity: 2026-06-24 -- Phase 06 planning complete
+Phase: 06 (bar-feed-window-copies-optional-slip-able) — EXECUTING
+Plan: 1 of 5
+Status: Executing Phase 06
+Last activity: 2026-06-24 -- Phase 06 execution started
 
 ## Milestone Gate (v1.5 — behavior-preserving performance; applies to EVERY optimization phase)
 

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-01-PLAN.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-01-PLAN.md
@@ -1,0 +1,243 @@
+---
+phase: 06-bar-feed-window-copies-optional-slip-able
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - itrader/price_handler/feed/bar_feed.py
+  - tests/unit/price/test_bar_feed.py
+autonomous: true
+requirements: [PERF-06]
+
+must_haves:
+  truths:
+    - "D-01: window() keeps returning a pd.DataFrame with its existing (ticker, timeframe, max_window, asof) signature — no caller changes — and _offset_alias is memoized so the per-call string compute fires once per timeframe"
+    - "D-07: the returned window is the SLICED existing frame marked read-only (not a pd.DataFrame reconstruction); dtype, tz-aware DatetimeIndex, and column set+order are byte-identical to the old frame.iloc[start:pos].copy()"
+    - "D-09: each master frame in self._frames is marked non-writeable at its two build sites (__init__ base load, _resampled_frame resample); views inherit the read-only buffer; resample/searchsorted/iterrows/ta-reads still work (no D-09 fallback triggered)"
+    - "D-02: a consumer in-place mutation of a returned window fails loudly (raises) instead of silently poisoning a future tick — the look-ahead invariant is hard-enforced at the feed source"
+    - "D-06: when the cutoff lands at frame start the empty window returns frame.iloc[pos:pos] unchanged, bypassing the view/read-only machinery, preserving byte-identical empty semantics the base.py empty-window guard relies on"
+    - "D-08: a dedicated drift/equivalence test proves (a) view content == old-copy content across sampled ticks, (b) a DIRECT numpy write to a returned window raises ValueError(read-only) and cannot leak into the master, (c) the existing 7-rule bar-timing contract tests stay green"
+    - "Gate (a): byte-exact SMA_MACD oracle green (134 trades / final_equity 46189.87730727451); mypy --strict clean; full unit/integration suite green"
+  artifacts:
+    - path: "itrader/price_handler/feed/bar_feed.py"
+      provides: "view-returning window() + memoized _offset_alias + read-only master frames at build sites"
+      contains: "writeable = False"
+    - path: "tests/unit/price/test_bar_feed.py"
+      provides: "D-08 three-assertion drift/equivalence lock co-located with the existing 7-rule contract suite"
+      contains: "read-only"
+  key_links:
+    - from: "BacktestBarFeed.window"
+      to: "self._frames master buffer"
+      via: "frame.iloc[start:pos] view sharing the read-only buffer"
+      pattern: "frame\\.iloc\\["
+    - from: "bar_feed build sites"
+      to: "numpy values buffer"
+      via: "flags.writeable = False at __init__ base load and _resampled_frame"
+      pattern: "writeable\\s*=\\s*False"
+---
+
+<objective>
+Reduce the per-tick bar-feed window cost (PERF-06, hotspot #5) by returning a read-only view from
+`BacktestBarFeed.window()` instead of materializing a fresh wrapper every tick, memoizing the
+per-call `_offset_alias` string compute (D-01), and enforcing the look-ahead invariant by marking
+master frames non-writeable at their build sites (D-09 — which subsumes D-02's view-safety). The
+change is behavior-preserving: byte-identical window content, no caller changes, the 7-rule
+bar-timing contract intact.
+
+Purpose: kill per-tick wrapper-construction churn + the `_offset_alias` string compute on the path
+that scales with symbol count (the W2 ~22%), while making a consumer mutation of a shared view fail
+loudly at the feed source rather than silently poison a future tick.
+
+Output: a view-returning `window()` + memoized alias + read-only master frames in `bar_feed.py`, and
+a co-located D-08 drift/equivalence test. Gate (a) held byte-exact.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-CONTEXT.md
+@.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-RESEARCH.md
+@.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-PATTERNS.md
+
+<interfaces>
+<!-- Extracted from the target file and existing test. Use these directly — no codebase exploration needed. -->
+
+itrader/price_handler/feed/bar_feed.py (4-SPACE indent — never normalize):
+- module fn `_offset_alias(timeframe: timedelta) -> str` (:78-121) — raises ValueError on unsupported
+  units; body must stay byte-unchanged, only memoize/wrap it.
+- `BacktestBarFeed.__init__` base load (~:181-188): builds `self._frames[(ticker, self._base_alias)] = frame`
+  from `store.read_bars(ticker)`, then reads `frame.index[0]/[-1]` into `_spans` and `frame.iterrows()`
+  into `_prebuilt`. Mark non-writeable right after the dict assignment (Pitfall 3: mark after the frame
+  is fully populated; iterrows/index reads still work on a non-writeable frame).
+- `BacktestBarFeed._resampled_frame(ticker, alias) -> pd.DataFrame` (~:256-274): memoizes
+  `resampled = base.resample(alias, label="left", closed="left").agg(_AGG)`; `self._frames[key] = resampled`;
+  `return resampled`. Mark non-writeable right before the return.
+- `BacktestBarFeed.window(ticker, timeframe, max_window, asof) -> pd.DataFrame` (tail ~:395-399):
+  `alias = _offset_alias(timeframe)` / `frame = self._resampled_frame(ticker, alias)` /
+  `cutoff = asof - timeframe + self._base_timeframe` /
+  `pos = int(frame.index.searchsorted(cutoff, side="right"))` /
+  `return frame.iloc[max(0, pos - max_window):pos]`. Keep signature + return type EXACTLY.
+
+tests/unit/price/test_bar_feed.py (4-SPACE indent):
+- Fixtures: `daily_store`, `daily_feed` (BacktestBarFeed over 1d base bars stamped 2020-01-01..10),
+  `daily_base_frame` (the raw store frame). Helper `ts(stamp)` -> tz-aware pd.Timestamp.
+- Existing contract suite uses `pd.testing.assert_frame_equal(window, daily_base_frame.iloc[2:5])`
+  (~:167) and `assert_frame_equal(window, expected, check_freq=False)` (~:183) — the byte-identity
+  backstop and assertion (c).
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 0: D-08 drift/equivalence test stub (Wave 0 — Nyquist)</name>
+  <files>tests/unit/price/test_bar_feed.py</files>
+  <read_first>
+    - tests/unit/price/test_bar_feed.py (existing fixtures daily_store/daily_feed/daily_base_frame, ts() helper, assert_frame_equal contract tests at ~:167/:183)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-RESEARCH.md (Code Examples — the three-assertion skeleton; Pitfall 1 — the mutation-form→exception map)
+    - tests/unit/portfolio/test_realised_pnl_accumulator.py (Phase 3 D-03 drift-lock docstring shape)
+    - tests/unit/strategy/test_type_hints_equivalence.py (Phase 4 D-05/D-07 equivalence-lock shape)
+  </read_first>
+  <action>
+    Add two NEW test functions to tests/unit/price/test_bar_feed.py (co-locate with the existing 7-rule
+    contract suite per RESEARCH Open Question 1 — treat D-08's literal tests/unit/price_handler/feed/
+    path as directional). Open the new block with a decision-tag-anchored docstring (cite D-01/D-06/D-07/
+    D-08/D-09) naming the oracle as the old `frame.iloc[start:pos].copy()` and stating no hot-path runtime
+    guard is added. Reuse the existing `daily_feed`/`daily_base_frame` fixtures and `ts()` helper.
+    `test_window_view_content_equals_old_copy`: sample several asof ticks, compare each `daily_feed.window(...)`
+    against the matching positional slice of `daily_base_frame` via `pd.testing.assert_frame_equal`
+    (check_freq=False idiom). `test_window_view_is_read_only_and_cannot_leak`: fetch a non-empty window,
+    capture `view.to_numpy().copy()` as `before`, then assert `pytest.raises(ValueError, match="read-only")`
+    on a DIRECT numpy write `view.to_numpy(copy=False)[0, 0] = 999.0` (NOT a pandas `.iloc`/column assignment —
+    those raise SettingWithCopyWarning/FutureWarning under filterwarnings=["error"] BEFORE the buffer is
+    touched, false confidence — RESEARCH Pitfall 1); then re-fetch the same window and assert
+    `np.array_equal(again.to_numpy(), before)` (no leak into the master). Stub the new functions so they
+    COLLECT now (the implementation lands in Task 1) — either skip-marked via folder-derived markers or
+    written to fail cleanly until Task 1; they MUST be selectable by `-k content_equals` and `-k read_only`.
+    File is 4-space — match it; never normalize.
+  </action>
+  <verify>
+    <automated>poetry run pytest tests/unit/price/test_bar_feed.py -k "content_equals or read_only" --collect-only -q</automated>
+  </verify>
+  <acceptance_criteria>
+    - `poetry run pytest tests/unit/price/test_bar_feed.py -k "content_equals or read_only" --collect-only -q` selects >= 2 tests
+    - The read-only test body contains `view.to_numpy(copy=False)` and `match="read-only"` and does NOT assert a `view.iloc[` write raises
+    - No indentation normalization in the file (diff touches only added lines, 4-space)
+  </acceptance_criteria>
+  <done>Two collectible D-08 drift tests exist co-located with the contract suite; the (b) test targets the numpy ValueError, not a pandas copy-warning.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 1: View-returning window() + memoized alias + read-only master frames</name>
+  <files>itrader/price_handler/feed/bar_feed.py</files>
+  <read_first>
+    - itrader/price_handler/feed/bar_feed.py (module docstring 7-rule contract :9-55; _offset_alias :78-121; __init__ base load :181-188; _resampled_frame :256-274; window tail :395-399; current_bars de-pandas precedent docstring :335-356)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-RESEARCH.md (Pattern 1 read-only-at-build; Pattern 2 view return; Pattern 3 memoize; Pitfall 2 the win is wrapper churn NOT a buffer copy; Pitfall 3 mark after populate; Pitfall 4 lru_cache preserves raise-on-unsupported)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-PATTERNS.md (in-file analog excerpts + the Phase 4 _declared_hints @functools.cache memoize template)
+  </read_first>
+  <behavior>
+    - window() returns byte-identical content to the prior `frame.iloc[start:pos].copy()` (values, float64 dtype, tz-aware DatetimeIndex, column set+order) — assert_frame_equal passes (D-08 a, Task 0 content test)
+    - a returned window's underlying numpy buffer is non-writeable: a direct `view.to_numpy(copy=False)[0,0] = x` raises ValueError(read-only); the master is unchanged afterward (D-08 b)
+    - an empty window (cutoff at frame start) returns `frame.iloc[pos:pos]` unchanged with float64 dtype + tz-aware empty index (D-06)
+    - the existing 7-rule contract tests stay green (D-08 c)
+  </behavior>
+  <action>
+    Memoize `_offset_alias` per D-01 using the Phase 4 `_declared_hints` template: wrap the module fn with
+    `@functools.cache` (Option A, smallest diff — `timedelta` is hashable; `functools.cache` does NOT cache
+    exceptions so the raise-on-unsupported ValueError guard is preserved, RESEARCH Pitfall 4). Keep the
+    `_offset_alias` body byte-unchanged; add `import functools`. At the two `self._frames[...] = ...` build
+    sites mark the master frame non-writeable (D-09): in `__init__` right after `self._frames[(ticker, self._base_alias)] = frame`
+    (before the `_spans`/`_prebuilt` reads, Pitfall 3), and in `_resampled_frame` right before `return resampled`.
+    Use the public handle `frame.to_numpy(copy=False).flags.writeable = False` (single float64 block ⇒ one flag
+    covers all 5 columns); guard with an `assert np.shares_memory(...)` at the build site since `to_numpy(copy=False)`
+    is not contractually zero-copy in all cases (RESEARCH Pattern 1 caveat) — add `import numpy as np`. In `window()`,
+    add the D-06 empty short-circuit: compute `start = max(0, pos - max_window)`, and `if start >= pos: return frame.iloc[pos:pos]`
+    unchanged (bypass the view/read-only path entirely); otherwise `view = frame.iloc[start:pos]` (already a view on
+    the float64 single block — do NOT reconstruct via `pd.DataFrame(...)`, D-07) and optionally re-mark
+    `view.to_numpy(copy=False).flags.writeable = False` as belt-and-suspenders defense-in-depth (RESEARCH Open
+    Question 2 recommendation), then `return view`. Keep window()'s signature and `pd.DataFrame` return type
+    EXACTLY (D-01) — no caller changes. Add a decision-tag-anchored comment (D-01/D-06/D-07/D-09) mirroring the
+    current_bars de-pandas docstring tone, noting the win is wall-clock wrapper-churn reduction (W2), not a
+    buffer-copy/memory drop (Pitfall 2). File is 4-space — match it; never normalize.
+  </action>
+  <verify>
+    <automated>poetry run pytest tests/unit/price/test_bar_feed.py -q && poetry run pytest tests/integration/test_backtest_oracle.py -q && poetry run mypy itrader</automated>
+  </verify>
+  <acceptance_criteria>
+    - `poetry run pytest tests/unit/price/test_bar_feed.py -q` exits 0 (D-08 a/b/c all green, including the 7-rule contract suite)
+    - `poetry run pytest tests/integration/test_backtest_oracle.py -q` exits 0 and reports 134 trades / final_equity 46189.87730727451 (Gate a)
+    - `poetry run mypy itrader` exits 0
+    - bar_feed.py contains `writeable = False` at both build sites and in window() (or its view re-mark), contains a `@functools.cache`/`lru_cache` on _offset_alias, contains the `start >= pos` empty short-circuit, and contains NO `pd.DataFrame(` reconstruction inside window()
+    - the _offset_alias function BODY is byte-unchanged (only a decorator added)
+  </acceptance_criteria>
+  <done>window() returns a read-only view byte-identical to the old copy; master frames are non-writeable; _offset_alias is memoized; empty windows short-circuit; oracle byte-exact and mypy clean.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Gate (a) lock — determinism double-run + full suite</name>
+  <files>(verification-only — no production files modified)</files>
+  <read_first>
+    - tests/integration/test_backtest_oracle.py (the byte-exact SMA_MACD oracle — 134 / 46189.87730727451; per memory oracle-test-location this is THE oracle, tests/golden is artifacts)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-RESEARCH.md (Validation Architecture — Sampling Rate / Phase gate (a))
+    - MEMORY worktree-make-test-env-abort: make test may abort on missing .env in a worktree — run `poetry run pytest tests` there
+  </read_first>
+  <action>
+    Prove Gate (a) end-to-end after the engine change. Run the oracle twice and assert byte-identical
+    output (determinism double-run — the run is deterministic via the seeded RNG + injected BacktestClock;
+    no new nondeterminism introduced this phase). Run the full unit/integration suite (`poetry run pytest tests`
+    in this worktree per the env-abort memory; `make test` in the main checkout). Confirm `mypy --strict`
+    clean. This task adds NO production code — it is the correctness-lock verification that the Task 1 change
+    re-baselines nothing numeric. Record the oracle trade count + final_equity + the double-run identity in
+    the plan SUMMARY.
+  </action>
+  <verify>
+    <automated>poetry run pytest tests/integration/test_backtest_oracle.py -q && poetry run pytest tests -q && poetry run mypy itrader</automated>
+  </verify>
+  <acceptance_criteria>
+    - `poetry run pytest tests/integration/test_backtest_oracle.py -q` exits 0 (134 / 46189.87730727451) on both of two consecutive runs with identical reported output
+    - `poetry run pytest tests -q` exits 0 (full unit/integration suite green)
+    - `poetry run mypy itrader` exits 0
+  </acceptance_criteria>
+  <done>Gate (a) held: oracle byte-exact and determinism double-run identical, full suite green, mypy --strict clean — confirming the view change changed no numbers.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| feed master frame → returned window view | A returned window aliases the cached master frame's buffer; a consumer holds a reference that shares memory with future ticks' data source. This is the ONE substantive boundary; there is no external/network/auth/user-input surface in this phase. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-06-01 | Tampering | `BacktestBarFeed.window()` returned view aliasing `self._frames` | mitigate | Mark the master frame's numpy buffer `writeable=False` at both build sites (D-09); views inherit read-only so a consumer in-place mutation raises `ValueError(read-only)` instead of silently poisoning a future tick (a look-ahead/data-integrity breach). Proven by the D-08 (b) direct-numpy-write test. |
+| T-06-02 | Spoofing / Repudiation / Information Disclosure / Denial of Service / Elevation | — | N/A | No external input, network, auth, secret, session, or user-data surface — internal offline backtest data-path optimization only. No new attack surface. |
+| T-06-SC | Tampering | npm/pip/cargo installs | accept | No packages installed or changed (RESEARCH Package Legitimacy Audit: not applicable; pandas/numpy/ta/functools already pinned and present). No supply-chain surface this phase. |
+</threat_model>
+
+<verification>
+- D-08 drift test green: content-equality (a), read-only-raises via direct numpy write (b), 7-rule contract (c).
+- Gate (a): `tests/integration/test_backtest_oracle.py` green (134 / 46189.87730727451); determinism double-run byte-identical; `mypy --strict` clean; full suite green.
+- bar_feed.py: read-only marks at both build sites + window view; `_offset_alias` memoized (body unchanged); empty short-circuit present; no `pd.DataFrame(` reconstruction in window().
+</verification>
+
+<success_criteria>
+- ROADMAP Success Criterion 1: per-tick window materialization reduces wrapper churn on the `window()` path (view return + memoized alias).
+- ROADMAP Success Criterion 2: the look-ahead bar-timing contract is preserved — all 7 rules hold; no future bar becomes visible; window content byte-identical.
+- ROADMAP Success Criterion 3 (Gate a): byte-exact oracle green; e2e/full suite green; `mypy --strict` clean; determinism double-run byte-identical.
+</success_criteria>
+
+<output>
+Create `.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-01-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-01-SUMMARY.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-01-SUMMARY.md
@@ -1,0 +1,146 @@
+---
+status: complete
+phase: 06-bar-feed-window-copies-optional-slip-able
+plan: 01
+subsystem: price-handler / feed
+tags: [perf, read-only-view, byte-identity, look-ahead-safety, behavior-preserving, PERF-06]
+requires: []
+provides:
+  - "BacktestBarFeed.window() returns a read-only VIEW on the cached master frame instead of materializing a fresh wrapper every tick (D-01/D-07)"
+  - "Master frames in self._frames are single-block + non-writeable at both build sites (D-09) — window views inherit read-only; an in-place mutation raises ValueError(read-only)"
+  - "_offset_alias memoized with @functools.cache — per-call string compute fires once per timeframe (D-01)"
+  - "D-08 three-assertion drift lock co-located with the 7-rule bar-timing contract suite"
+affects:
+  - itrader/price_handler/feed/bar_feed.py
+  - tests/unit/price/test_bar_feed.py
+tech-stack:
+  added: []
+  patterns:
+    - "numpy read-only buffer enforcement at build (flags.writeable=False), not a per-tick runtime guard"
+    - "byte-identity-preserving single-block consolidation via DataFrame.copy() before locking"
+    - "@functools.cache memoize of a pure module fn (raise-on-unsupported preserved — cache does not store exceptions)"
+key-files:
+  created: []
+  modified:
+    - itrader/price_handler/feed/bar_feed.py
+    - tests/unit/price/test_bar_feed.py
+decisions:
+  - "D-09 mechanism refined: the store's canonical OHLCV frame is MULTI-block (read_csv + astype(float) + .loc window slice leave it 4xN + 1xN), so to_numpy(copy=False) returns a fresh consolidated COPY and locking individual block buffers is unobservable through to_numpy. _readonly_master consolidates via a byte-identical DataFrame.copy() to a single block FIRST, then locks the single block's buffer — only then does the view inherit read-only and the D-08 (b) to_numpy(copy=False)[0,0] write raise. This is within the planned D-07 (byte-identity) + D-09 (read-only-at-build) envelope; the RESEARCH 'single homogeneous float64 block' premise held for the resampled frame but NOT the base store frame."
+  - "Lock the BASE buffer, not the to_numpy view: to_numpy(copy=False) on a single-block frame returns a non-owning view whose .base IS the block buffer; setting flags.writeable=False on the returned view only flips the view's local flag. _readonly_master walks `arr if arr.flags.owndata else arr.base` and locks that, asserting np.shares_memory so a future copy-returning shape fails loud (D-09 fallback signal) rather than silently leaving the master writeable."
+  - "window() returns the iloc view DIRECTLY with NO re-mark/re-copy: the view already inherits read-only from the locked single-block master, and an explicit _readonly_master(view) would re-copy and defeat the view return. _offset_alias body kept byte-unchanged (only the @functools.cache decorator added)."
+metrics:
+  duration: ~50min
+  completed: 2026-06-24
+  tasks: 3
+  files: 2
+  oracle: "134 trades / final_equity 46189.87730727451 (byte-exact, determinism double-run identical)"
+  suite: "1258 passed; mypy --strict clean (165 files)"
+---
+
+# Phase 06 Plan 01: Bar-Feed Read-Only Window View Summary
+
+`BacktestBarFeed.window()` now returns a read-only VIEW on the cached master frame instead of
+materializing a fresh `pd.DataFrame` wrapper every tick (PERF-06, hotspot #5 / W2 ~22%), with
+`_offset_alias` memoized via `@functools.cache` and the master frames marked non-writeable at
+their two build sites so the look-ahead invariant is hard-enforced at the feed source — a
+consumer in-place mutation now raises `ValueError(read-only)` instead of silently poisoning a
+future tick. Behavior-preserving: byte-identical window content, no caller changes, the 7-rule
+bar-timing contract intact, SMA_MACD oracle byte-exact (134 / 46189.87730727451).
+
+## Tasks Completed
+
+| Task | Name | Commit | Files |
+| ---- | ---- | ------ | ----- |
+| 0 | D-08 read-only-view drift lock (Nyquist Wave-0 test stub) | `41a2cf6` | tests/unit/price/test_bar_feed.py |
+| 1 | View-returning window() + memoized alias + read-only master frames (TDD GREEN) | `9168cae` | itrader/price_handler/feed/bar_feed.py |
+| 2 | Gate (a) lock — determinism double-run + full suite (verification-only) | (no commit — verification) | — |
+
+## What Changed
+
+### `itrader/price_handler/feed/bar_feed.py` (4-space — not normalized)
+
+- **`@functools.cache` on `_offset_alias`** (D-01): the per-call offset-alias string compute now
+  fires once per distinct `timeframe` across `__init__`/`precompute`/the per-tick `window()` path.
+  Function BODY byte-unchanged (verified `diff` of the executable lines) — only the decorator and a
+  4-line decision comment were added. `functools.cache` does not cache exceptions, so the
+  raise-on-unsupported `ValueError` guard is preserved (RESEARCH Pitfall 4).
+- **`_readonly_master(frame) -> pd.DataFrame`** new module helper (D-09): consolidates to a single
+  float64 block via a byte-identical `DataFrame.copy()`, then locks the single block's numpy buffer
+  `flags.writeable = False` (walking `arr if arr.flags.owndata else arr.base`, asserting
+  `np.shares_memory`). `resample`/`searchsorted`/`iterrows`/`ta` reads all verified to work on the
+  non-writeable frame — no D-09 per-view fallback triggered.
+- **Two build sites** call `_readonly_master`: `__init__` base load (`frame = _readonly_master(store.read_bars(ticker))`)
+  and `_resampled_frame` (`resampled = _readonly_master(resampled)`). The store frame is returned
+  untouched — only our cached copy is locked.
+- **`window()`**: D-06 `start >= pos` empty short-circuit returns `frame.iloc[pos:pos]` unchanged
+  (bypassing the view path); otherwise returns `frame.iloc[start:pos]` DIRECTLY — a view aliasing the
+  locked single-block master, inheriting `writeable=False` for free (D-07: no `pd.DataFrame(...)`
+  reconstruction, no per-tick copy). Signature + `pd.DataFrame` return type unchanged.
+
+### `tests/unit/price/test_bar_feed.py` (4-space)
+
+- **`test_window_view_content_equals_old_copy`** (D-08 a): the returned view is byte-identical to the
+  old `frame.iloc[start:pos].copy()` (oracle = the matching positional slice of `daily_base_frame`)
+  across sampled ticks, via `pd.testing.assert_frame_equal(check_freq=False)`.
+- **`test_window_view_is_read_only_and_cannot_leak`** (D-08 b): a DIRECT numpy write
+  `view.to_numpy(copy=False)[0,0] = 999.0` raises `ValueError(match="read-only")`, and re-fetching the
+  same window yields the unchanged values (no leak). Targets the numpy `ValueError`, NOT a pandas
+  `view.iloc[...] = x` chained assignment (RESEARCH Pitfall 1 — that fires `SettingWithCopyWarning`
+  under `filterwarnings=["error"]` BEFORE the buffer is touched: false confidence).
+- `import numpy as np` added. The existing 7-rule contract suite is D-08 assertion (c) — stays green.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Store frame is MULTI-block; RESEARCH single-block premise did not hold for the base frame**
+- **Found during:** Task 1 (the `_readonly_master` self-check assert fired in fixture setup).
+- **Issue:** RESEARCH Pattern 1 / Pitfall 2 assumed the golden OHLCV frame is a homogeneous single
+  float64 block, so `frame.to_numpy(copy=False)` aliases its buffer and locking it protects views.
+  Empirically the `CsvPriceStore` frame is MULTI-block (a 4xN block + a 1xN block — `read_csv` parse +
+  `astype(float)` + the `.loc` window slice leave it unconsolidated). On a multi-block frame
+  `to_numpy(copy=False)` returns a fresh CONSOLIDATED COPY: locking individual block buffers is
+  unobservable through `to_numpy`, and the D-08 (b) `view.to_numpy(copy=False)[0,0] = x` write would
+  target a throwaway copy and NOT raise — the read-only guarantee would be real but unverifiable, and a
+  consumer's `to_numpy(copy=False)` write would silently no-op. Additionally, setting `flags.writeable`
+  on the array returned by `to_numpy(copy=False)` (a non-owning VIEW) only flips that view's local flag,
+  leaving the master buffer writeable.
+- **Fix:** `_readonly_master` consolidates to a single block via a byte-identity-preserving
+  `DataFrame.copy()` (verified `assert_frame_equal` vs the store frame) BEFORE locking, and locks the
+  buffer the frame actually owns (`arr if arr.flags.owndata else arr.base`), with an
+  `np.shares_memory` assert so any future copy-returning shape fails loud rather than silently leaving
+  the master writeable. This stays inside the planned D-07 (byte-identity) + D-09 (read-only-at-build)
+  envelope — it pins the exact pandas-2.3.3 / numpy-2.2.6 API under Claude's-discretion (RESEARCH §22),
+  it does not change the design.
+- **Files modified:** itrader/price_handler/feed/bar_feed.py
+- **Commit:** `9168cae`
+
+**2. [Rule 3 - Blocking] mypy --strict: `np.ndarray` needs type arguments**
+- **Found during:** Task 1 (mypy gate).
+- **Issue:** the `buffer: np.ndarray` annotation failed `--strict` (`Missing type arguments for generic type "ndarray" [type-arg]`).
+- **Fix:** annotated `buffer: "np.ndarray[Any, np.dtype[Any]]"` (`Any` already imported). `.base` is
+  loosely typed in the numpy stubs, so `Any` dtype is the honest annotation.
+- **Files modified:** itrader/price_handler/feed/bar_feed.py
+- **Commit:** `9168cae`
+
+## Out-of-Plan Scope Note (not done — by design)
+
+This plan's `files_modified` frontmatter scopes it to `bar_feed.py` + `test_bar_feed.py` only. The
+gate-(b) W2 perf harness work (`perf/runners/run_w2_sweep.py` `--check`/`--baseline-out`, the
+`W2-BASELINE.json` artifact, the `W1-BASELINE.json` re-freeze, Makefile wiring) is described in
+RESEARCH/PATTERNS but is NOT in this plan's task list — it belongs to a later plan/phase-gate step and
+was deliberately left untouched.
+
+## Verification (Gate a — held)
+
+- `poetry run pytest tests/unit/price/test_bar_feed.py -q` → 22 passed (20 contract + 2 drift).
+- `poetry run pytest tests/integration/test_backtest_oracle.py -q` → 3 passed, byte-exact
+  **134 trades / final_equity 46189.87730727451**; determinism double-run produced identical output.
+- `poetry run pytest tests -q` → **1258 passed** (full unit/integration/e2e suite).
+- `poetry run mypy itrader` → Success, no issues in 165 source files (`--strict`).
+
+## Self-Check: PASSED
+
+- FOUND: `.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-01-SUMMARY.md`
+- FOUND commit `41a2cf6` (Task 0 — test), modifies `tests/unit/price/test_bar_feed.py`
+- FOUND commit `9168cae` (Task 1 — feat), modifies `itrader/price_handler/feed/bar_feed.py`

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-02-PLAN.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-02-PLAN.md
@@ -1,0 +1,244 @@
+---
+phase: 06-bar-feed-window-copies-optional-slip-able
+plan: 02
+type: execute
+wave: 2
+depends_on: [06-01]
+files_modified:
+  - perf/runners/run_w2_sweep.py
+  - Makefile
+  - perf/results/W2-BASELINE.json
+  - perf/results/W1-BASELINE.json
+autonomous: false
+requirements: [PERF-06]
+
+must_haves:
+  truths:
+    - "D-05: perf-w2 gains a --baseline-out/--check flag pair mirroring run_w1_benchmark.py; the gate keys on the 50-symbol wall-clock and PASSES (exit 0) iff the improvement is >= 10% (guard sense INVERTED vs W1 — this gate REQUIRES a win), carrying W1's WR-02 zero/malformed-baseline soft guard (non-positive baseline → return 1, never a ZeroDivisionError)"
+    - "D-05: a W2-BASELINE.json (the after-run 50-symbol wall_clock_s + peak_mem_mb) is captured and committed as the standing reproducible pass record — it also seeds Phase 5 (Incremental Indicators, W2-relevant)"
+    - "D-04: Gate (b) for THIS phase = perf-w2 shows a measurable win (>= 10% at 50 symbols) AND W1 does NOT regress (the standard >=5% W1 bar does NOT apply — PERF-06 is ~4% W1 by design); W1-BASELINE.json is re-frozen after"
+    - "D-04: thermal-drift discipline — the before-baseline is captured same-session/same-machine as the after-run on a cool box (per memory v15-perf-gateb-thermal-drift); a frozen cross-session baseline can drift and over/under-credit the win"
+    - "Gate (a) still held after the perf-runner/Makefile/baseline edits: byte-exact SMA_MACD oracle green (134 / 46189.87730727451); mypy --strict clean (no itrader/ engine code touched in this plan)"
+  artifacts:
+    - path: "perf/runners/run_w2_sweep.py"
+      provides: "--baseline-out/--check W2 gate-(b) mechanization (>=10% at 50 symbols, inverted guard)"
+      contains: "min_improvement_pct"
+    - path: "Makefile"
+      provides: "perf-w2 --check wiring + perf-w2-baseline freeze target"
+      contains: "perf-w2-baseline"
+    - path: "perf/results/W2-BASELINE.json"
+      provides: "committed after-run 50-symbol W2 reference (seeds Phase 5)"
+      contains: "wall_clock_s_at_50"
+    - path: "perf/results/W1-BASELINE.json"
+      provides: "re-frozen W1 reference after the phase (non-regression record)"
+      contains: "wall_clock_s"
+  key_links:
+    - from: "run_w2_sweep.py --check"
+      to: "perf/results/W2-BASELINE.json"
+      via: "50-symbol wall_clock_s improvement >= 10% gate"
+      pattern: "wall_clock_s_at_50"
+    - from: "Makefile perf-w2"
+      to: "run_w2_sweep.py"
+      via: "poetry run python -m perf.runners.run_w2_sweep"
+      pattern: "run_w2_sweep"
+---
+
+<objective>
+Mechanize and prove Gate (b) for this W2-dominant phase (D-04/D-05): add a `--baseline-out`/`--check`
+flag pair to `run_w2_sweep.py` mirroring `run_w1_benchmark.py` but with the guard sense INVERTED (the
+W2 gate REQUIRES a >= 10% wall-clock win at 50 symbols), wire it into the Makefile, capture the
+before/after W2 sweep on a cool same-session machine, commit a `W2-BASELINE.json`, and re-freeze
+`W1-BASELINE.json` after confirming W1 does not regress.
+
+Purpose: turn the "most visible in the W2 symbol sweep" success criterion into a concrete,
+reproducible pass record — and seed the standing W2 reference that Phase 5 (Incremental Indicators)
+will also be judged against. The standard >= 5% W1 bar does NOT apply here (PERF-06 is ~4% W1 by
+design); W1 stays the oracle-relevant non-regression guard.
+
+Output: extended W2 runner + Makefile targets, a committed `W2-BASELINE.json`, and a re-frozen
+`W1-BASELINE.json`.
+
+This plan depends on 06-01 (the engine view change must land before the after-measurement is meaningful).
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-CONTEXT.md
+@.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-RESEARCH.md
+@.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-PATTERNS.md
+
+<interfaces>
+<!-- The sibling runner to mirror + the W2 runner to extend + the baseline schema. -->
+
+perf/runners/run_w1_benchmark.py (the pattern to mirror, 4-space):
+- `main()` arg plumbing (:224-249): `--json` / `--check` / `--baseline-out PATH`; a guard message when
+  `--baseline-out` and `--check` are combined; then runs, optionally prints JSON, writes baseline, exits
+  on check.
+- `_to_baseline_schema(result)` / `_write_baseline(result, path)` (:150-186) — schema envelope
+  (schema_version / frozen_at / metric / ...).
+- `_check_regression(result, baseline_path)` (:189-221) — W1 soft guard: FAILS only on a slowdown beyond
+  band; WR-02 zero/malformed-baseline soft guard at :208-211 (non-positive baseline → return 1, message,
+  no traceback). INVERT the sense for W2 (require a win).
+
+perf/runners/run_w2_sweep.py (the target to EXTEND, not rewrite, 4-space):
+- already has `--json` (:151-158) and builds a `points` list of per-n_symbols dicts each with
+  `n_symbols`, `wall_clock_s`, `peak_mem_mb`. Sweep constants `_N_SYMBOLS_SWEEP` ({1,10,50}), `_N_BARS`,
+  `_SEED`.
+
+perf/results/W1-BASELINE.json (schema to mirror for W2): keys schema_version, frozen_at,
+metric{wall_clock_s, peak_mem_mb}, window, workload, oracle_provenance.
+
+Makefile (recipes use TABS by format): existing perf-w1 (--check), perf-w2, perf-baseline targets
+(:99-112); `.PHONY` line (:6); `include .env` / `.EXPORT_ALL_VARIABLES`.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add --baseline-out/--check to run_w2_sweep.py + Makefile wiring</name>
+  <files>perf/runners/run_w2_sweep.py, Makefile</files>
+  <read_first>
+    - perf/runners/run_w1_benchmark.py (:150-186 _to_baseline_schema/_write_baseline; :189-221 _check_regression incl. WR-02 zero-baseline guard :208-211; :224-249 main() arg plumbing)
+    - perf/runners/run_w2_sweep.py (existing --json at :151-158 + the points list shape)
+    - perf/results/W1-BASELINE.json (schema envelope to mirror)
+    - Makefile (:99-112 perf-w1/perf-w2/perf-baseline; :6 .PHONY)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-PATTERNS.md (run_w2_sweep section — _to_w2_baseline_schema + _check_w2 templates)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-RESEARCH.md (Code Examples — the W2 schema + _check_w2 with min_improvement_pct=10.0)
+  </read_first>
+  <action>
+    Extend (do NOT rewrite) `run_w2_sweep.py`'s `main()` to add `--baseline-out PATH` and `--check`
+    alongside the existing `--json`. Add `_to_w2_baseline_schema(points)` keyed on the 50-symbol point
+    (`next(p for p in points if p["n_symbols"] == 50)`) producing schema_version/frozen_at/
+    metric{wall_clock_s_at_50, peak_mem_mb_at_50}/sweep/points, mirroring the W1 envelope. Add `_write_w2_baseline`.
+    Add `_check_w2(points, baseline_path, min_improvement_pct=10.0)` that computes
+    `impr = (base50 - now50) / base50 * 100.0` on the 50-symbol wall_clock_s and returns 0 iff
+    `impr >= min_improvement_pct` (guard sense INVERTED vs W1 — this gate REQUIRES the win); carry W1's
+    WR-02 soft guard (non-positive `base50` → print message, return 1, never a ZeroDivisionError). Print the
+    `W2@50 {now}s improvement {impr:+.1f}% (baseline {base}s)` line. Wire `--baseline-out` → write, `--check`
+    → `sys.exit(_check_w2(...))`, and the combined-flag warning like run_w1. In the Makefile add `--check`
+    to the `perf-w2` recipe and a new `perf-w2-baseline` freeze target
+    (`run_w2_sweep --baseline-out perf/results/W2-BASELINE.json`) mirroring `perf-baseline`; add
+    `perf-w2-baseline` to the `.PHONY` line. Both files: match existing indentation (runner 4-space; Makefile
+    recipe tabs). This task only mechanizes the gate — no measurement run yet.
+  </action>
+  <verify>
+    <automated>poetry run python -m perf.runners.run_w2_sweep --help 2>&1 | grep -E -- '--check|--baseline-out' && grep -c 'perf-w2-baseline' Makefile</automated>
+  </verify>
+  <acceptance_criteria>
+    - `poetry run python -m perf.runners.run_w2_sweep --help` lists both `--check` and `--baseline-out`
+    - `run_w2_sweep.py` contains `min_improvement_pct` defaulting to `10.0` and a non-positive-baseline guard returning 1 (no ZeroDivisionError path)
+    - `_check_w2` returns 0 only when the 50-symbol improvement is >= 10% (inverted sense vs W1's slowdown guard)
+    - `grep -c 'perf-w2-baseline' Makefile` >= 1 and `perf-w2-baseline` is on the `.PHONY` line
+    - existing `--json` behavior is untouched (the points list/sweep constants unchanged)
+  </acceptance_criteria>
+  <done>run_w2_sweep.py has a working --baseline-out/--check pair keyed on the 50-symbol >=10% bar with the WR-02 soft guard; Makefile exposes perf-w2 --check + perf-w2-baseline.</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 2: Capture before/after W2 sweep + re-freeze baselines (cool-machine, thermal-sensitive)</name>
+  <what-built>
+    The W2 gate mechanization (Task 1) is in place: `make perf-w2` now runs the {1,10,50}-symbol sweep
+    with a `--check` that requires a >= 10% wall-clock win at 50 symbols, plus a `perf-w2-baseline` freeze
+    target. The 06-01 engine view change is merged. What remains is the thermal-drift-sensitive wall-clock
+    capture, which must run same-session/same-machine on a COOL box (per memory v15-perf-gateb-thermal-drift)
+    — Claude cannot guarantee the machine's thermal state, so the measurement + commit are human-gated.
+  </what-built>
+  <how-to-verify>
+    On a cool/quiet machine, in the MAIN checkout (not the worktree — perf needs .env; memory
+    worktree-make-test-env-abort):
+    1. Capture the BEFORE baseline on the PRE-06-01 code in the SAME session: `git stash` (or checkout the
+       parent of the 06-01 commit), then
+       `poetry run python -m perf.runners.run_w2_sweep --baseline-out perf/results/W2-BASELINE-pre.json`.
+    2. Restore the 06-01 change (`git stash pop` / checkout back), then run the AFTER check:
+       `poetry run python -m perf.runners.run_w2_sweep --check` against `W2-BASELINE-pre.json`
+       (point `--check` at the pre file). Confirm it prints `improvement >= +10.0%` at 50 symbols and exits 0.
+    3. Freeze the AFTER run as the standing reference:
+       `make perf-w2-baseline` → writes `perf/results/W2-BASELINE.json`.
+    4. Confirm W1 does NOT regress: `make perf-w1` (the --check soft guard) stays within band / does not
+       print a regression failure.
+    5. Re-freeze W1 after the phase: `make perf-baseline` → updates `perf/results/W1-BASELINE.json`.
+    6. Re-confirm Gate (a) on the same machine: `poetry run pytest tests/integration/test_backtest_oracle.py`
+       green (134 / 46189.87730727451).
+    Report the 50-symbol before/after wall-clock numbers and the % improvement. If the box was thermally
+    throttled (the before-run reads anomalously slow), do NOT commit — re-run on a cool machine (per the
+    pending-todo + thermal-drift memory), exactly as Phase 3's re-freeze was deferred.
+  </how-to-verify>
+  <resume-signal>Type "approved" with the before/after 50-symbol numbers + % improvement, or describe the thermal/measurement issue to defer.</resume-signal>
+  <action>Human-gated measurement: run the before/after W2 sweep + W1/W1-baseline re-freeze on a cool same-session machine per the how-to-verify steps; Claude cannot guarantee thermal state, so this is a blocking human-verify checkpoint (the steps are the manual procedure, not autonomous Claude work).</action>
+  <verify><human-check>The human reports the before/after 50-symbol wall-clock numbers and a >= 10% improvement at 50 symbols, with W1 non-regressed and Gate (a) green.</human-check></verify>
+  <done>The before/after W2 numbers are captured on a cool machine, the >=10%-at-50-symbols win + W1 non-regression are confirmed, and the human has approved (or deferred with a thermal reason).</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Commit W2-BASELINE.json + re-frozen W1-BASELINE.json; confirm Gate (a)</name>
+  <files>perf/results/W2-BASELINE.json, perf/results/W1-BASELINE.json</files>
+  <read_first>
+    - perf/results/W1-BASELINE.json (the re-frozen reference to confirm shape)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-CONTEXT.md (D-04/D-05 — committed W2 baseline + re-freeze W1)
+    - tests/integration/test_backtest_oracle.py (Gate (a) oracle)
+  </read_first>
+  <action>
+    After the human-verify checkpoint reports the measured >= 10% win and W1 non-regression, ensure the
+    standing `perf/results/W2-BASELINE.json` (the AFTER 50-symbol wall_clock_s + peak_mem_mb, the reference
+    that also seeds Phase 5) and the re-frozen `perf/results/W1-BASELINE.json` are present and trackable
+    (NOT gitignored — mirror the W1 trackability note from Phase 1; the narrow .gitignore only excludes
+    scalene artifacts). Remove the transient `W2-BASELINE-pre.json` if it was written. Record in the plan
+    SUMMARY: the before/after 50-symbol numbers, the % improvement (>= 10%), the W1 non-regression delta,
+    and the Gate (a) confirmation (oracle 134 / 46189.87730727451). Confirm `mypy --strict` clean (this plan
+    touched no itrader/ engine code, so it must remain clean).
+  </action>
+  <verify>
+    <automated>test -f perf/results/W2-BASELINE.json && test -f perf/results/W1-BASELINE.json && ! git check-ignore -q perf/results/W2-BASELINE.json && poetry run pytest tests/integration/test_backtest_oracle.py -q && poetry run mypy itrader</automated>
+  </verify>
+  <acceptance_criteria>
+    - `perf/results/W2-BASELINE.json` exists, is NOT git-ignored, and contains `wall_clock_s_at_50`
+    - `perf/results/W1-BASELINE.json` exists and is re-frozen (frozen_at reflects this phase's run)
+    - no `W2-BASELINE-pre.json` left committed (transient before-baseline removed)
+    - `poetry run pytest tests/integration/test_backtest_oracle.py -q` exits 0 (134 / 46189.87730727451)
+    - `poetry run mypy itrader` exits 0
+  </acceptance_criteria>
+  <done>The committed W2-BASELINE.json records the >=10%-at-50-symbols pass (and seeds Phase 5); W1-BASELINE.json is re-frozen with W1 non-regressed; Gate (a) re-confirmed.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| committed baseline JSON ← perf runner | A committed `W2-BASELINE.json` / re-frozen `W1-BASELINE.json` becomes the standing pass record the next phase diffs against; a malformed or thermally-drifted baseline could mis-credit a future win. No external/network/auth/user-input surface — offline perf tooling only. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-06-02-01 | Tampering | `_check_w2` zero/malformed baseline path | mitigate | Carry W1's WR-02 soft guard: non-positive/malformed `base50` returns 1 with a message, never a ZeroDivisionError traceback — a tampered/empty baseline fails closed rather than silently passing. |
+| T-06-02-02 | Repudiation | committed baseline as pass record | mitigate | Thermal-drift discipline (D-04, memory v15-perf-gateb-thermal-drift): same-session/same-machine before/after on a cool box, recorded in SUMMARY — the committed JSON is a reproducible, attributable record. |
+| T-06-02-03 | Spoofing / Information Disclosure / Denial of Service / Elevation | — | N/A | No external input, network, auth, secret, or user-data surface — offline perf-harness edits + data artifacts only. |
+| T-06-02-SC | Tampering | npm/pip/cargo installs | accept | No packages installed or changed this plan (RESEARCH Package Legitimacy Audit: not applicable). |
+</threat_model>
+
+<verification>
+- `run_w2_sweep.py --check` keys on 50-symbol wall_clock_s, returns 0 iff >= 10% improvement (inverted guard), carries the WR-02 zero-baseline soft guard; `--baseline-out` writes the W2 schema.
+- Makefile exposes `perf-w2 --check` + `perf-w2-baseline` (on `.PHONY`).
+- Committed `W2-BASELINE.json` (trackable) records the >= 10%-at-50-symbols pass; `W1-BASELINE.json` re-frozen, W1 non-regressed.
+- Gate (a) re-confirmed: oracle 134 / 46189.87730727451; `mypy --strict` clean.
+</verification>
+
+<success_criteria>
+- ROADMAP Success Criterion 4 (Gate b): the W2 symbol sweep shows a measurable improvement (>= 10% at 50 symbols) AND W1 does not regress; W1-BASELINE.json re-frozen and W2-BASELINE.json committed.
+- The W2 reference is seeded for Phase 5 (Incremental Indicators).
+</success_criteria>
+
+<output>
+Create `.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-02-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-02-SUMMARY.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-02-SUMMARY.md
@@ -1,0 +1,92 @@
+---
+phase: 06-bar-feed-window-copies-optional-slip-able
+plan: 02
+subsystem: testing
+tags: [perf, benchmark, w2-sweep, gate-b, makefile]
+
+# Dependency graph
+requires:
+  - phase: 06-01
+    provides: read-only view + alias memo in BacktestBarFeed.window() (the engine change the W2 after-measurement is meant to certify)
+provides:
+  - "W2 gate-(b) mechanization: run_w2_sweep.py --baseline-out/--check (50-symbol >=10% inverted guard + WR-02 zero-baseline soft guard)"
+  - "Makefile perf-w2 --check wiring + perf-w2-baseline freeze target"
+affects: [06-03, 06-04, 06-05]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: ["W1-mirrored baseline-out/--check runner pattern, guard sense INVERTED for a win-required gate"]
+
+key-files:
+  created: []
+  modified:
+    - perf/runners/run_w2_sweep.py
+    - Makefile
+
+key-decisions:
+  - "Task 1 (W2 gate harness) complete and committed (f51d7c6); reusable as-is per CONTEXT D-05"
+  - "Tasks 2/3 (before/after measurement + W2/W1 re-freeze) SUPERSEDED by 06-05 (D-14/D-15) after the 2026-06-24 cursor pivot"
+
+patterns-established:
+  - "Inverted-guard perf gate: _check_w2 returns 0 iff 50-symbol improvement >= min_improvement_pct (10.0), mirroring run_w1_benchmark but requiring a win"
+
+requirements-completed: []  # PERF-06 verdict is owned by 06-05 (the gate-(b) re-freeze + verdict plan); this plan only built the harness
+
+# Metrics
+duration: ~5min (Task 1 only; Tasks 2/3 superseded, not executed)
+completed: 2026-06-24
+---
+
+# Phase 06 Plan 02: W2 Gate-(b) Harness Summary
+
+**W2 gate-(b) mechanization (`run_w2_sweep --baseline-out/--check`, 50-symbol ≥10% inverted guard) landed as Task 1; the measurement + re-freeze tasks were superseded by 06-05 in the 2026-06-24 cursor pivot.**
+
+## Closeout Status
+
+This plan is closed out as **partially executed + superseded**, not re-run:
+
+- **Task 1 — DONE (committed):** Added `--baseline-out PATH` / `--check` to `run_w2_sweep.py`
+  (`_to_w2_baseline_schema`, `_write_w2_baseline`, `_check_w2` with `min_improvement_pct=10.0`, the
+  WR-02 non-positive-baseline soft guard returning 1, and the combined-flag warning), plus the
+  Makefile `perf-w2 --check` wiring and the `perf-w2-baseline` freeze target on `.PHONY`. Committed in
+  `f51d7c6` (`feat(06-02): mechanize W2 gate (b) — run_w2_sweep --baseline-out/--check + Makefile
+  wiring`).
+- **Task 2 (blocking human-verify) + Task 3 (commit baselines) — SUPERSEDED.** When this plan paused
+  at its checkpoint (`f5ac6c2`), the Gate (b) A/B + Scalene profile showed 06-01's view/alias gave
+  **~0% W2** — there was no ≥10% win to certify. The phase then **pivoted** (06-CONTEXT.md, D-10–D-16):
+  the real lever became the monotonic incremental cursor (06-04), with a denominator cleanup prep
+  (06-03) and a single gate-(b) **re-freeze + verdict** step (06-05, D-14/D-15). Per **D-05 (amended)**:
+  *"The 06-02 harness (`run_w2_sweep --baseline-out/--check`, commit `f51d7c6`) is reusable as-is — it
+  simply has no ≥10% win to certify until the cursor lands."* The before/after measurement and the
+  W1/W2 re-freeze that were Tasks 2/3 are now owned by **06-05** on the cleaned engine.
+
+## Task Commits
+
+1. **Task 1: Add --baseline-out/--check to run_w2_sweep.py + Makefile wiring** — `f51d7c6` (feat)
+   **Plan partial-progress marker:** `f5ac6c2` (docs)
+
+## Files Created/Modified
+- `perf/runners/run_w2_sweep.py` — `--baseline-out`/`--check` W2 gate-(b) flags (50-symbol ≥10%
+  inverted guard + WR-02 soft guard)
+- `Makefile` — `perf-w2 --check` wiring + `perf-w2-baseline` freeze target
+
+## Decisions Made
+- Closed out as superseded rather than re-executed: re-running would duplicate the committed harness
+  and re-enter a blocking checkpoint with nothing to certify (the cursor lands in 06-04; the verdict
+  is 06-05). Confirmed with the owner before writing this SUMMARY.
+
+## Deviations from Plan
+The plan's own Tasks 2/3 were not executed under this plan — they were re-scoped into 06-05 by the
+post-profile pivot (D-13/D-14/D-15). This is a planning-level re-scope, not an in-plan deviation.
+
+## Issues Encountered
+None — the pivot is documented in 06-CONTEXT.md and 06-PROFILE-FINDINGS.md.
+
+## Next Phase Readiness
+- The W2 `--check`/`--baseline-out` harness is in place and reusable by 06-03 (cleanup) and 06-05
+  (gate verdict). PERF-06's gate-(b) certification proceeds through 06-03 → 06-04 → 06-05.
+
+---
+*Phase: 06-bar-feed-window-copies-optional-slip-able*
+*Completed: 2026-06-24 (closed out as superseded)*

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-03-PLAN.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-03-PLAN.md
@@ -1,0 +1,189 @@
+---
+phase: 06-bar-feed-window-copies-optional-slip-able
+plan: 03
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - itrader/events_handler/full_event_handler.py
+  - perf/runners/run_w2_sweep.py
+autonomous: true
+requirements: [PERF-06]
+
+must_haves:
+  truths:
+    - "D-13(1): the per-bar `TIME EVENT` debug block in full_event_handler.py (the `if event.type is EventType.TIME:` → `self.logger.debug(f\"TIME EVENT: {event.time}\")` lines, ~22% of W2 CPU as an eager caller-built f-string discarded at the default INFO level) is REMOVED — behavior-neutral (the line never prints at INFO; logs are not the oracle), shrinking the W2/W1 denominator so the cursor's win (06-04) is a larger honest fraction"
+    - "D-13(2): run_w2_sweep.py::_run_point is DE-TIMED — tracemalloc no longer wraps the wall-clock timed `system.run()`; the timed pass measures the engine clean, and peak memory is captured in a SEPARATE instrumented pass (re-wired fresh system, same seed=42), so the timed wall_clock_s reflects engine work not ~19% harness allocation-tracking overhead"
+    - "D-13 carries forward gate (a) UNCHANGED: byte-exact SMA_MACD oracle (134 trades / final_equity 46189.87730727451) green, determinism double-run byte-identical, mypy --strict clean — this is a behavior-preserving prep step that re-baselines NOTHING numeric (the cleaned baselines are re-frozen in 06-05, not here)"
+    - "This plan is the PREP that MUST land before the cursor (06-04) and before the gate re-freeze (06-05): re-freezing on the diluted pre-D-13 engine would leave the ≥10% W2 bar unreachable (RESEARCH Pitfall 3)"
+  artifacts:
+    - path: "itrader/events_handler/full_event_handler.py"
+      provides: "dispatcher with the per-bar TIME EVENT debug log removed"
+      contains: "_dispatch"
+    - path: "perf/runners/run_w2_sweep.py"
+      provides: "two-pass _run_point — clean timed wall-clock + separate tracemalloc peak-mem pass"
+      contains: "perf_counter"
+  key_links:
+    - from: "perf/runners/run_w2_sweep.py::_run_point"
+      to: "wall_clock_s"
+      via: "perf_counter around system.run() with NO tracemalloc in the timed region"
+      pattern: "perf_counter"
+---
+
+<objective>
+D-13 denominator cleanup (the PREP step, runs BEFORE the cursor): remove the per-bar `TIME EVENT`
+debug log from the event dispatcher and de-time the W2 sweep harness so the W2/W1 wall-clock
+denominator measures engine work, not eager-f-string logging waste (~22% W2) or tracemalloc
+allocation-tracking overhead (~19% W2). This is behavior-neutral and re-baselines nothing numeric —
+it shrinks the denominator so the cursor's `searchsorted`-removal (06-04) becomes a larger, honest
+fraction that can clear the ≥10% W2 bar (06-05).
+
+Purpose: RESEARCH Pitfall 3 — re-freezing the W2 baseline on the diluted (pre-D-13) engine leaves the
+≥10% bar unreachable by design (exactly why 06-01's measurement read ~0%). The cleanup must land first.
+Output: a leaner dispatcher hot path + a two-pass W2 runner (clean timed run + separate peak-mem run).
+
+This plan has no dependencies; it is wave 1 and runs before 06-04 (cursor) and 06-05 (gate).
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-CONTEXT.md
+@.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-RESEARCH.md
+@.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-PROFILE-FINDINGS.md
+
+<interfaces>
+<!-- The two exact edit sites. Match each file's indentation — never normalize. -->
+
+itrader/events_handler/full_event_handler.py (TAB indent — do NOT introduce spaces):
+- `_dispatch` body at :114-116 — the block to DELETE:
+    `if event.type is EventType.TIME:`
+        `# D-21: per-tick flow log demoted from INFO to DEBUG.`
+        `self.logger.debug(f"TIME EVENT: {event.time}")`
+  The `try:` at :117 (`handlers = self.routes[event.type]`) and the rest of dispatch stay.
+  The eager f-string `f"TIME EVENT: {event.time}"` is built by Python BEFORE `.debug()` runs;
+  logger.py's internal isEnabledFor(DEBUG) gate fires AFTER the string is formatted, so
+  `str(event.time)` is paid every bar and discarded at INFO (RESEARCH Finding C, code-verified).
+
+perf/runners/run_w2_sweep.py (4-space indent):
+- `_run_point(n_symbols, tmpdir)` at :95-131 — today tracemalloc WRAPS the timed run:
+    `tracemalloc.start()` ; `t0 = time.perf_counter()` ; `system.run(print_summary=False)` ;
+    `wall_clock_s = time.perf_counter() - t0` ; `_current, peak_bytes = tracemalloc.get_traced_memory()` ;
+    `tracemalloc.stop()` ; `peak_mem_mb = peak_bytes / (1024 * 1024)`.
+  The synthetic frame/CSV generation (`make_synthetic_ohlcv`, `_write_kline_csv`) is ALREADY outside
+  the timed region — keep it there. The wiring block (`BacktestTradingSystem(...)`, add_strategy,
+  add_portfolio, subscribe_portfolio) is the re-wire to repeat for the second (mem) pass.
+- Constants: `_N_BARS`, `_SEED` (=42), `_TIMEFRAME`. `run_w2()` at :134 calls `_run_point` per n_symbols.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Remove the per-bar TIME EVENT debug log (D-13 part 1)</name>
+  <files>itrader/events_handler/full_event_handler.py</files>
+  <read_first>
+    - itrader/events_handler/full_event_handler.py (:108-122 — the `_dispatch` docstring + the TIME-EVENT block at :114-116 + the `try:` route lookup at :117; confirm TAB indentation)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-RESEARCH.md (Pattern 3a + Finding C — plain removal, not a guarded/lazy log; the line is already DEBUG-gated and never prints at INFO)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-CONTEXT.md (D-13 — the log line is outside bar_feed.py, accepted because it inflates the W2 denominator)
+  </read_first>
+  <action>
+    In `full_event_handler.py::_dispatch`, DELETE the three-line `TIME EVENT` block at :114-116 — the
+    `if event.type is EventType.TIME:` guard, its `# D-21:` comment, and the
+    `self.logger.debug(f"TIME EVENT: {event.time}")` call. Plain removal per D-13 — do NOT replace it
+    with a lazy/guarded `isEnabledFor` branch (that keeps a per-bar branch for zero benefit; the line
+    is already DEBUG-gated and never prints at the default INFO level, so there is no observable
+    behavior to preserve). Leave the `try:` route lookup at :117 and everything after it unchanged.
+    Match the file's TAB indentation exactly — this is the TAB file (CLAUDE.md indentation hazard;
+    RESEARCH Pitfall 4); do NOT normalize to spaces. EventType.TIME is still routed via `self.routes`
+    (the route list at :69 is untouched) — only the debug log is removed, not the dispatch.
+  </action>
+  <verify>
+    <automated>cd /Users/tizianoiacovelli/Desktop/projects/intelli-trader && ! grep -q 'TIME EVENT' itrader/events_handler/full_event_handler.py && poetry run pytest tests/integration/test_backtest_oracle.py -q && poetry run mypy itrader</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c 'TIME EVENT' itrader/events_handler/full_event_handler.py` returns 0 (the block is gone)
+    - the `EventType.TIME` route entry in `self.routes` (:69) is UNCHANGED — only the debug log was removed (grep still finds `EventType.TIME:` in the routes literal)
+    - the edited lines use TAB indentation (no space-indented lines introduced; `grep -nP '^\t' itrader/events_handler/full_event_handler.py` still matches the surrounding `_dispatch` body)
+    - `poetry run pytest tests/integration/test_backtest_oracle.py -q` exits 0 — byte-exact oracle 134 trades / final_equity 46189.87730727451 (logs are not the oracle; removal is behavior-neutral)
+    - `poetry run mypy itrader` exits 0
+  </acceptance_criteria>
+  <done>The per-bar TIME EVENT debug log is removed (TAB indentation preserved), TIME dispatch is unchanged, and the byte-exact oracle + mypy --strict stay green.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: De-time run_w2_sweep._run_point — two-pass clean timing + separate peak-mem (D-13 part 2)</name>
+  <files>perf/runners/run_w2_sweep.py</files>
+  <read_first>
+    - perf/runners/run_w2_sweep.py (:95-131 `_run_point` — the tracemalloc-wrapped timed region; the synthetic-gen already outside; the wiring block to re-run for the mem pass; constants `_N_BARS`/`_SEED`/`_TIMEFRAME`)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-RESEARCH.md (Pattern 3b — the two-pass structure: clean timed run, then a fresh re-wired system under tracemalloc for peak-mem; keep seed=42; synth frames/CSVs generated ONCE and reused across both passes)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-CONTEXT.md (D-13 — capture peak-mem in a SEPARATE pass, NOT inside the timed run)
+  </read_first>
+  <action>
+    Restructure `_run_point` into two passes. Generate the synthetic frames + CSVs ONCE (the existing
+    `make_synthetic_ohlcv`/`_write_kline_csv` loop and `csv_paths`/`start`/`end` derivation stay
+    outside any timed region). PASS 1 (clean wall-clock): wire a `BacktestTradingSystem` + strategy +
+    portfolio + subscribe exactly as today, then time ONLY `system.run(print_summary=False)` with
+    `time.perf_counter()` and NO tracemalloc anywhere in the timed region — set `wall_clock_s`. PASS 2
+    (peak memory): re-wire a SECOND fresh `BacktestTradingSystem` from the SAME csv_paths/start/end
+    (identical wiring, fresh state, same `seed=_SEED`/`_TIMEFRAME`), then `tracemalloc.start()`,
+    `system.run(print_summary=False)`, `tracemalloc.get_traced_memory()`, `tracemalloc.stop()`, and
+    `peak_mem_mb = peak_bytes / (1024 * 1024)`. Return the same dict shape
+    (`{"n_symbols", "wall_clock_s", "peak_mem_mb"}`) so `run_w2()`, `--json`, and the 06-02
+    `--check`/`--baseline-out` flags (committed `f51d7c6`, reusable as-is) are untouched. Factor the
+    repeated wiring into a small local helper if it reduces duplication, but do NOT change the wiring
+    parameters (same exchange="csv", same cash, same strategy/tickers). 4-space indentation. Do NOT
+    re-add `--check`/`--baseline-out` — they already exist from 06-02 (RESEARCH Wave 0 note).
+  </action>
+  <verify>
+    <automated>cd /Users/tizianoiacovelli/Desktop/projects/intelli-trader && poetry run python -m perf.runners.run_w2_sweep --help >/dev/null 2>&1 && python -c "import ast,sys; src=open('perf/runners/run_w2_sweep.py').read(); t=ast.parse(src); fn=[n for n in ast.walk(t) if isinstance(n,ast.FunctionDef) and n.name=='_run_point'][0]; runs=sum(1 for n in ast.walk(fn) if isinstance(n,ast.Call) and getattr(getattr(n.func,'attr',None),'__eq__',lambda x:False)('run')); assert src.count('tracemalloc.start') >= 1 and 'perf_counter' in src; print('OK two-pass')"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `_run_point` contains a `time.perf_counter()`-timed region that wraps `system.run(...)` with NO `tracemalloc.start()`/`get_traced_memory()` call inside that timed region (the timed pass is clean)
+    - `_run_point` runs `system.run(...)` TWICE: once timed-clean (wall_clock_s) and once under tracemalloc (peak_mem_mb) on a freshly re-wired system with the same `seed=_SEED`
+    - synthetic frame/CSV generation happens ONCE, outside both passes, and is reused
+    - the returned dict keeps exactly `{"n_symbols", "wall_clock_s", "peak_mem_mb"}` — `run_w2()`, `--json`, and the existing `--check`/`--baseline-out` flags are unchanged
+    - `poetry run python -m perf.runners.run_w2_sweep --help` still exits 0 and lists `--check` and `--baseline-out` (06-02 flags not removed)
+  </acceptance_criteria>
+  <done>`_run_point` measures wall-clock on a clean timed run and peak memory on a separate instrumented run, returns the unchanged dict shape, and the 06-02 gate flags are intact.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| (none new) | Internal engine performance prep — no external input, no auth, no network, no untrusted data, no secrets. The only safety-relevant invariant in this phase is the look-ahead bar-timing contract, and THIS plan touches neither `bar_feed.py` nor the window slice; the dispatcher edit removes only a debug log and the runner edit only re-orders measurement. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-06-03-01 | Tampering | removing the TIME EVENT log could alter behavior | accept | The line is DEBUG-gated and never prints at the default INFO level; logs are not the oracle. The byte-exact SMA_MACD oracle (gate a) is the run-path backstop and is asserted in Task 1's verify — a behavior change would fail it. |
+| T-06-03-02 | Tampering | de-timed harness mis-measures (under/over-credits a future win) | mitigate | The two-pass structure measures wall-clock clean and peak-mem separately on the SAME synthetic input (seed=42); the 06-05 re-freeze captures BOTH baseline and check-run with the SAME de-timed harness (RESEARCH Pattern 4), so the delta is apples-to-apples. |
+| T-06-03-SC | Tampering | npm/pip/cargo installs | N/A | No packages installed or changed this plan (RESEARCH Package Legitimacy Audit: not applicable — no external packages). |
+| — | Spoofing / Repudiation / Info Disclosure / DoS / Elevation | — | N/A | No external attack surface — internal hot-path log removal + perf-runner measurement hygiene only. |
+</threat_model>
+
+<verification>
+- `TIME EVENT` debug log removed from `full_event_handler.py` (TAB indentation preserved); TIME dispatch unchanged.
+- `_run_point` de-timed: clean wall-clock pass + separate tracemalloc peak-mem pass, same dict shape, 06-02 flags intact.
+- Gate (a) held: byte-exact oracle 134 / 46189.87730727451; `mypy --strict` clean. No numeric re-baseline (re-freeze is 06-05).
+</verification>
+
+<success_criteria>
+- The W2/W1 denominator is cleaned (engine log waste removed + harness de-timed) so the cursor's win in 06-04 is a larger, honest fraction (RESEARCH Pitfall 3 avoided).
+- Behavior-preserving: byte-exact SMA_MACD oracle green, `mypy --strict` clean.
+</success_criteria>
+
+<output>
+Create `.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-03-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-03-SUMMARY.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-03-SUMMARY.md
@@ -1,0 +1,82 @@
+---
+phase: 06-bar-feed-window-copies-optional-slip-able
+plan: 03
+subsystem: perf-denominator-cleanup
+tags: [PERF-06, D-13, hot-path, harness, behavior-preserving]
+requires:
+  - "frozen W1/W2 baselines (Phase 1 tooling)"
+  - "06-PROFILE-FINDINGS.md (real W2 hotspot map)"
+provides:
+  - "dispatcher hot path with the per-bar TIME EVENT debug log removed (~22% W2 CPU eager-f-string waste eliminated)"
+  - "two-pass W2 sweep runner — clean timed wall-clock + separate tracemalloc peak-mem (no ~19% allocation-tracking overhead in the timed region)"
+affects:
+  - "06-04 (cursor): the cleaned denominator makes the searchsorted-removal win a larger honest fraction"
+  - "06-05 (gate re-freeze): re-freeze both baseline and check-run with this de-timed harness (apples-to-apples)"
+tech-stack:
+  added: []
+  patterns:
+    - "two-pass perf measurement: time wall-clock on a clean run, capture peak-mem on a fresh re-wired run under tracemalloc"
+    - "plain removal of an already-DEBUG-gated hot-path log (no lazy/guarded isEnabledFor branch)"
+key-files:
+  created: []
+  modified:
+    - "itrader/events_handler/full_event_handler.py"
+    - "perf/runners/run_w2_sweep.py"
+decisions:
+  - "D-13(1): plain-remove the per-bar TIME EVENT debug block (not a lazy/guarded log) — the line is DEBUG-gated and never prints at INFO, so there is no observable behavior to preserve"
+  - "D-13(2): de-time _run_point — tracemalloc no longer wraps the timed system.run(); peak-mem moves to a separate fresh-wired pass (same seed=42)"
+  - "Factored identical wiring into _wire_system so both passes re-wire from the SAME csv_paths/start/end; the returned dict shape and the 06-02 --check/--baseline-out flags are unchanged"
+metrics:
+  duration_min: 2
+  tasks: 2
+  files: 2
+  completed: 2026-06-24
+---
+
+# Phase 6 Plan 03: D-13 Denominator Cleanup Summary
+
+D-13 prep step (runs BEFORE the cursor): removed the per-bar `TIME EVENT` debug log from the event dispatcher (~22% W2 CPU as an eager caller-built f-string discarded at INFO) and de-timed the W2 sweep harness into two passes (clean wall-clock + separate tracemalloc peak-mem), so the W2/W1 denominator measures engine work — not logging waste or ~19% allocation-tracking overhead. Behavior-neutral: re-baselines nothing numeric (the cleaned baselines re-freeze in 06-05).
+
+## What Was Built
+
+### Task 1 — Remove the per-bar TIME EVENT debug log (D-13 part 1)
+- Deleted the three-line `if event.type is EventType.TIME:` block (its `# D-21:` comment + the `self.logger.debug(f"TIME EVENT: {event.time}")` call) from `EventHandler._dispatch`.
+- The eager `f"TIME EVENT: {event.time}"` was formatted every bar before `.debug()` ran, then discarded at the default INFO level — pure denominator inflation (RESEARCH Finding C, code-verified).
+- The `EventType.TIME` route entry in `self.routes` is untouched — TIME dispatch is unchanged; only the debug log was removed.
+- TAB indentation preserved (the file is a TAB module — CLAUDE.md indentation hazard).
+- Commit: `15834d7`
+
+### Task 2 — De-time `run_w2_sweep._run_point` into two passes (D-13 part 2)
+- Restructured `_run_point` so synthetic frames/CSVs are generated ONCE outside both passes and reused.
+- PASS 1 (clean wall-clock): wires a fresh `BacktestTradingSystem` and times ONLY `system.run(print_summary=False)` with `time.perf_counter()` — NO `tracemalloc` anywhere in the timed region.
+- PASS 2 (peak memory): re-wires a SECOND fresh system from the same `csv_paths`/`start`/`end` (same `seed=42`, same `_TIMEFRAME`), then runs under `tracemalloc.start()` → `get_traced_memory()` → `stop()` and computes `peak_mem_mb`.
+- Factored the identical wiring into a small local `_wire_system` helper (no wiring-parameter changes: same `exchange="csv"`, same cash, same strategy/tickers).
+- The returned dict shape (`{"n_symbols", "wall_clock_s", "peak_mem_mb"}`) and the 06-02 `--check`/`--baseline-out`/`--json` flags are unchanged.
+- 4-space indentation preserved.
+- Commit: `43e5e72`
+
+## Deviations from Plan
+
+None — plan executed exactly as written. (The wiring helper `_wire_system` was anticipated by the plan: "Factor the repeated wiring into a small local helper if it reduces duplication.")
+
+## Verification Evidence
+
+- Task 1 automated verify: `grep 'TIME EVENT'` returns nothing; `EventType.TIME` still present once (the route literal); `^\t+try:` matches (TAB indentation intact).
+- Gate (a) oracle GREEN: `poetry run pytest tests/integration/test_backtest_oracle.py -q` → 3 passed (byte-exact 134 trades / `final_equity 46189.87730727451`). Logs are not the oracle — removal is behavior-neutral.
+- `poetry run mypy itrader` → `Success: no issues found in 187 source files`.
+- Task 2 automated verify: `poetry run python -m perf.runners.run_w2_sweep --help` exits 0 and lists `--check` + `--baseline-out`; AST check confirms exactly 2 `system.run()` calls in `_run_point` and `perf_counter` + `tracemalloc.start` present; targeted assertion confirms the `t0=perf_counter()` → `wall_clock_s=` timed window contains NO `tracemalloc` call (the timed pass is clean).
+
+## Threat Surface Scan
+
+No new threat surface. This plan removes a debug log and re-orders perf measurement; it touches neither `bar_feed.py` nor the look-ahead window slice, and introduces no external input, auth, network, or schema change. T-06-03-01 (Tampering: log removal alters behavior) is backstopped GREEN by the byte-exact oracle in Task 1's verify.
+
+## Notes for Downstream Plans
+
+- 06-04 (cursor) and 06-05 (gate re-freeze) MUST run against this cleaned engine + de-timed harness. Re-freezing on the pre-D-13 (diluted) engine would leave the ≥10% W2 bar unreachable by design (RESEARCH Pitfall 3) — the exact reason 06-01's measurement read ~0%.
+- 06-05 should capture BOTH the baseline and the check-run with this same de-timed harness so the delta is apples-to-apples (RESEARCH Pattern 4 / T-06-03-02 mitigation).
+
+## Self-Check: PASSED
+- FOUND: itrader/events_handler/full_event_handler.py (modified, TIME EVENT block removed)
+- FOUND: perf/runners/run_w2_sweep.py (modified, two-pass `_run_point`)
+- FOUND: commit 15834d7 (Task 1)
+- FOUND: commit 43e5e72 (Task 2)

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-04-PLAN.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-04-PLAN.md
@@ -1,0 +1,272 @@
+---
+phase: 06-bar-feed-window-copies-optional-slip-able
+plan: 04
+type: execute
+wave: 2
+depends_on: [06-03]
+files_modified:
+  - itrader/price_handler/feed/bar_feed.py
+  - tests/unit/price/test_bar_feed.py
+autonomous: true
+
+requirements: [PERF-06]
+
+must_haves:
+  truths:
+    - "D-10: BacktestBarFeed.window() replaces the per-tick `frame.index.searchsorted(cutoff, side=\"right\")` (13.2% of W2 CPU) with a monotonic per-(ticker, alias) forward cursor that steps forward over `frame.index.asi8` (int64 ns) comparing `iv_i8[pos] <= cutoff.value` — NOT a pandas-Timestamp compare and NOT a per-tick np.datetime64 conversion (both deliver no win; int64 is load-bearing). Cutoff stays exclusive-right (`<=` reproduces searchsorted side=\"right\" byte-for-byte)"
+    - "D-10 reset/seek-safety (correctness crux): cursor state is keyed `(ticker, alias)` exactly like self._frames; on a COLD cursor (key unseen) OR a NON-MONOTONIC step (`cutoff_i8 < last_cut`) OR an unknown/gap frame, window() falls back to a safe `searchsorted` rebuild — it NEVER trusts stale state and NEVER leaks a future bar. The rebuild is byte-identical to today's behavior (silent, not fail-loud — a non-monotonic cutoff is legitimate: screener re-entry, resampled cutoffs)"
+    - "D-12: the cursor is built ON TOP of the kept 06-01 foundation — window() still returns the same read-only `frame.iloc[start:pos]` VIEW off the locked single-block non-writeable master (D-09), still short-circuits the empty window with `frame.iloc[pos:pos]` (D-06), and the 06-01 D-08 read-only/content tests stay green. 06-01 (commit 9168cae) is NOT reverted or modified"
+    - "D-11: the `iloc[start:pos]` slice is KEPT (cursor-only) — every cheaper-slice candidate measured slower than iloc on this single-block float64 frame and D-07 forbids `pd.DataFrame(...)` reconstruction (byte-identity). D-11's separate-cheaper-slice idea is recorded as investigated + empirically infeasible, superseded by research; the 7.9% iloc cost is accepted via the D-15 ship-and-reframe fallback (06-05)"
+    - "D-16 / D-08: the existing D-08 drift suite in tests/unit/price/test_bar_feed.py is EXTENDED (not replaced) — across sampled MONOTONIC ticks the cursor's computed `(start, pos)` == a fresh `searchsorted(cutoff, side=\"right\")` on the same frame, PLUS the no-future-bar invariant (`(win.index <= cutoff).all()`), PLUS reset-safety cases: backwards/out-of-order asof rebuild, cold cursor, gap frame, universe re-entry. Test-only — ZERO hot-loop runtime assert (an always-on `assert cursor == searchsorted` would re-pay the searchsorted the cursor removes, rejected by D-16)"
+    - "Gate (a) held: byte-exact SMA_MACD oracle (134 trades / final_equity 46189.87730727451) green, determinism double-run byte-identical, mypy --strict clean, full suite green; the 7-rule look-ahead bar-timing contract (bar_feed.py module docstring) preserved byte-for-byte; window() keeps its `(ticker, timeframe, max_window, asof) -> pd.DataFrame` signature + return type"
+  artifacts:
+    - path: "itrader/price_handler/feed/bar_feed.py"
+      provides: "monotonic int64 forward cursor in window() with a searchsorted rebuild guard; cursor state dicts in __init__"
+      contains: "asi8"
+    - path: "tests/unit/price/test_bar_feed.py"
+      provides: "D-16 cursor==searchsorted equivalence + no-future-bar + reset/cold/gap/re-entry tests, co-located with the kept D-08 suite"
+      contains: "searchsorted"
+  key_links:
+    - from: "BacktestBarFeed.window()"
+      to: "frame.index.asi8 / cutoff.value"
+      via: "forward int64-ns cursor step with a `cutoff_i8 < last_cut` searchsorted rebuild guard"
+      pattern: "asi8"
+    - from: "tests/unit/price/test_bar_feed.py"
+      to: "frame.index.searchsorted(cutoff, side=\"right\")"
+      via: "cursor (start,pos) == fresh searchsorted across sampled ticks (D-16 drift lock)"
+      pattern: "searchsorted"
+---
+
+<objective>
+D-10 monotonic incremental cursor: replace the per-tick `searchsorted` in `BacktestBarFeed.window()`
+(13.2% of W2 CPU, the largest reducible per-tick cost) with a per-(ticker, alias) forward cursor over
+the index's int64 nanoseconds, with a safe `searchsorted` rebuild on any cold/non-monotonic/gap step
+so it can never leak a future bar. Built on top of the kept 06-01 read-only view (D-12); the cursor
+returns the same read-only `iloc[start:pos]` view (D-11 cursor-only — the cheaper slice is empirically
+infeasible). Extend the D-08 drift suite with cursor==searchsorted equivalence + reset-safety (D-16).
+
+Purpose: the int64 forward cursor is 0.14 µs/step vs searchsorted's 4.3 µs — byte-identical to
+`searchsorted(side="right")` (VERIFIED across 3000 on-grid + 3000 mid-gap ticks). It removes ~36% of
+the window() path, the larger, certain lever for the ≥10% W2 gate (06-05). The correctness crux is the
+reset guard (never leak a future bar); the look-ahead contract is the only safety-relevant invariant
+and is covered by the D-16 drift test + the byte-exact oracle.
+Output: a cursored `window()` + an extended drift suite; gate (a) held byte-for-byte.
+
+This plan depends on 06-03 (the denominator cleanup must land first so the cursor's win is measurable
+in 06-05). It does NOT touch 06-01's shipped code beyond adding the cursor inside window() + the init
+state dicts.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-CONTEXT.md
+@.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-RESEARCH.md
+@.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-PATTERNS.md
+@.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-01-SUMMARY.md
+
+<interfaces>
+<!-- The cursor is internal to window() + __init__ state. No signature/queue/handler/ABC change.
+     Match bar_feed.py's 4-space indentation; never normalize. -->
+
+itrader/price_handler/feed/bar_feed.py (4-space — the ONLY engine file this phase edits):
+- `window(ticker, timeframe, max_window, asof) -> pd.DataFrame` at :427-486 — KEEP the signature +
+  return type. Current per-tick steps (:470-486):
+    `alias = _offset_alias(timeframe)` ; `frame = self._resampled_frame(ticker, alias)` ;
+    `cutoff = asof - timeframe + self._base_timeframe` ;
+    `pos = int(frame.index.searchsorted(cutoff, side="right"))` ;  ← REPLACE with the cursor
+    `start = max(0, pos - max_window)` ;
+    `if start >= pos: return frame.iloc[pos:pos]` (D-06 empty short-circuit — KEEP) ;
+    `return frame.iloc[start:pos]` (D-09 read-only view — KEEP).
+- `__init__` at :199-258 — the cursor state dicts go alongside `self._frames`/`self._spans`/
+  `self._prebuilt` (after the `self._prebuilt` loop, before the run-path bindings at :253).
+- `_resampled_frame(ticker, alias)` at :319-341 — keys frames `(ticker, alias)`; the cursor mirrors
+  this exact keying (Pitfall 5: keying on ticker alone shares one cursor across two timeframes).
+- `_readonly_master` (:132) + the locked single-block master are 06-01 — UNCHANGED. The index int64
+  backing (`asi8`) is separate from the locked values block and reads fine on a non-writeable frame.
+
+The cursor (RESEARCH Pattern 1, VERIFIED byte-identical to searchsorted side="right"):
+  `key = (ticker, alias)` ; `n = len(frame.index)` ;
+  `iv_i8 = frame.index.asi8`            # zero-copy cached int64 ns view (UTC); stable across calls
+  `cutoff_i8 = cutoff.value`            # O(1) int64 ns; == asi8[k] for tz-aware index [VERIFIED]
+  `last_pos = self._cursor.get(key)` ; `last_cut = self._cursor_cut.get(key)`
+  `if last_pos is None or last_cut is None or cutoff_i8 < last_cut:`
+      `pos = int(frame.index.searchsorted(cutoff, side="right"))`   # COLD / NON-MONOTONIC: SAFE REBUILD
+  `else:`
+      `pos = last_pos`
+      `while pos < n and iv_i8[pos] <= cutoff_i8: pos += 1`          # 0.14 µs/step; exclusive-right
+  `self._cursor[key] = pos` ; `self._cursor_cut[key] = cutoff_i8`
+
+Cursor state dicts (__init__, 4-space, mypy --strict typed):
+  `self._cursor: dict[tuple[str, str], int] = {}`      # last forward position per (ticker, alias)
+  `self._cursor_cut: dict[tuple[str, str], int] = {}`  # last cutoff (int64 ns) per (ticker, alias)
+
+tests/unit/price/test_bar_feed.py (4-space — extend, do NOT rewrite):
+- `ts(stamp) -> pd.Timestamp` tz-aware helper (:50).
+- Fixtures present: `daily_feed` (:88), `daily_base_frame` (:93), `duo_feed` (:98, BTC/ETH/LATE),
+  `gappy_feed` (:112, missing interior Jan-5 bar). These already supply the cold/gap/churn cases.
+- The KEPT 06-01 D-08 tests: `test_window_view_content_equals_old_copy` (:343),
+  `test_window_view_is_read_only_and_cannot_leak` (:359) — stay green unchanged.
+- The 7-rule contract suite (:125-308) is D-08 assertion (c) — stays green.
+- `pd.testing.assert_frame_equal(..., check_freq=False)` is the byte-identity backstop (:167,:183,:356).
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Extend the D-08 drift suite with D-16 cursor-equivalence + reset-safety tests</name>
+  <files>tests/unit/price/test_bar_feed.py</files>
+  <behavior>
+    - cursor==searchsorted across MONOTONIC sampled ticks: for a sequence of advancing `asof`, the
+      window's last position equals a fresh `int(frame.index.searchsorted(cutoff, side="right"))` (i.e.
+      `frame.index.get_loc(win.index[-1]) == fresh_pos - 1` when non-empty), AND `(win.index <= cutoff).all()`
+    - no-future-bar invariant: every returned stamp <= cutoff for each sampled tick (no leak)
+    - reset-safety / backwards asof: advance the cursor to a late asof, then query an EARLIER asof on
+      the SAME feed — the early window contains NO bar later than its cutoff (the `cutoff_i8 < last_cut`
+      rebuild guard fired); byte-identical to a virgin-cursor fresh searchsorted at the early cutoff
+    - reset-safety / cold cursor: the FIRST call for a key resolves byte-identically (cold rebuild)
+    - reset-safety / gap frame (gappy_feed): a cutoff landing on the missing Jan-5 gap day resolves
+      with no future leak and the gap day absent from the window
+    - reset-safety / universe re-entry (duo_feed): BTC queried, then ETH (other key), then BTC again at
+      a LATER tick — BTC's forward step is still correct (cutoff advanced monotonically), no leak
+  </behavior>
+  <read_first>
+    - tests/unit/price/test_bar_feed.py (:50 `ts`; :88/:93/:98/:112 fixtures; :343/:359 the kept D-08 tests; :167/:183 the assert_frame_equal idiom; the 7-rule contract suite :125-308)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-RESEARCH.md (Code Examples — the four D-16 test skeletons: test_cursor_equals_fresh_searchsorted_across_ticks, test_cursor_safe_rebuild_on_backwards_asof, test_cursor_cold_and_gap, test_cursor_universe_reentry; Validation Architecture → Phase Requirements → Test Map)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-PATTERNS.md (test section — decision-tag-anchored drift-lock docstring; reuse assert_frame_equal; the Pitfall-1 read-only mutation form is already in the kept :359 test, do not duplicate)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-01-SUMMARY.md (the D-08 three-assertion lock these tests extend)
+  </read_first>
+  <action>
+    EXTEND `test_bar_feed.py` (do NOT rewrite; the kept D-08 tests at :343/:359 and the 7-rule contract
+    suite stay verbatim). Add D-16 tests co-located with the D-08 suite, opening each with a
+    decision-tag-anchored docstring (D-10/D-16) naming the oracle (a fresh `searchsorted(cutoff,
+    side="right")`) and stating explicitly that NO hot-path runtime guard is added — re-paying the
+    searchsorted is exactly what the cursor removes (project house style; PATTERNS). Add:
+    (1) `test_cursor_equals_fresh_searchsorted_across_ticks` — across advancing `asof` on `daily_feed`,
+    assert `frame.index.get_loc(win.index[-1]) == fresh_pos - 1` (non-empty) and `(win.index <= cutoff).all()`;
+    (2) `test_cursor_safe_rebuild_on_backwards_asof` — `daily_feed` advanced to a late asof then queried
+    at an earlier asof; assert `(early.index <= early_cutoff).all()` (no Jan-late leak), byte-identical
+    to a fresh-cursor feed's window at the same early asof;
+    (3) `test_cursor_cold_and_gap` — `gappy_feed`, a cold first call AND a cutoff on the missing Jan-5
+    gap day both resolve with no future-bar leak and the gap day absent;
+    (4) `test_cursor_universe_reentry` — `duo_feed`: BTC, then ETH, then BTC at a later tick; assert
+    BTC's re-entry window respects `(w2.index <= cutoff).all()` and ends at the expected last bar.
+    Use the tz-aware `ts()` helper and `pd.testing.assert_frame_equal(check_freq=False)` for any
+    content equality. These tests will FAIL against the un-cursored window() only where they assert the
+    cursor wiring exists; primarily they lock the post-cursor invariant — keep them GREEN against the
+    current (searchsorted) window() too, since the cursor is byte-identical (they encode the invariant,
+    not the implementation). 4-space indentation.
+  </action>
+  <verify>
+    <automated>cd /Users/tizianoiacovelli/Desktop/projects/intelli-trader && poetry run pytest tests/unit/price/test_bar_feed.py -k "cursor or view_content or read_only" -q && poetry run pytest tests/unit/price/test_bar_feed.py -q</automated>
+  </verify>
+  <acceptance_criteria>
+    - `poetry run pytest tests/unit/price/test_bar_feed.py -k cursor -q` selects >= 4 tests and they pass
+    - the kept D-08 tests still pass: `-k "view_content or read_only"` selects the 2 existing tests and they pass
+    - the full `tests/unit/price/test_bar_feed.py` file passes (7-rule contract suite green — D-08 assertion c)
+    - each new test asserts BOTH cursor==searchsorted equivalence (via `searchsorted(cutoff, side="right")`) AND the no-future-bar invariant `(window.index <= cutoff).all()`
+    - the backwards-asof test exercises the rebuild guard (a query at an earlier asof after a later one) and asserts no future-bar leak
+    - no always-on runtime `assert` is added to `bar_feed.py::window()` (the equivalence is proven in the test only — grep `bar_feed.py` for `assert.*searchsorted` returns nothing)
+  </acceptance_criteria>
+  <done>The D-08 suite is extended with passing D-16 cursor-equivalence + no-future-bar + reset/cold/gap/re-entry tests; the kept 06-01 D-08 tests and the 7-rule contract suite stay green; no hot-loop runtime guard added.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Add the monotonic int64 forward cursor to window() with a searchsorted rebuild guard</name>
+  <files>itrader/price_handler/feed/bar_feed.py</files>
+  <behavior>
+    - the cursor's resolved `pos` equals `int(frame.index.searchsorted(cutoff, side="right"))` on every
+      reachable cutoff (cold, monotonic-forward, backwards-rebuild, gap) — proven by Task 1's D-16 tests
+    - window() returns the SAME read-only `frame.iloc[start:pos]` view as today (06-01 D-08 read-only +
+      content tests stay green); empty windows still short-circuit `frame.iloc[pos:pos]` (D-06)
+    - no future bar ever appears in a returned window (the `cutoff_i8 < last_cut` rebuild guard)
+    - SMA_MACD byte-exact oracle unchanged (134 / 46189.87730727451); determinism double-run identical
+  </behavior>
+  <read_first>
+    - itrader/price_handler/feed/bar_feed.py (:427-486 window(); :199-258 __init__ state; :319-341 _resampled_frame keying; :132 _readonly_master + the 7-rule contract docstring :9-55; :462-486 the existing D-01/D-06/D-07/D-09 comments to preserve/extend)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-RESEARCH.md (Pattern 1 the cursor + the byte-identity proof obligation + the asi8/`.value` caveats; Pattern 2 reset/seek-safety table + the never-leak invariant; Pitfall 1 int64-vs-Timestamp; Pitfall 2 backwards-cutoff leak; Pitfall 5 (ticker,alias) keying; Don't Hand-Roll table; Code Examples — cursor wiring in __init__)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-CONTEXT.md (D-10 cursor + reset-safety; D-11 cursor-only / iloc kept; D-12 keep 06-01)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-01-SUMMARY.md (the read-only single-block master + view-return invariant the cursor must preserve)
+  </read_first>
+  <action>
+    In `__init__` (after the `self._prebuilt` build loop, before the run-path bindings at :253), add the
+    two cursor state dicts: `self._cursor: dict[tuple[str, str], int] = {}` (last forward position per
+    `(ticker, alias)`) and `self._cursor_cut: dict[tuple[str, str], int] = {}` (last cutoff int64 ns per
+    key), with a D-10 decision comment mirroring the file's decision-tag-anchored style. In `window()`,
+    REPLACE the single line `pos = int(frame.index.searchsorted(cutoff, side="right"))` (:473) with the
+    forward cursor: compute `key = (ticker, alias)`, `n = len(frame.index)`, `iv_i8 = frame.index.asi8`
+    (zero-copy int64 ns view), `cutoff_i8 = cutoff.value` (O(1) int64 ns — NOT a per-tick
+    `np.datetime64` conversion, NOT a Timestamp compare; Pitfall 1/Don't-Hand-Roll). If `last_pos is
+    None or last_cut is None or cutoff_i8 < last_cut` → SAFE REBUILD
+    `pos = int(frame.index.searchsorted(cutoff, side="right"))` (cold or non-monotonic — never trust
+    stale state, never leak; silent rebuild, NOT fail-loud per RESEARCH A3); else forward-step
+    `pos = last_pos; while pos < n and iv_i8[pos] <= cutoff_i8: pos += 1` (the `<=` preserves
+    exclusive-right / searchsorted side="right" byte-for-byte). Store
+    `self._cursor[key] = pos; self._cursor_cut[key] = cutoff_i8`. KEEP everything else: `start = max(0,
+    pos - max_window)`, the D-06 `if start >= pos: return frame.iloc[pos:pos]` short-circuit, and the
+    final `return frame.iloc[start:pos]` read-only view (D-11 cursor-only — KEEP `iloc`; do NOT add a
+    cheaper-slice path; do NOT reconstruct via `pd.DataFrame(...)`). Update the window() docstring +
+    the :462-469 comment block to describe the cursor (cite D-10/D-11/D-12) and record D-11 as
+    "investigated, empirically infeasible — every cheaper-slice candidate measured slower than iloc on
+    this single-block frame; superseded by research; cursor-only shipped, the 7.9% accepted via D-15".
+    Do NOT add a runtime `assert cursor == searchsorted` (D-16 rejects it — re-pays the cost). Match the
+    file's 4-space indentation. Preserve the 7-rule contract docstring (:9-55) byte-for-byte.
+  </action>
+  <verify>
+    <automated>cd /Users/tizianoiacovelli/Desktop/projects/intelli-trader && grep -q 'asi8' itrader/price_handler/feed/bar_feed.py && grep -q '_cursor' itrader/price_handler/feed/bar_feed.py && ! grep -qE 'assert.*searchsorted' itrader/price_handler/feed/bar_feed.py && poetry run pytest tests/unit/price/test_bar_feed.py -q && poetry run pytest tests/integration/test_backtest_oracle.py -q && poetry run mypy itrader</automated>
+  </verify>
+  <acceptance_criteria>
+    - `bar_feed.py::window()` no longer calls `searchsorted` unconditionally per tick — it is reached ONLY on the cold/non-monotonic rebuild branch; the forward path uses `frame.index.asi8` int64 comparison `iv_i8[pos] <= cutoff_i8` (grep finds `asi8` and `cutoff.value`/`.value`)
+    - the cursor is keyed `(ticker, alias)` (mirrors `_resampled_frame`), and `__init__` declares `self._cursor`/`self._cursor_cut` as typed `dict[tuple[str, str], int]` (mypy --strict clean)
+    - the rebuild guard `cutoff_i8 < last_cut` (or cold `last_pos is None`) is present (Pitfall 2 — backwards-cutoff leak prevention)
+    - window() still returns `frame.iloc[start:pos]` and short-circuits empty with `frame.iloc[pos:pos]` (D-06); the slice is unchanged (D-11 cursor-only — no `pd.DataFrame(...)` reconstruction)
+    - NO `assert ... searchsorted` runtime guard in `window()` (D-16)
+    - `poetry run pytest tests/unit/price/test_bar_feed.py -q` passes (D-16 cursor tests + kept D-08 + 7-rule contract all green)
+    - `poetry run pytest tests/integration/test_backtest_oracle.py -q` exits 0 — byte-exact 134 / 46189.87730727451; `poetry run mypy itrader` exits 0
+    - the 7-rule bar-timing contract docstring (bar_feed.py :9-55) is unchanged
+  </acceptance_criteria>
+  <done>window() resolves its cutoff via a per-(ticker,alias) monotonic int64 forward cursor with a safe searchsorted rebuild guard, returns the same read-only iloc view (cursor-only, iloc kept), the D-16 + kept D-08 tests pass, and gate (a) holds byte-for-byte with mypy --strict clean.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| (none new) | Internal hot-path data-engine refactor — no external input, no auth, no network, no untrusted data, no secrets. The single safety-relevant invariant is the look-ahead bar-timing contract: a stale cursor must never leak a future bar into a decision window. No new attack surface. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-06-04-01 | Tampering | a stale forward cursor under-counts on a backwards cutoff → leaks a bar stamped > cutoff (silent look-ahead breach) | mitigate | The `cutoff_i8 < last_cut` (and cold `last_pos is None`) guard forces a safe `searchsorted` rebuild (RESEARCH Pattern 2 — byte-identical to today). Proven by the D-16 backwards-asof + no-future-bar tests (Task 1); the byte-exact SMA_MACD oracle (gate a) is the run-path backstop (Task 2 verify). |
+| T-06-04-02 | Tampering | a consumer mutates the returned view → poisons a future tick | mitigate | Carried from 06-01 (D-09): the master values block is `writeable=False`; the cursor returns the SAME read-only `iloc` view; the kept 06-01 D-08(b) read-only test stays green (Task 1/Task 2 verify). |
+| T-06-04-SC | Tampering | npm/pip/cargo installs | N/A | No packages installed or changed this plan (RESEARCH Package Legitimacy Audit: not applicable — no external packages; only already-pinned pandas/numpy used). |
+| — | Spoofing / Repudiation / Info Disclosure / DoS / Elevation | — | N/A | No external attack surface — internal window-slice cutoff optimization only. |
+</threat_model>
+
+<verification>
+- `window()` resolves the cutoff via the int64 forward cursor (`asi8` + `cutoff.value`) with a `cutoff_i8 < last_cut`/cold searchsorted rebuild guard; keyed `(ticker, alias)`.
+- The returned slice is the unchanged read-only `frame.iloc[start:pos]` view (D-11 cursor-only); empty short-circuit `frame.iloc[pos:pos]` kept (D-06); 06-01 D-08 read-only/content tests green.
+- D-16: cursor==searchsorted + no-future-bar + reset/cold/gap/re-entry tests pass; no hot-loop runtime assert.
+- Gate (a): byte-exact oracle 134 / 46189.87730727451; determinism double-run identical; `mypy --strict` clean; 7-rule contract docstring unchanged.
+</verification>
+
+<success_criteria>
+- The per-tick `searchsorted` (13.2% W2) is removed on the forward path and replaced by a 0.14 µs int64 cursor step, byte-identical to `searchsorted(side="right")`, with a safe rebuild that never leaks a future bar.
+- 06-01 is kept and built upon (D-12); the cheaper slice is recorded as investigated + infeasible (D-11), iloc kept (cursor-only).
+- Gate (a) held byte-for-byte; the look-ahead contract preserved.
+</success_criteria>
+
+<output>
+Create `.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-04-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-04-SUMMARY.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-04-SUMMARY.md
@@ -1,0 +1,132 @@
+---
+phase: 06-bar-feed-window-copies-optional-slip-able
+plan: 04
+subsystem: infra
+tags: [pandas, numpy, bar-feed, cursor, searchsorted, asi8, look-ahead, perf, backtest]
+
+# Dependency graph
+requires:
+  - phase: 06-01
+    provides: read-only single-block non-writeable master frames + window() iloc view (D-09/D-12) the cursor returns on top of
+  - phase: 06-03
+    provides: cleaned engine denominator (TIME EVENT log removed, run_w2_sweep de-timed) so the cursor's W2 win is measurable
+provides:
+  - "Per-(ticker, alias) monotonic int64 forward cursor in BacktestBarFeed.window() replacing the per-tick searchsorted (13.2% W2 hotspot), byte-identical to searchsorted(side=right)"
+  - "Safe searchsorted rebuild guard (cold key OR cutoff_i8 < last_cut) that never leaks a future bar"
+  - "Extended D-08 drift suite (D-16): cursor==searchsorted equivalence + no-future-bar + backwards-asof/cold/gap/re-entry reset-safety tests"
+affects: [06-05, "gate-b W2 re-freeze", "Phase 5 incremental indicators"]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Monotonic forward cursor over frame.index.asi8 (int64 ns) compared against pd.Timestamp(cutoff).value — int64 path is load-bearing (0.14 µs/step vs 4.3 µs searchsorted)"
+    - "Fast-path-with-correct-fallback: trust the cached cursor only on a monotonic-forward step; silently rebuild via searchsorted on any cold/non-monotonic step (never trust stale state, never leak)"
+    - "Audit-the-invariant + dedicated drift test, zero hot-loop runtime guard (Phase 3 D-03 / Phase 4 D-06/07 / this phase D-08/D-09/D-16)"
+
+key-files:
+  created: []
+  modified:
+    - "itrader/price_handler/feed/bar_feed.py — cursor state dicts in __init__; monotonic int64 forward cursor + searchsorted rebuild guard in window()"
+    - "tests/unit/price/test_bar_feed.py — 4 D-16 cursor-equivalence + reset-safety tests extending the D-08 suite"
+
+key-decisions:
+  - "D-10: replace per-tick searchsorted with a per-(ticker,alias) forward int64 cursor; cutoff stays exclusive-right (<= reproduces side=right byte-for-byte)"
+  - "D-10 reset-safety: cold key OR cutoff_i8 < last_cut -> silent safe searchsorted rebuild (a non-monotonic cutoff is legitimate — screener re-entry/resampled cutoffs — not a crash)"
+  - "D-11: iloc[start:pos] KEPT cursor-only — every cheaper-slice candidate measured slower than iloc on this single-block frame; recorded as investigated + empirically infeasible (D-15 absorbs the 7.9%)"
+  - "D-12: built on top of 06-01's read-only view — 9168cae not reverted or modified"
+  - "D-16: cursor==searchsorted proven in the test only; NO hot-loop runtime assert (would re-pay the searchsorted the cursor removes)"
+  - "cutoff_i8 = pd.Timestamp(cutoff).value (not cutoff.value) — no-op box keeps mypy --strict happy since asof is typed datetime, no per-tick datetime64 convert"
+
+patterns-established:
+  - "Monotonic int64 forward cursor with a searchsorted rebuild guard for a look-ahead-safe window slice"
+  - "Cursor keyed (ticker, alias) mirroring self._frames exactly (Pitfall 5 — never key on ticker alone)"
+
+requirements-completed: [PERF-06]
+
+# Metrics
+duration: 5min
+completed: 2026-06-24
+---
+
+# Phase 6 Plan 04: D-10 Monotonic Incremental Cursor Summary
+
+**BacktestBarFeed.window() now resolves its cutoff via a per-(ticker,alias) monotonic int64 forward cursor over `frame.index.asi8` — byte-identical to `searchsorted(side="right")`, removing the 13.2%-of-W2 per-tick searchsorted hotspot — with a cold/non-monotonic searchsorted rebuild guard that can never leak a future bar.**
+
+## Performance
+
+- **Duration:** 5 min
+- **Started:** 2026-06-24T15:00:58Z
+- **Completed:** 2026-06-24T15:05:28Z
+- **Tasks:** 2 (both TDD/auto)
+- **Files modified:** 2
+
+## Accomplishments
+- Replaced the per-tick `frame.index.searchsorted(cutoff, side="right")` in `window()` with a per-(ticker, alias) monotonic forward cursor over `frame.index.asi8` (int64 ns), comparing `iv_i8[pos] <= cutoff_i8` (0.14 µs/step vs searchsorted's 4.3 µs). The `<=` reproduces `searchsorted(side="right")` byte-for-byte (exclusive-right, contract rule 4).
+- Added the reset-safety guard: on a COLD key (`last_pos is None`) OR a NON-MONOTONIC step (`cutoff_i8 < last_cut`), `window()` falls back to a silent safe `searchsorted` rebuild — never trusting stale state, never leaking a bar stamped `> cutoff`. Threat T-06-04-01 mitigated.
+- Kept the 06-01 read-only `iloc[start:pos]` view and the D-06 empty short-circuit (`iloc[pos:pos]`) unchanged (D-11 cursor-only, D-12 built-on-top). The cheaper-slice idea (D-11) is recorded in-code as investigated + empirically infeasible (every candidate slower than iloc; D-07 forbids reconstruction), the 7.9% accepted via D-15.
+- Extended the D-08 drift suite with 4 D-16 tests: cursor==searchsorted across monotonic ticks + no-future-bar, backwards-asof rebuild, cold cursor + gap frame, universe re-entry. Co-located with the kept 06-01 D-08 tests, opened with decision-tag docstrings stating no hot-path runtime guard is added.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Extend the D-08 drift suite with D-16 cursor-equivalence + reset-safety tests** - `d034ea3` (test)
+2. **Task 2: Add the monotonic int64 forward cursor to window() with a searchsorted rebuild guard** - `00c5480` (feat)
+
+_TDD note: the Task-1 tests encode the look-ahead INVARIANT (byte-identical to searchsorted), so they pass against both the pre-cursor (searchsorted) and post-cursor `window()` — a deliberate invariant-lock rather than an implementation-coupled RED. They were committed before the implementation per the plan's TDD framing._
+
+## Files Created/Modified
+- `itrader/price_handler/feed/bar_feed.py` — added `self._cursor` / `self._cursor_cut` typed `dict[tuple[str, str], int]` state in `__init__` (after the `_prebuilt` loop); replaced the single `searchsorted` line in `window()` with the forward int64 cursor + rebuild guard; updated the window() docstring (rule-4 cursor note) and the D-01/D-06/D-07/D-09 comment block to cite D-10/D-11/D-12. The 7-rule contract docstring (:9-55) is byte-unchanged.
+- `tests/unit/price/test_bar_feed.py` — 4 new tests (`test_cursor_equals_fresh_searchsorted_across_ticks`, `test_cursor_safe_rebuild_on_backwards_asof`, `test_cursor_cold_and_gap`, `test_cursor_universe_reentry`) extending the D-08 section; the kept 06-01 D-08 tests (`test_window_view_content_equals_old_copy`, `test_window_view_is_read_only_and_cannot_leak`) and the 7-rule contract suite stay green verbatim.
+
+## Decisions Made
+- **`cutoff_i8 = pd.Timestamp(cutoff).value`** (not `cutoff.value`): `asof` is typed `datetime` in the `window()` signature, so the derived `cutoff` is statically `datetime`, which has no `.value` (mypy --strict error). Wrapping in `pd.Timestamp(...)` is a no-op box at run time (the value already arrives as a tz-aware `pd.Timestamp`), keeps the O(1) int64 attribute access (no per-tick `np.datetime64` conversion), and is mypy-clean. Documented in-code.
+- Silent safe-rebuild (not fail-loud) on a non-monotonic cutoff, per RESEARCH A3 — a backwards cutoff is legitimate (screener re-entry, resampled cutoffs); the rebuild is exactly today's behavior and never leaks.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] mypy --strict rejected `cutoff.value`**
+- **Found during:** Task 2 (cursor implementation)
+- **Issue:** `cutoff = asof - timeframe + self._base_timeframe` is statically typed `datetime` (the `window()` signature types `asof: datetime`), and `datetime` has no `.value` attribute → `mypy itrader` reported `"datetime" has no attribute "value"`. The plan's interface snippet used `cutoff.value` directly. Gate (a) requires `mypy --strict` clean.
+- **Fix:** Used `pd.Timestamp(cutoff).value` — a no-op box (the run-time value is already a tz-aware `pd.Timestamp`) that is statically `pd.Timestamp` (which has `.value -> int`). Preserves the O(1) int64-ns semantics the plan/research mandate (NOT a per-tick `np.datetime64` conversion — Pitfall anti-pattern avoided) and added a comment explaining the box.
+- **Files modified:** itrader/price_handler/feed/bar_feed.py (part of the Task 2 commit)
+- **Verification:** `poetry run mypy itrader` → "Success: no issues found in 187 source files"; bar_feed cursor tests + oracle still green; the int64 fast path is unchanged.
+- **Committed in:** `00c5480` (Task 2 commit)
+
+---
+
+**Total deviations:** 1 auto-fixed (1 blocking)
+**Impact on plan:** The fix is a mypy-driven type adjustment required by gate (a); it preserves the exact int64-ns mechanism the research verified (no perf regression — `.value` is O(1) on an already-boxed Timestamp). No scope creep.
+
+## Issues Encountered
+None beyond the mypy type fix documented above.
+
+## Verification Evidence
+
+- **Gate (a) — byte-exact oracle:** `tests/integration/test_backtest_oracle.py` → 3 passed (134 trades / final_equity 46189.87730727451, frozen golden CSVs byte-equal).
+- **Determinism double-run byte-identical:** two consecutive full SMA_MACD backtest runs hashed identical (`dc937b59…039e91` == `dc937b59…039e91`, SHA-256 over trade+equity frames).
+- **mypy --strict:** Success, no issues in 187 source files.
+- **D-16 / D-08 drift suite:** `-k cursor` selects 4, all pass; `-k "view_content or read_only"` selects the 2 kept D-08 tests, both pass; full `test_bar_feed.py` 26 tests green (7-rule contract = D-08 assertion c).
+- **No hot-loop runtime assert:** `grep -E 'assert.*searchsorted' bar_feed.py` returns nothing (D-16).
+- **Cursor wiring present:** `asi8`, `_cursor`, `cutoff.value` all grep-confirmed in `bar_feed.py`; `iloc[start:pos]` + `iloc[pos:pos]` unchanged.
+- **Full suite:** `poetry run pytest tests` → 1262 passed.
+
+## Known Stubs
+None.
+
+## Next Phase Readiness
+- The cursor is shipped on top of the cleaned engine (06-03) and the kept 06-01 view. 06-05 (gate b) can now re-freeze BOTH `W1-BASELINE.json` and `W2-BASELINE.json` on the cleaned + cursored engine on a cool machine, then gate the cursor alone at ≥10% W2 / W1 non-regress (D-14), with the D-15 ship-and-reframe fallback if <10% honestly.
+- **Gate (b) is human-gated (cool machine):** the W2 re-freeze + verdict measurement is deferred to 06-05 per the thermal-drift lesson and the pending-todo W1 re-freeze. This plan does not run the perf gate; it lands the correctness-locked cursor.
+
+## Self-Check: PASSED
+
+- FOUND: `.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-04-SUMMARY.md`
+- FOUND commit: `d034ea3` (Task 1, test)
+- FOUND commit: `00c5480` (Task 2, feat)
+
+---
+*Phase: 06-bar-feed-window-copies-optional-slip-able*
+*Completed: 2026-06-24*

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-05-PLAN.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-05-PLAN.md
@@ -1,0 +1,215 @@
+---
+phase: 06-bar-feed-window-copies-optional-slip-able
+plan: 05
+type: execute
+wave: 3
+depends_on: [06-03, 06-04]
+files_modified:
+  - perf/results/W2-BASELINE.json
+  - perf/results/W1-BASELINE.json
+autonomous: false
+requirements: [PERF-06]
+
+must_haves:
+  truths:
+    - "D-14: BOTH perf/results/W1-BASELINE.json AND perf/results/W2-BASELINE.json are re-frozen on the CLEANED engine (after 06-03 log-removal + harness de-time), on a COOL machine (the v1.5 thermal-drift lesson) — re-freezing on the diluted pre-06-03 engine would mis-credit the delta (RESEARCH Pitfall 3). This plan SUPERSEDES and ABSORBS 06-02's deferred Tasks 2/3 (cool-machine freeze + verify) — 06-02 Task 1's run_w2_sweep --check/--baseline-out harness (commit f51d7c6) is reused AS-IS, not rebuilt"
+    - "D-14: the cursor ALONE must clear ≥10% W2 at 50 symbols vs the CLEANED W2 baseline — the cleanup's win is isolated into the baseline (BEFORE baseline captured on the cleaned engine WITHOUT the cursor, AFTER check with the cursor on), so the ≥10% is attributable to the cursor, not the D-13 cleanup. The 06-02 `_check_w2` keys on `wall_clock_s_at_50` and requires `impr >= 10.0%` (inverted guard); thermal-drift discipline: same-session/same-machine before/after on a cool box"
+    - "D-14: W1 stays the GUARD, not a win — `make perf-w1 --check` must stay within the ±5% soft non-regress band (the cursor adds per-(ticker,alias) state with ~no benefit at 1 symbol, so a W1 win is NOT required and not expected). W1-BASELINE.json is re-frozen after confirming non-regression"
+    - "D-15 ship-and-reframe fallback: if the cursor on the cleaned baseline cannot HONESTLY clear ≥10% W2, SHIP the cursor + cleanup anyway (real look-ahead-safety + the removed per-tick searchsorted + a measurable win), RECORD the actual W2 % achieved as the locked result, and re-frame gate (b) → 'measurable W2 win + W1 non-regress' (no hard ≥10% kill — this phase is OPTIONAL/slip-able). No revert, no keep-iterating"
+    - "Gate (a) re-confirmed on the same machine at the freeze: byte-exact SMA_MACD oracle (134 trades / final_equity 46189.87730727451) green; mypy --strict clean (this plan touches NO itrader/ engine code — only data artifacts). The committed baselines are trackable (NOT gitignored; the narrow .gitignore only excludes scalene artifacts) and seed Phase 5 (Incremental Indicators, W2-relevant)"
+  artifacts:
+    - path: "perf/results/W2-BASELINE.json"
+      provides: "committed cursor-on 50-symbol W2 reference on the cleaned engine (seeds Phase 5); records the ≥10% pass or the D-15 actual-% result"
+      contains: "wall_clock_s_at_50"
+    - path: "perf/results/W1-BASELINE.json"
+      provides: "re-frozen W1 reference on the cleaned engine after confirming non-regression"
+      contains: "wall_clock_s"
+  key_links:
+    - from: "run_w2_sweep.py --check (06-02 harness, f51d7c6)"
+      to: "perf/results/W2-BASELINE.json"
+      via: "50-symbol wall_clock_s improvement ≥10% gate on the cleaned engine, cursor alone"
+      pattern: "wall_clock_s_at_50"
+    - from: "make perf-w1 --check"
+      to: "perf/results/W1-BASELINE.json"
+      via: "±5% soft non-regression guard (W1 is the guard, not a win)"
+      pattern: "wall_clock_s"
+---
+
+<objective>
+D-14/D-15 gate (b) re-freeze + verdict: on a cool machine, re-freeze BOTH W1-BASELINE.json and
+W2-BASELINE.json on the CLEANED engine (06-03 landed), capture the cursor's BEFORE baseline on the
+cleaned-but-cursorless engine, then prove the cursor ALONE clears ≥10% W2 at 50 symbols vs that
+cleaned baseline (`run_w2_sweep --check`, the reused 06-02 harness), with W1 within the ±5% soft
+non-regress band. If <10% honestly, ship-and-reframe per D-15 (record the actual W2 %, no kill). This
+plan absorbs 06-02's deferred freeze/verify.
+
+Purpose: turn the W2-dominant win into a concrete, reproducible, attributable pass record on the
+cleaned denominator, isolating the cursor's win from the D-13 cleanup, and seed the standing W2
+reference Phase 5 is also judged against. The measurement is thermal-drift sensitive and human-gated
+(Claude cannot guarantee the box is cool — the v1.5 thermal-drift lesson and the pending-todo
+re-freeze discipline).
+Output: committed cleaned-engine W2-BASELINE.json + re-frozen W1-BASELINE.json; gate (b) verdict recorded.
+
+This plan depends on 06-03 (cleaned denominator) AND 06-04 (the cursor). It supersedes 06-02 Tasks 2/3
+(the paused cool-machine freeze + verify) and reuses 06-02 Task 1's harness as-is.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-CONTEXT.md
+@.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-RESEARCH.md
+@.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-02-PLAN.md
+
+<interfaces>
+<!-- The 06-02 harness (committed f51d7c6) is reused AS-IS — do NOT re-add or rebuild flags. -->
+
+perf/runners/run_w2_sweep.py (06-02 Task 1, committed f51d7c6 — reusable as-is):
+- `--baseline-out PATH` writes the W2 schema; `--check` exits `_check_w2(...)`.
+- `_check_w2(points, baseline_path, min_improvement_pct=10.0)` keys on `wall_clock_s_at_50`,
+  returns 0 iff `impr = (base50 - now50) / base50 * 100.0 >= 10.0`; carries the WR-02 zero/malformed
+  baseline soft guard (non-positive base50 → return 1, no ZeroDivisionError).
+- After 06-03, `_run_point` is two-pass (clean timed wall-clock + separate tracemalloc peak-mem) — the
+  baseline AND the check-run both use this SAME de-timed harness (the only requirement for a fair delta).
+
+Makefile (06-02 Task 1): `perf-w2` (now with `--check`), `perf-w2-baseline`
+(`run_w2_sweep --baseline-out perf/results/W2-BASELINE.json`), `perf-w1` (`--check`), `perf-baseline`
+(re-freeze W1). Worktree `.env`-abort caveat (memory worktree-make-test-env-abort): run perf in the
+MAIN checkout, or invoke `poetry run python -m perf.runners.run_w2_sweep ...` directly.
+
+perf/results/W1-BASELINE.json — the W1 schema to re-freeze (schema_version/frozen_at/metric/...).
+perf/results/W2-BASELINE.json — NOT YET FROZEN (correct — nothing to freeze until the cursor lands).
+
+tests/integration/test_backtest_oracle.py — gate (a) byte-exact oracle (134 / 46189.87730727451).
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 1: Cool-machine re-freeze + cursor-alone ≥10% W2 verdict (thermal-sensitive, human-run)</name>
+  <what-built>
+    06-03 cleaned the denominator (removed the per-bar TIME EVENT log + de-timed the W2 harness) and
+    06-04 landed the monotonic int64 cursor in window() (gate (a) byte-exact, mypy --strict clean). The
+    06-02 `run_w2_sweep --check/--baseline-out` harness + Makefile `perf-w2`/`perf-w2-baseline`
+    (committed f51d7c6) are reused as-is. What remains is the thermal-drift-sensitive wall-clock
+    capture, which Claude cannot run reliably (it cannot guarantee the machine is cool) — so the
+    measurement + verdict are human-gated.
+  </what-built>
+  <how-to-verify>
+    On a COOL/quiet machine, in the MAIN checkout (perf needs .env; memory worktree-make-test-env-abort):
+    1. Confirm both 06-03 and 06-04 are merged (cleaned engine + cursor present): `grep -L 'TIME EVENT'
+       itrader/events_handler/full_event_handler.py` (no match = removed) and `grep -q asi8
+       itrader/price_handler/feed/bar_feed.py`.
+    2. Capture the cursor's BEFORE baseline on the cleaned engine WITHOUT the cursor — in the SAME
+       session, temporarily revert ONLY the 06-04 window()/__init__ cursor change (e.g. `git stash`
+       the bar_feed.py cursor edit, or check out the parent of the 06-04 commit) so 06-03's cleanup
+       stays in: `poetry run python -m perf.runners.run_w2_sweep --baseline-out perf/results/W2-BASELINE-pre.json`.
+       This is the cleaned denominator the cursor is judged against (isolates the cursor from the cleanup).
+    3. Restore the cursor (`git stash pop` / check back out), then run the AFTER check against the pre
+       file: `poetry run python -m perf.runners.run_w2_sweep --check` pointed at `W2-BASELINE-pre.json`.
+       Confirm it prints `W2@50 ... improvement +X.X%` at 50 symbols.
+    4. Verdict:
+       - If improvement ≥ +10.0% AND exits 0 → the cursor ALONE cleared the bar (D-14). Freeze the
+         AFTER run as the standing reference: `make perf-w2-baseline` → `perf/results/W2-BASELINE.json`.
+       - If improvement < +10.0% honestly → D-15 ship-and-reframe: do NOT revert. RECORD the actual
+         W2 % achieved, freeze the AFTER run anyway as `W2-BASELINE.json`, and note in the report that
+         gate (b) is re-framed to "measurable W2 win + W1 non-regress".
+    5. Confirm W1 does NOT regress: `make perf-w1` (the --check ±5% soft guard) stays within band / does
+       not print a regression failure (W1 is the guard, not a win — a W1 win is not expected at 1 symbol).
+    6. Re-freeze W1 on the cleaned engine: `make perf-baseline` → updates `perf/results/W1-BASELINE.json`.
+    7. Re-confirm gate (a) on the same machine: `poetry run pytest
+       tests/integration/test_backtest_oracle.py -q` green (134 / 46189.87730727451).
+    Report: the 50-symbol BEFORE/AFTER wall-clock numbers, the % improvement (and whether ≥10% or the
+    D-15 actual-%), the W1 non-regression delta, and the gate (a) confirmation. If the box was thermally
+    throttled (the before-run reads anomalously slow vs the frozen reference), do NOT commit — defer and
+    re-run on a cool machine (per the pending-todo + thermal-drift memory), exactly as Phase 3's
+    re-freeze was deferred.
+  </how-to-verify>
+  <read_first>
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-RESEARCH.md (Pattern 4 — the re-freeze sequencing; Pitfall 3 — re-freeze on the cleaned engine; Environment Availability — cool-machine human-gate)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-CONTEXT.md (D-14 re-freeze both + gate cursor alone; D-15 ship-and-reframe fallback)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-02-PLAN.md (the absorbed Task 2/3 procedure + the reused --check/--baseline-out harness)
+    - .planning/STATE.md (Pending Todos — the cool-machine re-freeze discipline; v15-perf-gateb-thermal-drift)
+  </read_first>
+  <resume-signal>Type "approved" with the BEFORE/AFTER 50-symbol numbers + % improvement (≥10% or the D-15 actual-%), the W1 non-regression delta, and gate (a) green — or describe the thermal/measurement issue to defer.</resume-signal>
+  <action>Human-gated measurement: on a cool same-session machine, capture the cursor's BEFORE baseline on the cleaned-but-cursorless engine, run the AFTER `--check`, apply the D-14 ≥10% verdict or the D-15 ship-and-reframe fallback, confirm W1 non-regression, re-freeze BOTH baselines, and re-confirm gate (a). Claude cannot guarantee thermal state, so this is a blocking human-verify checkpoint (the steps are the manual procedure, not autonomous Claude work).</action>
+  <verify><human-check>The human reports the BEFORE/AFTER 50-symbol wall-clock numbers and the % improvement (≥10% per D-14, or the actual-% recorded per D-15), with W1 non-regressed and gate (a) green (134 / 46189.87730727451).</human-check></verify>
+  <done>The BEFORE/AFTER W2 numbers are captured on a cool machine on the cleaned engine, the cursor-alone verdict (≥10% D-14 or D-15 actual-%) + W1 non-regression are confirmed, gate (a) is green, and the human has approved (or deferred with a thermal reason).</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Commit cleaned-engine W2-BASELINE.json + re-frozen W1-BASELINE.json; confirm Gate (a)</name>
+  <files>perf/results/W2-BASELINE.json, perf/results/W1-BASELINE.json</files>
+  <read_first>
+    - perf/results/W1-BASELINE.json (the re-frozen reference shape to confirm; trackability — NOT gitignored)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-CONTEXT.md (D-14 committed cleaned-engine W2 baseline + re-freeze W1; D-15 record the actual W2 %)
+    - .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-02-PLAN.md (Task 3 — the absorbed commit/cleanup procedure, the W2-BASELINE-pre.json removal)
+    - tests/integration/test_backtest_oracle.py (gate (a) oracle)
+  </read_first>
+  <action>
+    After the human-verify checkpoint reports the verdict, ensure the standing
+    `perf/results/W2-BASELINE.json` (the cleaned-engine AFTER 50-symbol `wall_clock_s_at_50` +
+    `peak_mem_mb_at_50`, the reference that also seeds Phase 5) and the re-frozen
+    `perf/results/W1-BASELINE.json` are present and TRACKABLE (NOT gitignored — mirror the Phase-1 W1
+    trackability note; the narrow .gitignore only excludes scalene artifacts). Remove the transient
+    `perf/results/W2-BASELINE-pre.json` if it was written. Record in the plan SUMMARY: the BEFORE/AFTER
+    50-symbol numbers, the % improvement and which verdict applied (≥10% D-14 pass, or the D-15
+    ship-and-reframe with the actual W2 % as the locked result + the re-framed gate (b) statement), the
+    W1 non-regression delta, and the gate (a) confirmation (oracle 134 / 46189.87730727451). Confirm
+    `mypy --strict` clean (this plan touched no itrader/ engine code, so it must remain clean — the
+    engine work is 06-03/06-04). Do NOT modify any itrader/ source here.
+  </action>
+  <verify>
+    <automated>cd /Users/tizianoiacovelli/Desktop/projects/intelli-trader && test -f perf/results/W2-BASELINE.json && test -f perf/results/W1-BASELINE.json && ! git check-ignore -q perf/results/W2-BASELINE.json && ! test -f perf/results/W2-BASELINE-pre.json && grep -q wall_clock_s_at_50 perf/results/W2-BASELINE.json && poetry run pytest tests/integration/test_backtest_oracle.py -q && poetry run mypy itrader</automated>
+  </verify>
+  <acceptance_criteria>
+    - `perf/results/W2-BASELINE.json` exists, is NOT git-ignored, and contains `wall_clock_s_at_50` (the cleaned-engine cursor-on 50-symbol reference)
+    - `perf/results/W1-BASELINE.json` exists and is re-frozen (frozen_at reflects this phase's cleaned-engine run)
+    - no `perf/results/W2-BASELINE-pre.json` left committed (transient before-baseline removed)
+    - the SUMMARY records the BEFORE/AFTER numbers + the % improvement + which verdict applied (D-14 ≥10% pass OR D-15 actual-% ship-and-reframe) + the W1 non-regression delta
+    - `poetry run pytest tests/integration/test_backtest_oracle.py -q` exits 0 (134 / 46189.87730727451)
+    - `poetry run mypy itrader` exits 0 (no itrader/ engine code touched in this plan)
+  </acceptance_criteria>
+  <done>The committed cleaned-engine W2-BASELINE.json records the cursor-alone verdict (≥10% per D-14 or the D-15 actual-%) and seeds Phase 5; W1-BASELINE.json is re-frozen with W1 non-regressed; gate (a) re-confirmed; the transient pre-baseline is removed.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| committed baseline JSON ← perf runner | A committed `W2-BASELINE.json` / re-frozen `W1-BASELINE.json` becomes the standing pass record the next phase (Phase 5) diffs against; a malformed or thermally-drifted baseline could mis-credit a future win. No external/network/auth/user-input surface — offline perf tooling + data artifacts only. This plan touches no engine code, so the look-ahead invariant (covered by 06-04's cursor + the byte-exact oracle) is not at risk here. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-06-05-01 | Tampering | `_check_w2` zero/malformed baseline path | mitigate | The reused 06-02 harness carries the WR-02 soft guard: non-positive/malformed `base50` returns 1 with a message, never a ZeroDivisionError — a tampered/empty baseline fails closed rather than silently passing. |
+| T-06-05-02 | Repudiation | committed baseline as pass record | mitigate | Thermal-drift discipline (D-14, memory v15-perf-gateb-thermal-drift): same-session/same-machine BEFORE/AFTER on a cool box, re-frozen on the CLEANED engine, recorded in the SUMMARY — the committed JSON is a reproducible, attributable record. The cursor's win is isolated from the D-13 cleanup (BEFORE baseline on the cleaned-but-cursorless engine). |
+| T-06-05-SC | Tampering | npm/pip/cargo installs | N/A | No packages installed or changed this plan (RESEARCH Package Legitimacy Audit: not applicable — no external packages). |
+| — | Spoofing / Info Disclosure / DoS / Elevation | — | N/A | No external attack surface — offline perf-harness measurement + data-artifact commits only. |
+</threat_model>
+
+<verification>
+- BOTH W1-BASELINE.json and W2-BASELINE.json re-frozen on the cleaned engine (cool machine); W2 baseline trackable + contains `wall_clock_s_at_50`; transient pre-baseline removed.
+- Cursor-alone verdict recorded: ≥10% W2 at 50 symbols (D-14) OR the D-15 actual-% ship-and-reframe; W1 within the ±5% soft band (guard, not a win).
+- Gate (a) re-confirmed: oracle 134 / 46189.87730727451; `mypy --strict` clean (no engine code touched here).
+</verification>
+
+<success_criteria>
+- ROADMAP Success Criterion 4 (gate b): the W2 symbol sweep shows a measurable improvement on the cleaned engine (≥10% at 50 symbols per D-14, or the D-15 actual-% with the re-framed gate) AND W1 does not regress; W1-BASELINE.json re-frozen, W2-BASELINE.json committed and seeding Phase 5.
+- 06-02's deferred freeze/verify is absorbed and closed.
+</success_criteria>
+
+<output>
+Create `.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-05-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-05-SUMMARY.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-05-SUMMARY.md
@@ -1,0 +1,133 @@
+---
+phase: 06-bar-feed-window-copies-optional-slip-able
+plan: 05
+subsystem: testing
+tags: [perf, benchmark, w2-sweep, gate-b, baseline, d-15, thermal-drift]
+
+# Dependency graph
+requires:
+  - phase: 06-03
+    provides: cleaned W2/W1 denominator (per-bar TIME EVENT log removed + harness de-timed)
+  - phase: 06-04
+    provides: monotonic int64 forward cursor in window() (the lever this plan certifies)
+provides:
+  - "Committed cleaned-engine cursor-on W2-BASELINE.json (13.61s @ 50 symbols) — the standing reference seeding Phase 5"
+  - "Gate (b) verdict for PERF-06: +1.9% W2 at 50 symbols → D-15 ship-and-reframe (measurable W2 win + W1 non-regress), NOT the ≥10% bar"
+affects: [phase-5-incremental-indicators]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: ["same-session cursorless→cursor A/B as the thermally-fair gate-(b) signal; absolute W1 wall-clock deferred when the box is warm"]
+
+key-files:
+  created:
+    - perf/results/W2-BASELINE.json
+  modified: []
+
+key-decisions:
+  - "D-15 invoked: cursor delivered +1.9% W2 at 50 symbols (< 10% honestly) → SHIP the cursor + cleanup anyway, record the actual %, reframe gate (b) → 'measurable W2 win + W1 non-regress'. No revert, no iterate."
+  - "W1 absolute re-freeze DEFERRED: the re-freeze run read 259.1s vs prior 238.5s (+8.6%), but the same-session 1-symbol A/B is flat (cursorless 0.423s → cursor-on 0.425/0.445s) — the +8.6% is thermal drift (W1 ran last on the warmest box), not a cursor regression. Prior 238.5 W1 baseline kept; do NOT freeze the inflated number."
+
+patterns-established:
+  - "Gate-(b) thermal discipline: trust the same-session before/after A/B (back-to-back, same warmed box); distrust an absolute wall-clock vs a baseline frozen at a different time"
+
+requirements-completed: [PERF-06]
+
+# Metrics
+duration: ~12min (cool-machine measurement: cursorless W2 baseline + cursor-on --check + W2 freeze + W1 run + oracle)
+completed: 2026-06-24
+---
+
+# Phase 06 Plan 05: Gate (b) Re-Freeze + Verdict Summary
+
+**PERF-06 cursor certified via D-15 ship-and-reframe: +1.9% W2 at 50 symbols on the cleaned engine (cursorless 14.31s → cursor-on 14.04s), gate (a) byte-exact green; W1 absolute re-freeze deferred (the +8.6% read is thermal drift, the 1-symbol A/B is flat).**
+
+## Performance
+- **Duration:** ~12 min (human-gated cool-machine measurement)
+- **Completed:** 2026-06-24
+- **Tasks:** 2 (Task 1 human-verify checkpoint; Task 2 commit + confirm)
+- **Files modified:** 1 (perf/results/W2-BASELINE.json created)
+
+## Gate (b) Verdict — D-15 ship-and-reframe
+
+Measured on the **cleaned engine** (06-03 log-removal + harness de-time), cursor's win **isolated** from
+the D-13 cleanup (BEFORE baseline captured on the cleaned-but-**cursorless** engine, AFTER `--check`
+with the cursor on), same-session/same-machine on a cool box:
+
+| n_symbols | cursorless (BEFORE) | cursor-on (AFTER, --check) | improvement |
+|-----------|---------------------|----------------------------|-------------|
+| 1         | 0.423 s             | 0.445 s                    | ~flat (sub-second noise) |
+| 10        | 2.951 s             | 2.930 s                    | ~flat |
+| **50**    | **14.310 s**        | **14.037 s**               | **+1.9%** |
+
+- **Verdict:** `+1.9% < required 10.0%` → the `_check_w2` ≥10% bar (06-02 harness, `f51d7c6`) did **not**
+  pass. Per **D-15** (locked fallback for the OPTIONAL/slip-able phase): **ship** the cursor + cleanup,
+  **record +1.9%** as the locked result, **reframe gate (b) → "measurable W2 win + W1 non-regress."**
+  No revert, no keep-iterating.
+- **Why under the 13.2% the Scalene profile predicted:** line-level profilers over-attribute to
+  `searchsorted`; in clean wall-clock the per-tick `searchsorted` over a ~3000-row index is nearly
+  free. The cursor still removes that per-tick call and rides 06-01's read-only views — the +1.9% is a
+  bonus on top of the look-ahead-safety value, exactly the D-15 framing.
+
+## W1 non-regression — confirmed (thermal caveat)
+
+- The W1 re-freeze run read **259.1 s vs the prior frozen 238.5 s (+8.6%)** — surfaced as a "regression"
+  only because W1 ran **last**, after a back-to-back battery of W2 sweeps warmed the box (the v1.5
+  thermal-drift lesson; memory `v15-perf-gateb-thermal-drift`).
+- The **same-session 1-symbol A/B is flat** (cursorless 0.423 s → cursor-on 0.425/0.445 s). The cursor
+  adds per-(ticker, alias) state with ~no benefit at 1 symbol and 06-03 *removes* a per-bar log — there
+  is no mechanism for a real +8.6% single-symbol regression. **Conclusion: cursor is W1-non-regressive;
+  the +8.6% is thermal.**
+- **Action:** prior **238.5 s** W1 baseline **kept** (the inflated 259.1 s was NOT frozen). The absolute
+  W1 re-freeze on the cleaned engine is **DEFERRED to a verified-cool isolated run** (see Pending Todo
+  below) — consistent with Phase 3's deferred re-freeze discipline.
+
+## Gate (a) — re-confirmed
+- Byte-exact SMA_MACD oracle: **3 passed** (134 trades / `final_equity 46189.87730727451`).
+- `mypy --strict`: **clean** (187 source files) — this plan touched no `itrader/` engine code.
+
+## Task Commits
+1. **Task 1: Cool-machine re-freeze + cursor-alone verdict** (human-verify checkpoint) — owner ran the
+   measurement; verdict +1.9% W2 → D-15. Measurement is procedural (no code commit).
+2. **Task 2: Commit cleaned-engine W2-BASELINE.json; confirm Gate (a)** — see the docs commit for this SUMMARY.
+
+## Files Created/Modified
+- `perf/results/W2-BASELINE.json` — cleaned-engine cursor-on 50-symbol reference (13.61 s, peak 214.58 MB);
+  trackable (not gitignored), seeds Phase 5. (The recorded gate verdict is the `--check` +1.9%; the frozen
+  reference is a fresh cursor-on freeze run.)
+- `perf/results/W1-BASELINE.json` — **unchanged** (kept at the prior 238.5 s; the thermally-inflated 259.1 s
+  was deliberately NOT frozen).
+
+## Decisions Made
+- Invoked D-15 (ship-and-reframe) on the honest +1.9% < 10% result — the planned path for this OPTIONAL phase.
+- Deferred the absolute W1 re-freeze rather than committing a thermally-drifted number (thermal discipline).
+
+## Deviations from Plan
+- The plan's W1 re-freeze step (Task 1 step 6: `make perf-baseline` → update W1-BASELINE.json) was
+  **deferred**, not executed, because the run was thermally contaminated. The plan's own how-to-verify
+  step 7 prescribes exactly this: "If the box was thermally throttled … do NOT commit — defer and re-run
+  on a cool machine." This is following the plan's contingency, not a scope deviation.
+- `--check` hardcodes the baseline path to `perf/results/W2-BASELINE.json` (06-02 harness `f51d7c6`),
+  so the cursorless BEFORE baseline was written to that canonical path (not a `-pre.json` sidecar); the
+  cursor-on AFTER freeze then overwrote it. No transient sidecar to remove.
+
+## Issues Encountered
+- W1 thermal drift (+8.6% absolute) — diagnosed via the same-session 1-symbol A/B and dispositioned as
+  measurement artifact, not a regression. Resolved by deferring the W1 re-freeze.
+
+## Pending Todo (carried)
+- **Re-freeze `W1-BASELINE.json` on a verified-cool isolated run.** Run `make perf-baseline` alone on a
+  cool/quiet box (no preceding W2 battery) so the W1 number isn't thermally inflated, then commit. The
+  current 238.5 s reference is the prior (pre-phase-6) freeze; the cleaned+cursor engine's honest W1
+  number should replace it before the next phase diffs W1 against it.
+
+## Next Phase Readiness
+- PERF-06 closed via D-15. The cursor + cleanup are shipped, gate (a) byte-exact, the W2 reference is
+  frozen and seeds Phase 5 (Incremental Indicators, W2-relevant). 06-02's deferred freeze/verify is
+  absorbed and closed.
+- One carried todo: the cool-machine W1 absolute re-freeze.
+
+---
+*Phase: 06-bar-feed-window-copies-optional-slip-able*
+*Completed: 2026-06-24 (D-15 ship-and-reframe)*

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-CONTEXT.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-CONTEXT.md
@@ -1,32 +1,48 @@
 # Phase 6: Bar-Feed Window Copies (OPTIONAL, slip-able) - Context
 
 **Gathered:** 2026-06-24
-**Status:** Ready for planning
+**Updated:** 2026-06-24 — **PIVOT after Gate (b) measurement + Scalene profile** (see
+`06-PROFILE-FINDINGS.md`). Primary lever changed from view/alias copy-reduction (06-01, kept but
+profiled ~0% W2) to a **monotonic incremental-cursor `window()`**. New decisions **D-10–D-16** below
+supersede/amend **D-01, D-04, D-05**; D-02/D-03/D-06/D-07/D-08/D-09 carry forward unchanged.
+**Status:** Ready for re-planning (cursor fix)
 
 <domain>
 ## Phase Boundary
 
-Phase 6 reduces the per-tick **frame-copy** cost on `BacktestBarFeed.window()` (PERF-06, hotspot #5,
-~4% W1 / ~22% W2 — it scales with symbol count). Today `window()` does
-`_offset_alias(timeframe)` + `frame.index.searchsorted(cutoff)` + **`frame.iloc[start:pos]`**, and
-that final positional slice materializes a fresh DataFrame (data copy of N×5 float64) **every tick,
-per symbol, per strategy** (`strategies_handler.py:125`, and twice per pair strategy at `:294-295`).
-The fix replaces that copy with a **read-only view** sharing the cached master frame's buffer,
-preserving all 7 rules of the look-ahead bar-timing contract (`feed/bar_feed.py` module docstring).
+Phase 6 reduces the per-tick **window-construction** cost on `BacktestBarFeed.window()` (PERF-06,
+hotspot #5, ~4% W1 / ~22% W2 — it scales with symbol count). Today `window()` does
+`_offset_alias(timeframe)` + `frame.index.searchsorted(cutoff)` + **`frame.iloc[start:pos]`**.
+
+**PIVOT (2026-06-24):** 06-01 already replaced the `.iloc` data *copy* with a read-only **view** and
+memoized `_offset_alias` — correct and a real look-ahead-safety win, but the Scalene profile shows it
+delivers **~0% W2** (the copy was short-lived; the alias was never expensive). The profile pinpoints
+the true per-tick hotspot as **`searchsorted` (13.2%) + the `iloc[start:pos]` view construction
+(7.9%)** — ~26% of W2 CPU, untouched by 06-01. The phase now pivots its primary lever to a
+**monotonic incremental cursor** that replaces the per-tick `searchsorted` (the backtest cutoff
+advances monotonically per (ticker, timeframe)), built **on top of** 06-01, and also pursues a
+**cheaper slice path** to cut the 7.9% `iloc`. This is exactly the mechanism ROADMAP success
+criterion 1 already names ("reusable view / **cached `searchsorted` bounds**") — in scope, not new
+scope. All 7 rules of the look-ahead bar-timing contract (`feed/bar_feed.py` module docstring) are
+preserved byte-for-byte.
 
 This is a v1.5 **behavior-preserving** perf phase: it re-baselines **nothing** numeric. The window is
 the `ta` float64 OHLCV domain (D-17), **not** money — no Decimal/float surface is touched, no oracle
 re-baseline.
 
-**In scope:**
-- `BacktestBarFeed.window()` only — replace the `.iloc` data copy with a read-only view; memoize
-  `_offset_alias` (D-01).
-- Hard read-only enforcement implemented by marking the **master frames** (`self._frames`)
-  non-writeable at build time, so views inherit non-writeable buffers and any mutation fails loudly
-  at source (D-02 + D-09 — one mechanism).
-- Empty-window short-circuit (D-06); slice-and-mark construction direction (D-07).
-- Behavior-preservation drift/equivalence test + audit (D-08).
-- Gate (b) judged on the W2 sweep + W1 non-regression; commit a W2 baseline (D-04, D-05).
+**In scope (post-pivot):**
+- **Monotonic incremental cursor** in `BacktestBarFeed.window()` replacing per-tick `searchsorted`
+  (D-10) **+** a cheaper slice path to cut the `iloc[start:pos]` construction (D-11). Built on top of
+  06-01 (kept, D-12).
+- **Denominator cleanup (prep step):** remove the per-bar `TIME EVENT` debug log
+  (`full_event_handler.py:116`) and de-time the harness overhead (tracemalloc + synth-gen) in
+  `run_w2_sweep.py` (D-13). One line outside `bar_feed.py` — accepted (it inflates the W2
+  denominator).
+- **Carried forward from 06-01 (unchanged):** read-only view + non-writeable master frames at build
+  (D-02 + D-09); empty-window short-circuit (D-06); slice-and-mark / byte-identity direction (D-07);
+  drift/equivalence test (D-08), extended with the cursor==searchsorted assertion (D-16).
+- Gate (b): re-freeze BOTH W1 and W2 baselines on the cleaned engine, then gate the cursor alone at
+  ≥10% W2 / W1 non-regress (D-14), with a ship-and-reframe fallback (D-15).
 
 **Out of scope (behavior-preserving milestone — changes NO numbers):**
 - `megaframe()` / screener path rework (D-03 — deferred subsystem; inherits the per-symbol view for
@@ -38,11 +54,15 @@ re-baseline.
   feed's concern.
 - Any money / float / Decimal change; any oracle re-baseline.
 
-**Gate (inherited from Phase 1 D-04, with a phase-specific gate-(b) verdict — see D-04/D-05):**
+**Gate (inherited from Phase 1 D-04, with a phase-specific gate-(b) verdict — see D-13/D-14/D-15):**
 - **Gate (a):** byte-exact SMA_MACD oracle green (134 trades / `final_equity 46189.87730727451`); the
-  e2e suite green; `mypy --strict` clean; determinism double-run byte-identical.
-- **Gate (b):** the perf-w2 sweep shows a measurable win (≥10% at 50 symbols) AND W1 does not regress;
-  re-freeze `W1-BASELINE.json` and commit a `W2-BASELINE.json` after.
+  e2e suite green; `mypy --strict` clean; determinism double-run byte-identical. **(unchanged by the
+  pivot — held.)**
+- **Gate (b) (post-pivot):** clean the denominator (D-13), re-freeze BOTH `W1-BASELINE.json` and
+  `W2-BASELINE.json` on the cleaned engine (cool machine), then the **cursor alone** must clear
+  **≥10% W2 at 50 symbols vs the cleaned W2 baseline** AND keep **W1 within the ±5% soft non-regress
+  band** (D-14). **Fallback (D-15):** if <10% honestly, ship anyway, record the actual W2 %, and
+  re-frame gate (b) → "measurable W2 win + W1 non-regress" (no hard kill — this phase is OPTIONAL).
 
 **OPTIONAL / slip-able note:** this is the optional, contract-gated item, independent of Phases 2–5
 and sequenced last (Phase 5 — Incremental Indicators, FRAGILE — is deferred to run AFTER this). The
@@ -54,8 +74,89 @@ judged honestly rather than failing the W1-only ≥5% bar by design.
 <decisions>
 ## Implementation Decisions
 
+> **PIVOT DECISIONS (2026-06-24, post-profile) — D-10–D-16.** These are the active mechanism after
+> Gate (b) measurement proved 06-01's view/alias gave ~0% W2. They supersede/amend D-01, D-04, D-05.
+> The rest of the original decisions (D-02/D-03/D-06/D-07/D-08/D-09) carry forward unchanged because
+> the cursor is built **on top of** 06-01, not instead of it.
+
+### Cursor mechanism (PERF-06 — supersedes D-01)
+- **D-10 (monotonic incremental-cursor `window()` — primary lever; reverses D-01's cursor
+  rejection):** Replace the per-tick `frame.index.searchsorted(cutoff)` (13.2% of W2 CPU) with a
+  cached **per-(ticker, timeframe) cursor** that only steps **forward** from its last position — the
+  backtest `asof` cutoff advances monotonically per series. Cursor is **reset/seek-safe**: a ticker
+  that leaves and re-enters the universe (screener membership), a sparse/gap frame (D-04), or any
+  non-forward `asof` step must NOT leak a future bar — default to a **safe rebuild via
+  `searchsorted`** on any non-monotonic step rather than trusting stale state. Exact
+  reset-trigger/non-monotonic handling (fail-loud vs silent rebuild) is researcher/planner territory
+  within "never leak a future bar." Cutoff stays **exclusive-right** (today's semantics). **Rejected
+  (the old D-01 rationale, now empirically wrong):** "cursor is a microsecond-class gain over O(log n)
+  searchsorted" — the profile shows searchsorted at 13.2%, the single largest reducible per-tick cost.
+
+### Slice cost (extends the lever beyond searchsorted)
+- **D-11 (cursor + cheaper slice together):** Beyond the cursor, also pursue a **cheaper slice path**
+  to cut the per-tick `iloc[start:pos]` view construction (7.9% of W2 CPU). **Byte-identity (dtype,
+  tz-aware `DatetimeIndex`, column set + order) is the HARD constraint** (carries D-07); the exact
+  lower-level construction (array slicing + view rebuild vs an `iloc` alternative) is
+  researcher/planner territory. Return type **stays `pd.DataFrame`** (D-01 consumers label-slice).
+  **Rejected:** searchsorted-only, leaving the 7.9% on the table (given the D-15 ship-even-if-short
+  fallback, the extra headroom is worth the bounded byte-identity risk).
+
+### 06-01 disposition
+- **D-12 (keep 06-01 as foundation):** 06-01 (read-only view + alias memo + non-writeable master
+  frames, commit `9168cae`, SUMMARY written) is **kept** — it is a real look-ahead-safety improvement
+  (mutation fails loudly, D-02/D-09) **and** its read-only master frames are the foundation the cursor
+  + cheaper slice (D-10/D-11) build on. The D-08 drift test carries forward (extended by D-16).
+  **Rejected:** reverting 06-01 to rebuild clean from base (loses the proven safety guard + drift
+  test; the cursor would have to re-establish read-only safety from scratch).
+
+### Gate (b) denominator cleanup (amends D-05)
+- **D-13 (clean the W2/W1 denominator BEFORE gating — prep step):** Before the cursor, a prep step:
+  **(1)** remove the per-bar `TIME EVENT` debug log (`full_event_handler.py:116` — a `logger.debug`
+  whose f-string `f"TIME EVENT: {event.time}"` is built **every bar** by the caller then discarded at
+  the default INFO level; ~22% of W2 CPU, a genuine engine waste even though nothing prints);
+  **(2)** de-time the **harness overhead** in `run_w2_sweep.py` (tracemalloc + synthetic-bar-gen,
+  ~19% of the W2 denominator) — capture peak-mem in a **separate pass**, not inside the timed run.
+  This is a real engine + measurement cleanup that shrinks total wall-clock so the cursor's
+  `searchsorted` savings become a larger, honest fraction (≥10% reachable). NOTE: the log line is
+  **outside `bar_feed.py`** (widens the strict "window() only" scope by one line) — accepted because
+  it directly inflates the W2 denominator. **Rejected:** gating on the raw diluted sweep (≥10% likely
+  unreachable by design); lowering the threshold instead of cleaning the signal.
+
+### Gate (b) verdict + W1 handling (amends D-04/D-05)
+- **D-14 (re-freeze both baselines on the cleaned engine, then gate the cursor alone):** After D-13,
+  re-freeze **BOTH** `W1-BASELINE.json` and `W2-BASELINE.json` on the cleaned engine, on a **cool
+  machine** (the v1.5 thermal-drift lesson). THEN require the **cursor alone** to clear **≥10% W2 at
+  50 symbols vs the cleaned W2 baseline** (cursor's win isolated from the cleanup), with **W1 within
+  the existing ±5% soft non-regress band** (`perf-w1 --check`). W1 stays the **guard, not a win** —
+  the cursor adds per-(ticker, timeframe) state with ~no benefit at 1 symbol, so a W1 win is not
+  required. Supersedes D-05's "≥10% vs current baseline" (now vs the **cleaned** baseline) and keeps
+  D-04's "re-freeze W1 + W1 non-regress." **Rejected:** single end-of-phase re-freeze conflating
+  cleanup+cursor on W1; holding the cursor to an actual W1 improvement (fails by design at 1 symbol).
+- **D-15 (ship-and-reframe fallback if <10% honestly):** If the cursor on the cleaned baseline still
+  cannot honestly clear ≥10% W2, **ship** the cursor + cleanup anyway (real correctness/safety + a
+  modest perf win + the removed per-tick searchsorted), **record the actual W2 % achieved** as the
+  locked result, and re-frame gate (b) → **"measurable W2 win + W1 non-regress"** (no hard ≥10%
+  kill). The phase is **OPTIONAL/slip-able** by design. **Rejected:** slipping/reverting the whole
+  phase on a <10% miss (loses the safety + modest win already built); keep-iterating until ≥10%
+  (scope sprawl on an optional phase).
+
+### Defensive correctness guard (extends D-08)
+- **D-16 (extend the D-08 drift test — no hot-path runtime guard):** Add to the D-08 drift suite:
+  across sampled ticks, assert the cursor's computed `(start, pos)` **==** a fresh
+  `searchsorted(cutoff)` on the same frame, **plus** the invariant "no bar with `time` > cutoff
+  appears in the returned window." **Zero hot-loop cost** — matches the established audit-the-invariant
+  + dedicated-test pattern (Phase 3 D-03, Phase 4 D-06/07, this phase's D-08/D-09). **Rejected:**
+  always-on runtime `assert cursor == searchsorted` in `window()` (re-pays the searchsorted the cursor
+  removes — defeats the optimization); an opt-in debug-flag runtime assert (unnecessary given the test
+  + the byte-exact oracle already gate-(a) lock the result).
+
 ### Copy-reduction mechanism (PERF-06)
-- **D-01 (view-primary + memoize alias; `searchsorted` stays):** Replace `frame.iloc[start:pos]` (a
+- **D-01 (view-primary + memoize alias; `searchsorted` stays):** ⚠️ **SUPERSEDED 2026-06-24 by
+  D-10/D-11** — the view+alias landed in 06-01 (kept, D-12) but profiled **~0% W2**; the
+  `searchsorted` this decision deliberately left in place IS the real hotspot. The cursor this
+  decision **rejected** is now the primary lever (D-10). Original text retained below for the record.
+
+  Replace `frame.iloc[start:pos]` (a
   per-tick data copy of N×5 float64) with a **read-only view** sharing the cached master frame's
   buffer — this is the named "frame copy" cost and the real win, scaling with symbol count (the ~22%
   W2). Bundle the trivial free extra: memoize `_offset_alias(timeframe)` (string compute per call).
@@ -125,14 +226,22 @@ judged honestly rather than failing the W1-only ≥5% bar by design.
   to the planner.
 
 ### Gate (b) verdict for a W2-dominant phase (PERF-06 is ~4% W1 / ~22% W2)
-- **D-04 (gate on W2 measurable win + W1 non-regress; re-freeze W1):** The standard milestone gate (b)
+- **D-04 (gate on W2 measurable win + W1 non-regress; re-freeze W1):** ⚠️ **AMENDED by D-14** — the
+  "re-freeze W1 + W1 non-regress" framing holds, but the re-freeze now happens on the **cleaned**
+  engine (D-13) and the cursor's win is isolated from the cleanup. Original text below.
+  The standard milestone gate (b)
   ≥5% bar is **W1-only**, and this phase is ~4% W1 **by design** — its win lives in the symbol-dense
   W2 sweep (success criterion: "most visible in the W2 symbol sweep"). So gate (b) for THIS phase =
   the `perf-w2` sweep shows a measurable win AND W1 **does not regress** (W1 stays the
   oracle-relevant non-regression guard); re-freeze `W1-BASELINE.json` after. **Rejected:** holding the
   standard ≥5% W1 bar (the phase can't pass it by design → would force an unwarranted slip/drop);
   a fully soft "any W2 win + W1 non-regress, no threshold" (looser than prior phases' concrete bars).
-- **D-05 (commit a W2 baseline + ≥10% bar at 50 symbols):** Capture `perf-w2 --json` before/after,
+- **D-05 (commit a W2 baseline + ≥10% bar at 50 symbols):** ⚠️ **AMENDED by D-13/D-14** — the W2
+  baseline + ≥10%-at-50-symbols bar stand, but are now measured on the **cleaned denominator** (log
+  removed + harness overhead de-timed), and D-15 adds a ship-and-reframe fallback. The 06-02 harness
+  (`run_w2_sweep --baseline-out/--check`, commit `f51d7c6`) is **reusable as-is** — it simply has no
+  ≥10% win to certify until the cursor lands. Original text below.
+  Capture `perf-w2 --json` before/after,
   commit a `W2-BASELINE.json` (the 50-symbol wall-clock) as the concrete, reproducible pass record,
   and require a **≥10% improvement at the 50-symbol point**. `perf-w2` today is a visibility sweep with
   no `--check`/baseline — this seeds the standing W2 reference, which **also benefits Phase 5**
@@ -157,7 +266,21 @@ judged honestly rather than failing the W1-only ≥5% bar by design.
 
 **Downstream agents MUST read these before planning or implementing.**
 
-### Target code — the single file this phase edits
+### THE PIVOT EVIDENCE — read first
+- `.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-PROFILE-FINDINGS.md` — **the
+  authoritative pivot rationale.** Gate (b) A/B (~0% W2 for 06-01), the Scalene line-level profile
+  (searchsorted 13.2% / iloc slice 7.9% / per-bar logging ~22% / harness overhead ~19%), why 06-01
+  missed, and the recommended cursor fix + its look-ahead constraints. **D-10–D-16 derive from this.**
+
+### Denominator cleanup target (D-13 — outside bar_feed.py)
+- `itrader/events_handler/full_event_handler.py` — **`:116`** `self.logger.debug(f"TIME EVENT:
+  {event.time}")` — the per-bar debug log to **remove** (eager f-string built every bar, discarded at
+  INFO; ~22% W2). **Tab indent.** Single-line removal; not a behavior/number change (logs aren't the
+  oracle).
+- `perf/runners/run_w2_sweep.py` — de-time the tracemalloc + synthetic-bar-gen harness overhead
+  (~19% of the W2 denominator); peak-mem in a separate pass (D-13).
+
+### Target code — the single ENGINE file this phase edits
 - `itrader/price_handler/feed/bar_feed.py` — **THE** target. The 7-rule bar-timing contract is in the
   module docstring (lines 9-55, the look-ahead invariant this phase MUST preserve); `window()` at
   **:360-399** (the `_offset_alias` + `searchsorted` + `frame.iloc[start:pos]` copy to view-ify, D-01);
@@ -243,15 +366,18 @@ judged honestly rather than failing the W1-only ≥5% bar by design.
 <specifics>
 ## Specific Ideas
 
-- The win is killing the per-tick **frame copy** in `window()` via a read-only view — NOT caching
-  `searchsorted` bounds (already cheap) and NOT touching the return type (D-01).
+- ⚠️ **REVISED 2026-06-24:** the win is **NOT** the frame copy (06-01 removed it for ~0% W2). The win
+  is killing the per-tick **`searchsorted`** (13.2%) with a monotonic cursor (D-10) **and** the
+  `iloc` slice construction (7.9%) with a cheaper path (D-11). Return type still stays `pd.DataFrame`.
 - Read-only is enforced **at the master frame** (mark non-writeable at build), which makes both the
   view aliasing safe and the master immutable in one mechanism (D-02 + D-09) — mutation fails loudly
   rather than silently poisoning a future tick.
 - Empty windows are short-circuited and returned exactly as today — they carry no copy cost and no
   aliasing risk (D-06).
 - Gate (b) is judged on the **W2 sweep** (≥10% at 50 symbols, committed `W2-BASELINE.json`) with **W1
-  non-regression** — because PERF-06 is ~4% W1 / ~22% W2 by design (D-04/D-05).
+  non-regression** — but now on a **cleaned denominator** (per-bar log removed + harness de-timed,
+  D-13), with baselines re-frozen on the cleaned engine (D-14) and a **ship-and-reframe fallback** if
+  <10% honestly (D-15). PERF-06 is ~4% W1 / ~22% W2 by design.
 - View-construction stays **slice + mark read-only** on the existing frame (preserve dtype/tz-index/
   columns); the exact pandas API is the researcher's to pin against pinned pandas 2.3.3, byte-identity
   the hard constraint (D-07).
@@ -265,9 +391,9 @@ judged honestly rather than failing the W1-only ≥5% bar by design.
   multi-symbol `pd.concat` is inherent assembly; it inherits the per-symbol view for free. Revisit
   only if/when the production screener is built (N+4 Live Trading Readiness) and W2 measurement shows
   it dominates (D-03).
-- **Monotonic per-(ticker,tf) cursor replacing `searchsorted`** — a microsecond-class gain over the
-  existing O(log n) `searchsorted`; not worth the added per-(ticker,tf) state in this phase (D-01).
-  Could be revisited if a future profile shows `searchsorted` itself as a hotspot.
+- ~~**Monotonic per-(ticker,tf) cursor replacing `searchsorted`**~~ — **NO LONGER DEFERRED. PROMOTED
+  to the primary lever (D-10) on 2026-06-24** after the profile showed `searchsorted` at 13.2% of W2
+  (the "future profile" this bullet anticipated). The microsecond-class assumption was wrong.
 - **Removing the in-strategy/adapter re-slicing** (`catalog.py` `bars[start_dt:]` building an
   intermediate per compute) — a strategy/adapter concern with byte-identity risk, outside the feed's
   window path. Revisit in a future non-byte-exact cleanup if it profiles hot (D-01 out-of-scope note).

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-CONTEXT.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-CONTEXT.md
@@ -1,0 +1,280 @@
+# Phase 6: Bar-Feed Window Copies (OPTIONAL, slip-able) - Context
+
+**Gathered:** 2026-06-24
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Phase 6 reduces the per-tick **frame-copy** cost on `BacktestBarFeed.window()` (PERF-06, hotspot #5,
+~4% W1 / ~22% W2 — it scales with symbol count). Today `window()` does
+`_offset_alias(timeframe)` + `frame.index.searchsorted(cutoff)` + **`frame.iloc[start:pos]`**, and
+that final positional slice materializes a fresh DataFrame (data copy of N×5 float64) **every tick,
+per symbol, per strategy** (`strategies_handler.py:125`, and twice per pair strategy at `:294-295`).
+The fix replaces that copy with a **read-only view** sharing the cached master frame's buffer,
+preserving all 7 rules of the look-ahead bar-timing contract (`feed/bar_feed.py` module docstring).
+
+This is a v1.5 **behavior-preserving** perf phase: it re-baselines **nothing** numeric. The window is
+the `ta` float64 OHLCV domain (D-17), **not** money — no Decimal/float surface is touched, no oracle
+re-baseline.
+
+**In scope:**
+- `BacktestBarFeed.window()` only — replace the `.iloc` data copy with a read-only view; memoize
+  `_offset_alias` (D-01).
+- Hard read-only enforcement implemented by marking the **master frames** (`self._frames`)
+  non-writeable at build time, so views inherit non-writeable buffers and any mutation fails loudly
+  at source (D-02 + D-09 — one mechanism).
+- Empty-window short-circuit (D-06); slice-and-mark construction direction (D-07).
+- Behavior-preservation drift/equivalence test + audit (D-08).
+- Gate (b) judged on the W2 sweep + W1 non-regression; commit a W2 baseline (D-04, D-05).
+
+**Out of scope (behavior-preserving milestone — changes NO numbers):**
+- `megaframe()` / screener path rework (D-03 — deferred subsystem; inherits the per-symbol view for
+  free; its `pd.concat` is inherent multi-symbol assembly).
+- `current_bars()` (already de-pandas'd to a dict lookup in a prior phase, D-07 there).
+- Changing the `window()` **return type** away from a `pd.DataFrame` (consumers label-slice the index:
+  `bars[start_dt:][input_col]`, `window.index[-1]`).
+- Rewriting in-strategy/adapter slicing (`catalog.py` `bars[start_dt:]`) — byte-identity risk, not the
+  feed's concern.
+- Any money / float / Decimal change; any oracle re-baseline.
+
+**Gate (inherited from Phase 1 D-04, with a phase-specific gate-(b) verdict — see D-04/D-05):**
+- **Gate (a):** byte-exact SMA_MACD oracle green (134 trades / `final_equity 46189.87730727451`); the
+  e2e suite green; `mypy --strict` clean; determinism double-run byte-identical.
+- **Gate (b):** the perf-w2 sweep shows a measurable win (≥10% at 50 symbols) AND W1 does not regress;
+  re-freeze `W1-BASELINE.json` and commit a `W2-BASELINE.json` after.
+
+**OPTIONAL / slip-able note:** this is the optional, contract-gated item, independent of Phases 2–5
+and sequenced last (Phase 5 — Incremental Indicators, FRAGILE — is deferred to run AFTER this). The
+phase is fully intended to land now; the gate (b) verdict (D-04) is framed so a W2-dominant win is
+judged honestly rather than failing the W1-only ≥5% bar by design.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Copy-reduction mechanism (PERF-06)
+- **D-01 (view-primary + memoize alias; `searchsorted` stays):** Replace `frame.iloc[start:pos]` (a
+  per-tick data copy of N×5 float64) with a **read-only view** sharing the cached master frame's
+  buffer — this is the named "frame copy" cost and the real win, scaling with symbol count (the ~22%
+  W2). Bundle the trivial free extra: memoize `_offset_alias(timeframe)` (string compute per call).
+  `window()` **keeps returning a `pd.DataFrame`** (consumers label-slice the index). `searchsorted`
+  is left as-is — it is O(log ~2900) ≈ microsecond-class, not the hotspot. **Rejected:** a monotonic
+  per-(ticker,tf) cursor to replace `searchsorted` (added state for a microsecond gain); bounds-only
+  caching that keeps the copy (leaves the headline cost on the table); returning a bare numpy array
+  (breaks the label-slicing consumers).
+
+### View-aliasing safety / master-frame immutability (the look-ahead invariant)
+- **D-02 (hard read-only at the feed boundary; mutation fails loudly at source — NOT a global flag):**
+  A view aliases the cached master frame, so an in-place mutation by any consumer would silently
+  poison **future** ticks (a look-ahead breach). All current consumers are **verified read-only**
+  (the window lands on `strategy.bars`; indicator `compute` reads `bars[input_col]` /
+  `bars[start_dt:][input_col]` and builds new Series — see `indicators/catalog.py`, `handle.py`). The
+  guarantee is enforced **at the source** (see D-09), so a mutation attempt raises loudly rather than
+  silently corrupting state, plus a written audit and a drift test (D-08). **Rejected:** global
+  `pd.options.mode.copy_on_write` (process-wide blast radius + byte-identity risk in a byte-exact
+  phase; mutation copies silently instead of failing loudly); audit + test only with no runtime guard.
+- **D-09 (enforce read-only at source — mark master frames non-writeable at build; this *subsumes*
+  the view-safety mechanism):** Mark each master frame in `self._frames` non-writeable when it is
+  built (after the `__init__` base load and after each lazy/eager `_resampled_frame` resample). Views
+  then inherit non-writeable buffers automatically (one mechanism implements D-02's view-safety too)
+  **and** any accidental in-place mutation of a cached master frame also fails loudly. Lazy resample
+  still **inserts NEW frames** as dict keys (never mutates an existing frame), each marked read-only on
+  build — so the "frames written once, never mutated after" invariant holds and is now hard-enforced.
+  **Researcher MUST confirm** marking frames non-writeable does not break `resample`/`searchsorted`/
+  the `ta` reads on views; **if it does, fall back** to marking the per-view buffer non-writeable
+  instead (D-07 direction still applies). **Rejected:** audit + test only (no hard runtime guard
+  against a future master mutation).
+
+### Path scope
+- **D-03 (`window()` only):** `window()` is the oracle-relevant path AND the one that scales with
+  symbol count (the W2 win). `megaframe()` (screener path, a **deferred** subsystem, likely not in the
+  W1/W2 benchmark) inherits the read-only view for free on its per-symbol `window()` calls; its
+  `pd.concat` assembly is inherent and not worth separate work in a behavior-preserving phase.
+  `current_bars()` is already a pure dict lookup. **Rejected:** also reworking `megaframe()`'s
+  concat (added contract surface for little gated payoff in a deferred subsystem).
+
+### Empty-window edge
+- **D-06 (short-circuit empty; return the existing slice unchanged):** When the cutoff lands at the
+  frame start, `window()` returns `frame.iloc[pos:pos]` (size-0). An empty slice carries zero rows →
+  zero data-copy cost **and** zero aliasing risk (no shared data), so empty windows **bypass the view
+  + read-only machinery entirely** and return the existing `frame.iloc[pos:pos]` unchanged. This keeps
+  byte-identical empty semantics (float64 dtype, tz-aware index, column set/order) that the
+  empty-window guard (`base.py:347-351`, `window.index[-1]` would raise on size-0) and consumer
+  `.empty`/`len` checks rely on, and sidesteps any `writeable=False`-on-empty concern. **Rejected:**
+  routing empty windows through the uniform view path (pointless read-only marking on an empty buffer,
+  must prove it's a no-op, zero gain).
+
+### View-construction approach
+- **D-07 (set direction; researcher pins the exact API):** **Direction (locked):** operate on the
+  **sliced existing frame** and mark it read-only, preserving dtype / tz-aware `DatetimeIndex` /
+  column set+order **exactly** — do **NOT** reconstruct via a new `pd.DataFrame(...)` (which risks
+  index/tz/dtype drift and would break byte-identity). The exact pandas 2.3.3 view/CoW API + the
+  `ta`-read compatibility check are **researcher/planner** territory, with **byte-identity as the hard
+  constraint**. **Rejected:** pinning the precise construction call now (premature — depends on pinned
+  pandas mechanics); fully deferring (doesn't steer away from the risky reconstruct path).
+
+### Behavior-preservation proof (criterion #2/#3 — gate (a) does not observe window internals)
+- **D-08 (drift/equivalence test — all three assertions; mirrors Phase 3 D-03 / Phase 4 D-06-07):**
+  A dedicated test that asserts **(a)** view content == old-copy content across sampled ticks (capture
+  a `.copy()` and compare — byte-identical values, dtype, index); **(b)** mutating a returned window
+  **RAISES** and cannot leak into the master frame (proves D-02/D-09); **(c)** the existing 7-rule
+  bar-timing contract tests stay green. **Home:** `tests/unit/price_handler/feed/`. **Rejected:**
+  content + contract only (drops the direct proof of the safety guarantee); leaving assertions fully
+  to the planner.
+
+### Gate (b) verdict for a W2-dominant phase (PERF-06 is ~4% W1 / ~22% W2)
+- **D-04 (gate on W2 measurable win + W1 non-regress; re-freeze W1):** The standard milestone gate (b)
+  ≥5% bar is **W1-only**, and this phase is ~4% W1 **by design** — its win lives in the symbol-dense
+  W2 sweep (success criterion: "most visible in the W2 symbol sweep"). So gate (b) for THIS phase =
+  the `perf-w2` sweep shows a measurable win AND W1 **does not regress** (W1 stays the
+  oracle-relevant non-regression guard); re-freeze `W1-BASELINE.json` after. **Rejected:** holding the
+  standard ≥5% W1 bar (the phase can't pass it by design → would force an unwarranted slip/drop);
+  a fully soft "any W2 win + W1 non-regress, no threshold" (looser than prior phases' concrete bars).
+- **D-05 (commit a W2 baseline + ≥10% bar at 50 symbols):** Capture `perf-w2 --json` before/after,
+  commit a `W2-BASELINE.json` (the 50-symbol wall-clock) as the concrete, reproducible pass record,
+  and require a **≥10% improvement at the 50-symbol point**. `perf-w2` today is a visibility sweep with
+  no `--check`/baseline — this seeds the standing W2 reference, which **also benefits Phase 5**
+  (Incremental Indicators, W2-relevant, runs after this). **Researcher/planner** decides whether
+  `perf-w2` needs a `--check`/`--baseline-out` flag (mirroring `run_w1_benchmark`) to mechanize it.
+  **Rejected:** recording before/after in artifacts only with no committed baseline or % bar (no
+  concrete threshold, nothing seeded for Phase 5).
+
+### Claude's Discretion
+- Exact pandas 2.3.3 view-construction API under D-07 (slice + mark read-only), and the precise spot
+  to mark master frames non-writeable under D-09 — within the locked direction + byte-identity
+  constraint + the `ta`/`resample` compatibility check.
+- Shape/placement of the `_offset_alias` memoization (D-01).
+- Exact placement/shape of the drift/equivalence test within the D-08 three-assertion contract.
+- Whether to add a `--check`/`--baseline-out` flag to `perf-w2` (vs an ad-hoc before/after capture)
+  to mechanize the D-05 ≥10% verdict.
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Target code — the single file this phase edits
+- `itrader/price_handler/feed/bar_feed.py` — **THE** target. The 7-rule bar-timing contract is in the
+  module docstring (lines 9-55, the look-ahead invariant this phase MUST preserve); `window()` at
+  **:360-399** (the `_offset_alias` + `searchsorted` + `frame.iloc[start:pos]` copy to view-ify, D-01);
+  `_resampled_frame` at **:256-274** and `__init__` base load at **:181-188** (where master frames
+  enter `self._frames` — the mark-read-only sites, D-09); `current_bars` at :335-356 (already
+  de-pandas'd, out of scope); `megaframe` at :403-443 (out of scope, D-03). **4-space indent.**
+
+### Consumers (read-only audit, D-02) — explain why a view is safe
+- `itrader/strategy_handler/strategies_handler.py` — `feed.window(...)` at **:125** (single-symbol,
+  per tick), **:294-295** (pair strategy, two windows). **Tab indent — read-only.**
+- `itrader/strategy_handler/base.py` — `evaluate()` stashes the window on `self.bars` (**:368**) and
+  `self.now = window.index[-1]`; the **empty-window guard** at **:346-351** (D-06 must preserve this).
+  **Tab indent.**
+- `itrader/strategy_handler/indicators/handle.py` — `repopulate(bars, ...)` → `adapter.compute(...)`.
+- `itrader/strategy_handler/indicators/catalog.py` — the 5 `compute` paths (`:49/:64/:90/:122/:145`),
+  all read-only column/label access (`bars[input_col]`, `bars[start_dt:][input_col]`) — the evidence
+  consumers don't mutate the window. **Read-only — do NOT "tidy" the slicing (byte-identity).**
+
+### Milestone scope + requirements + gate
+- `.planning/REQUIREMENTS.md` — **PERF-06** (optional) + the milestone gate (a)/(b) definition.
+- `.planning/ROADMAP.md` — Phase 6 entry + Success Criteria (4 criteria; criterion 4 = "most visible in
+  the W2 symbol sweep", the basis for D-04) + the v1.5 behavior-preserving framing.
+- `.planning/STATE.md` — milestone gate (a)/(b) full text; the deliberate 6-before-5 reorder.
+
+### Perf harness + baselines (gate (b), D-04/D-05)
+- `Makefile` — `perf-w1` (gated `--check` vs frozen baseline, **:99-101**), `perf-w2`
+  (scaling sweep {1,10,50}, `--json`, **:104-106**), `perf-baseline` (re-freeze W1, **:110-112**).
+- `perf/runners/run_w1_benchmark.py` — the W1 runner (`--check`/`--json`/`--baseline-out` flags; the
+  pattern to mirror if `perf-w2` gets a `--check`/`--baseline-out`).
+- `perf/runners/run_w2_sweep.py` — the W2 sweep runner (D-05 captures/commits its 50-symbol number).
+- `perf/results/W1-BASELINE.json` — the frozen W1 reference (re-frozen after this phase, D-04).
+  `perf/results/PERF-BASELINE-RESULTS.md` — §2 ranked hotspots (**#5** = bar-feed window copies),
+  §6 phase breakdown, §7 exit criteria. **Authoritative source — the spike IS the research.**
+
+### Precedent phases (the audit-the-invariant + dedicated test pattern, reused as D-08/D-09)
+- `.planning/phases/03-running-pnl-accumulator/03-CONTEXT.md` — D-03 audit-the-invariant + equivalence
+  test precedent.
+- `.planning/phases/04-hot-path-discipline/04-CONTEXT.md` — D-06/D-07 behavior-preservation drift-lock
+  precedent (proof without re-paying cost), and the Phase-1 D-04 ≥5%/single-timed-run gate inheritance.
+- `.planning/phases/01-perf-tooling-baseline/01-CONTEXT.md` — D-04 gate (b) definition + the baseline /
+  regression-guard tooling.
+
+### Gate (a) — correctness lock (held, not changed)
+- `tests/integration/test_backtest_oracle.py` — byte-exact SMA_MACD oracle (134 /
+  `46189.87730727451`). (Per memory `oracle-test-location`: this is the oracle; `tests/golden` is
+  artifacts, 0 tests collected.)
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- **The window path is already a single, tight slice** — `window()` is the one method to change; the
+  master frames are already cached in `self._frames` and (per the module design) written once at
+  build / first resample, so a view aliasing them is well-defined (D-01/D-09).
+- **`current_bars` already shows the de-pandas pattern** — it was front-loaded to a `{ticker:{time:Bar}}`
+  dict in a prior phase (D-07 there); this phase applies the analogous "stop re-materializing per tick"
+  idea to the history-window path, but via a view (the window must stay a DataFrame).
+- **The W1/W2 harness exists** — `run_w1_benchmark` (gated `--check`) and `run_w2_sweep` (`--json`)
+  from Phase 1; D-05 only adds a committed W2 baseline + threshold on top.
+
+### Established Patterns
+- **Look-ahead safety is an ENGINE invariant enforced in the window slice** (module docstring), never a
+  strategy responsibility — so the read-only guarantee belongs in the feed (D-02/D-09), not in
+  consumers.
+- **Audit-the-invariant + dedicated equivalence/regression test, no hot-path runtime guard**
+  (Phase 3 D-03, Phase 4 D-06/D-07) — reused here as D-08 (drift test) and D-09 (build-time read-only
+  enforcement, not a per-tick guard).
+- **Indentation hazard (CLAUDE.md):** `bar_feed.py` is **4-space**; `strategies_handler.py` /
+  `base.py` / `handle.py` / `catalog.py` are **tab**. Match each file — never normalize. (This phase
+  edits only the 4-space `bar_feed.py`.)
+
+### Integration Points
+- The change is internal to `BacktestBarFeed.window()` + the `self._frames` build sites — no
+  event-queue, handler, ABC, or public-signature change. `window()` keeps its
+  `(ticker, timeframe, max_window, asof) -> pd.DataFrame` signature; all callers are unchanged (D-01).
+- The read-only marking lands at the frame-build sites (`__init__` base load, `_resampled_frame`
+  memoize) — a one-time cost at construction/first-access, not the hot loop (D-09).
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- The win is killing the per-tick **frame copy** in `window()` via a read-only view — NOT caching
+  `searchsorted` bounds (already cheap) and NOT touching the return type (D-01).
+- Read-only is enforced **at the master frame** (mark non-writeable at build), which makes both the
+  view aliasing safe and the master immutable in one mechanism (D-02 + D-09) — mutation fails loudly
+  rather than silently poisoning a future tick.
+- Empty windows are short-circuited and returned exactly as today — they carry no copy cost and no
+  aliasing risk (D-06).
+- Gate (b) is judged on the **W2 sweep** (≥10% at 50 symbols, committed `W2-BASELINE.json`) with **W1
+  non-regression** — because PERF-06 is ~4% W1 / ~22% W2 by design (D-04/D-05).
+- View-construction stays **slice + mark read-only** on the existing frame (preserve dtype/tz-index/
+  columns); the exact pandas API is the researcher's to pin against pinned pandas 2.3.3, byte-identity
+  the hard constraint (D-07).
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- **`megaframe()` / screener concat optimization** — the screener is a deferred subsystem and its
+  multi-symbol `pd.concat` is inherent assembly; it inherits the per-symbol view for free. Revisit
+  only if/when the production screener is built (N+4 Live Trading Readiness) and W2 measurement shows
+  it dominates (D-03).
+- **Monotonic per-(ticker,tf) cursor replacing `searchsorted`** — a microsecond-class gain over the
+  existing O(log n) `searchsorted`; not worth the added per-(ticker,tf) state in this phase (D-01).
+  Could be revisited if a future profile shows `searchsorted` itself as a hotspot.
+- **Removing the in-strategy/adapter re-slicing** (`catalog.py` `bars[start_dt:]` building an
+  intermediate per compute) — a strategy/adapter concern with byte-identity risk, outside the feed's
+  window path. Revisit in a future non-byte-exact cleanup if it profiles hot (D-01 out-of-scope note).
+
+</deferred>
+
+---
+
+*Phase: 6-bar-feed-window-copies-optional-slip-able*
+*Context gathered: 2026-06-24*

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-DISCUSSION-LOG.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-DISCUSSION-LOG.md
@@ -133,3 +133,68 @@
 - `megaframe()` / screener concat optimization → revisit with the production screener (N+4).
 - Monotonic per-(ticker,tf) cursor replacing `searchsorted` → microsecond gain, not worth the state now.
 - Removing in-strategy/adapter re-slicing (`catalog.py` `bars[start_dt:]`) → byte-identity risk, future non-byte-exact cleanup.
+
+---
+
+# PIVOT SESSION — 2026-06-24 (post Gate-(b) profile)
+
+**Trigger:** `06-PROFILE-FINDINGS.md` — 06-01's view/alias measured ~0% W2; real hotspot is per-tick
+`searchsorted` (13.2%) + `iloc` slice (7.9%). Re-discussed to pivot the mechanism.
+**Areas discussed:** Gate (b) realism, Fallback if cursor falls short, Cursor change scope, 06-01
+disposition, W1 re-baseline + non-regression, Defensive correctness guard.
+
+## Gate (b) realism / denominator cleanup (D-13/D-14)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Clean denominator first | Remove per-bar TIME-EVENT debug log + de-time tracemalloc/synth-gen; re-baseline; gate ≥10% on cleaned engine | ✓ |
+| Keep ≥10% on raw sweep | Gate on full diluted wall-clock | |
+| Lower threshold | Drop to ≥5% on raw sweep | |
+
+**Follow-up:** user confirmed the per-bar log is DEBUG (`full_event_handler.py:116`, eager f-string
+discarded at INFO) and chose to **remove it completely** (not just disable during the timed run).
+Sub-decision: **remove log → re-baseline → gate the cursor alone** (isolate the cursor's win), not a
+combined-win gate.
+
+## Fallback if cursor falls short (D-15)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Ship as correctness+modest-perf, re-frame gate (b) | Record actual W2 %, re-frame to "measurable W2 win + W1 non-regress" | ✓ |
+| Slip the whole phase | Revert/park, defer Phase 6 | |
+| Keep iterating | Chase more hotspots until ≥10% | |
+
+## Cursor change scope (D-10/D-11)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Searchsorted only (slice as stretch) | Cursor replaces searchsorted; iloc slice only if needed | |
+| Cursor + slice together | Cursor for bounds AND cheaper slice path for the 7.9% iloc | ✓ |
+| Searchsorted only, slice never | Leave iloc exactly as 06-01 | |
+
+## 06-01 disposition (D-12)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Keep as foundation | Cursor builds on 06-01's read-only master frames + view; D-08 drift test carries | ✓ |
+| Revert 06-01 first | Rebuild window path clean from base | |
+
+## W1 re-baseline + non-regression (D-14)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Re-freeze on cleaned engine, then non-regress | Re-freeze W1 post-cleanup; cursor held to ±5% soft band; cool machine | ✓ |
+| Single end re-freeze | One re-freeze after cursor, no intermediate | |
+| Require W1 improvement too | Hold cursor to an actual W1 win | |
+
+## Defensive correctness guard (D-16)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Dedicated test only (extend D-08) | Assert cursor (start,pos) == fresh searchsorted + no-future-bar invariant | ✓ |
+| Test + optional debug-flag runtime assert | Add opt-in runtime check off by default | |
+| Runtime assert always on | Verify every tick (re-pays searchsorted) | |
+
+**Skipped (folded as carry-forward defaults, not separate decisions):** cursor reset/non-monotonic
+semantics (→ safe rebuild via searchsorted, never leak a future bar — D-10); plan split/sequencing
+(→ planner's call).

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-DISCUSSION-LOG.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-DISCUSSION-LOG.md
@@ -1,0 +1,135 @@
+# Phase 6: Bar-Feed Window Copies (OPTIONAL, slip-able) - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-06-24
+**Phase:** 6-bar-feed-window-copies-optional-slip-able
+**Areas discussed:** Copy-reduction mechanism, View-aliasing safety, Path scope, Gate (b) verdict (W1 vs W2), W2 record, Empty-window edge, View-construction approach, Drift/equivalence test design, Master-frame immutability
+
+---
+
+## Copy-reduction mechanism (D-01)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| View-primary (+ cheap caching) | Replace `frame.iloc[start:pos]` data copy with a read-only view; memoize `_offset_alias`; `searchsorted` stays | ✓ |
+| View + cursor bounds | Also replace `searchsorted` with a monotonic per-(ticker,tf) cursor | |
+| Bounds-only (keep copy) | Cache alias + bounds but still copy via `.iloc` | |
+
+**User's choice:** View-primary (+ cheap caching)
+**Notes:** Attacks the actual named cost (the per-tick frame copy); `searchsorted` is microsecond-class and left alone. `window()` keeps returning a DataFrame.
+
+---
+
+## View-aliasing safety (D-02)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Hard read-only + audit + test | Enforce read-only at the feed boundary so mutation raises loudly; + audit + drift test; no global flag | ✓ |
+| Global pandas Copy-on-Write | Flip `pd.options.mode.copy_on_write` process-wide | |
+| Audit + drift test only | Rely on verified read-only consumers, no runtime guard | |
+
+**User's choice:** Hard read-only + audit + test
+**Notes:** Mutation must fail loudly at source, not silently poison future ticks. Implementation consolidated into D-09 (enforce at master-frame build). Researcher verifies `writeable=False` doesn't break `ta` reads; fall back if it does.
+
+---
+
+## Path scope (D-03)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| `window()` only | Oracle-relevant + symbol-count-scaling path; megaframe inherits the view free | ✓ |
+| `window()` + `megaframe()` | Also rework megaframe's concat | |
+
+**User's choice:** `window()` only
+**Notes:** `megaframe()` is a deferred screener subsystem; `current_bars()` already de-pandas'd.
+
+---
+
+## Gate (b) verdict (W1 vs W2) (D-04)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| W2 shows win + W1 non-regress | Judge gate (b) on the perf-w2 sweep; W1 must not regress; re-freeze W1 | ✓ |
+| Hold standard ≥5% W1 bar | Apply the same ≥5% W1 bar; phase slips if it can't pass | |
+| Soft: W1 non-regress + any W2 win | No hard % threshold | |
+
+**User's choice:** W2 shows win + W1 non-regress
+**Notes:** PERF-06 is ~4% W1 / ~22% W2 — below the W1-only ≥5% bar by design; success criterion says "most visible in W2 sweep."
+
+---
+
+## W2 record (D-05)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Commit W2 baseline + ≥10% bar | Capture perf-w2 --json before/after, commit W2-BASELINE.json (50-sym), require ≥10% at 50 symbols; seeds Phase 5 | ✓ |
+| Record before/after only, no threshold | Evidence in artifacts only, no standing baseline | |
+| You decide (planner) | Leave mechanism + threshold to planner | |
+
+**User's choice:** Commit W2 baseline + ≥10% bar
+**Notes:** Gives a reproducible, thresholded verdict and seeds a W2 baseline for Phase 5 (incremental indicators, also W2-relevant, runs after this).
+
+---
+
+## Empty-window edge (D-06)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Short-circuit empty, return as today | Empty slice carries no copy cost / no aliasing risk → bypass view machinery, return `frame.iloc[pos:pos]` unchanged | ✓ |
+| Uniform view path | Route empty windows through the same view + writeable path | |
+
+**User's choice:** Short-circuit empty, return as today
+**Notes:** Preserves byte-identical empty semantics for the `base.py:347` empty-window guard; sidesteps `writeable=False`-on-empty.
+
+---
+
+## View-construction approach (D-07)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Set direction, researcher pins API | Direction: slice existing frame + mark read-only, preserve dtype/tz-index/columns (not reconstruct via new DataFrame); researcher pins exact pandas 2.3.3 API + ta compat, byte-identity the constraint | ✓ |
+| Pin exact API now | Decide the precise call in discussion | |
+| Fully defer | Leave both direction and API to research/planning | |
+
+**User's choice:** Set direction, researcher pins API
+
+---
+
+## Drift/equivalence test design (D-08)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| All three: content + mutation + contract | (a) content equivalence vs old copy; (b) mutation raises + no master leak; (c) 7-rule contract tests green; in tests/unit/price_handler/feed/ | ✓ |
+| Content + contract only | Skip the mutation/no-leak assertion | |
+| You decide (planner) | Leave assertions + placement to planner | |
+
+**User's choice:** All three: content + mutation + contract
+
+---
+
+## Master-frame immutability (D-09)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Enforce at source (marks subsume view safety) | Mark master frames read-only at build → views inherit non-writeable buffers AND master mutation fails loudly; one mechanism implements D-02 too | ✓ |
+| Audit + test only | Document the invariant, cover via drift test, no marking | |
+
+**User's choice:** Enforce at source
+**Notes:** Elegantly unifies the view-safety mechanism (D-02) with the immutability invariant. Researcher confirms it doesn't break resample/ta reads, else fall back to per-view marking.
+
+---
+
+## Claude's Discretion
+
+- Exact pandas 2.3.3 view-construction API and the precise master-frame mark-read-only site (D-07/D-09), within the locked direction + byte-identity + ta/resample compatibility.
+- Shape/placement of the `_offset_alias` memoization (D-01).
+- Exact placement/shape of the drift/equivalence test within the D-08 three-assertion contract.
+- Whether to add a `--check`/`--baseline-out` flag to `perf-w2` to mechanize the D-05 ≥10% verdict.
+
+## Deferred Ideas
+
+- `megaframe()` / screener concat optimization → revisit with the production screener (N+4).
+- Monotonic per-(ticker,tf) cursor replacing `searchsorted` → microsecond gain, not worth the state now.
+- Removing in-strategy/adapter re-slicing (`catalog.py` `bars[start_dt:]`) → byte-identity risk, future non-byte-exact cleanup.

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-PATTERNS.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-PATTERNS.md
@@ -1,0 +1,305 @@
+# Phase 6: Bar-Feed Window Copies (OPTIONAL, slip-able) - Pattern Map
+
+**Mapped:** 2026-06-24
+**Files analyzed:** 4 (1 modify-source, 1 create-test, 2 modify-perf-harness)
+**Analogs found:** 4 / 4 (all exact or in-file)
+
+This is a narrow, behavior-preserving perf phase. The file list is already pinned by
+CONTEXT.md `canonical_refs` — this map's job is to point each edit at the single best
+in-repo pattern to copy and to surface the load-bearing excerpts so the planner does not
+re-discover them.
+
+> **Indentation hazard (CLAUDE.md / RESEARCH anti-pattern):** `bar_feed.py` is **4-space**.
+> The consumers (`strategies_handler.py`, `base.py`, `catalog.py`, `handle.py`) are **tab** and
+> are NOT edited this phase. The test files and perf runners are **4-space**. Match each file;
+> never normalize.
+
+## File Classification
+
+| New/Modified File | Role | Data Flow | Closest Analog | Match Quality |
+|-------------------|------|-----------|----------------|---------------|
+| `itrader/price_handler/feed/bar_feed.py` (MODIFY: `window`, `_resampled_frame`, `__init__`, `_offset_alias`) | feed / read-model | request-response (per-tick slice read) | itself — `window()` body + `current_bars()` de-pandas precedent in the SAME file; Phase 4 `_declared_hints` memoize precedent | in-file (self-analog) |
+| `tests/unit/price/test_bar_feed.py` (MODIFY/CREATE: add drift+read-only assertions, or sibling `test_bar_feed_window_view.py`) | test | transform / equivalence-assert | `tests/unit/portfolio/test_realised_pnl_accumulator.py` (Phase 3 D-03) + `tests/unit/strategy/test_type_hints_equivalence.py` (Phase 4 D-05/D-07) + the existing `test_bar_feed.py` contract tests (assertion c) | exact (two precedent drift-locks + in-file contract suite) |
+| `perf/runners/run_w2_sweep.py` (MODIFY: add `--check`/`--baseline-out`) | config / perf-runner | batch (sweep) + transform (schema) | `perf/runners/run_w1_benchmark.py` (`--check`/`--baseline-out`/`--json` flag plumbing) | exact (sibling runner, same pattern) |
+| `Makefile` (MODIFY: `perf-w2` gating + `perf-w2-baseline`) | config | request-response (task target) | `Makefile` `perf-w1` / `perf-baseline` targets `:99-112` | exact (sibling target) |
+| `perf/results/W2-BASELINE.json` (CREATE: committed baseline) | config / data artifact | — | `perf/results/W1-BASELINE.json` (schema to mirror) | exact (sibling artifact) |
+
+---
+
+## Pattern Assignments
+
+### `itrader/price_handler/feed/bar_feed.py` (feed, request-response) — **4-space**
+
+**Analog:** itself. The win is killing per-tick wrapper churn in `window()` (D-01) and
+marking master frames read-only at the two build sites (D-09). The de-pandas precedent
+(`current_bars`, already front-loaded to a dict in a prior phase) and the Phase 4 memoize
+pattern are the in-repo templates.
+
+**Existing `window()` to view-ify** (`:395-399` — the `_offset_alias` + `searchsorted` +
+`frame.iloc[...]` slice; THIS is the slice to keep, the alias call to memoize, and the empty
+case to short-circuit per D-06):
+```python
+        alias = _offset_alias(timeframe)
+        frame = self._resampled_frame(ticker, alias)
+        cutoff = asof - timeframe + self._base_timeframe
+        pos = int(frame.index.searchsorted(cutoff, side="right"))
+        return frame.iloc[max(0, pos - max_window):pos]
+```
+> RESEARCH Pitfall 2: on the homogeneous float64 single-block golden frame the `.iloc` slice
+> is **already a view** — there is no large buffer copy. The win is wrapper-construction churn +
+> the per-call `_offset_alias` string compute, validated by **wall-clock** (W2), not tracemalloc.
+> D-07: slice-and-mark; do NOT reconstruct via `pd.DataFrame(...)` (byte-identity risk).
+> D-06: short-circuit `start >= pos` → `return frame.iloc[pos:pos]` unchanged (bypass the view path).
+
+**Master-frame build sites to mark non-writeable** (`__init__` base load `:181-188` and
+`_resampled_frame` memoize `:264-274`). The two `self._frames[...] = ...` writes are the
+one-time, out-of-hot-loop mark sites (D-09):
+```python
+        # __init__ base load (:181-188) — mark right after the frame enters self._frames
+        for ticker in self._symbols:
+            frame = store.read_bars(ticker)
+            self._frames[(ticker, self._base_alias)] = frame      # <-- mark non-writeable here (D-09)
+            self._spans[ticker] = (frame.index[0], frame.index[-1])
+            self._prebuilt[ticker] = {
+                ts: Bar.from_row(ts, row)
+                for ts, row in frame.iterrows()                   # iterrows still works on non-writeable (Pitfall 3)
+            }
+```
+```python
+        # _resampled_frame memoize (:272-274) — mark before the return
+        resampled = base.resample(alias, label="left", closed="left").agg(_AGG)
+        self._frames[key] = resampled                             # <-- mark non-writeable here (D-09)
+        return resampled
+```
+> RESEARCH Pattern 1 + Caveat: use the public handle `frame.to_numpy(copy=False).flags.writeable = False`
+> (single float64 block ⇒ one flag covers all 5 cols), OR the lower-level `frame._mgr.blocks[0].values.flags.writeable = False`.
+> Assert `np.shares_memory(...)` at the build site if using `to_numpy(copy=False)` (not contractually zero-copy in all cases). `resample`/`searchsorted`/`iterrows`/`ta`-reads all verified to work on a non-writeable master — **no D-09 fallback needed.**
+
+**De-pandas precedent in the SAME file** — `current_bars()` (`:335-356`) was front-loaded to a
+`{ticker: {time: Bar}}` dict in a prior phase (D-07 there). Its docstring frames the
+"structural hot-loop de-pandas, bit-identical" rationale this phase mirrors for the
+history-window path (but the window must stay a `pd.DataFrame`, D-01). Copy the docstring
+tone (decision-tag-anchored WHY) when documenting the view change.
+
+**Memoize `_offset_alias`** (`:78-121`) — the free win (D-01). Two locked-direction options:
+- **Option A (smallest diff):** wrap the module fn with `@functools.cache` / `@functools.lru_cache(maxsize=None)`. `timedelta` is hashable; `lru_cache` does NOT cache exceptions, so the raise-on-unsupported guard is preserved (RESEARCH Pitfall 4).
+- **Option B:** per-feed instance dict (`self._alias_cache: dict[timedelta, str]`).
+
+> **Best in-repo memoize template = Phase 4 `_declared_hints`** (`itrader/strategy_handler/base.py`):
+> `@functools.cache def _declared_hints(cls)` replaced a hot per-call re-walk with a once-per-key
+> resolve, locked by a dedicated equivalence test (see test analog below). This is the exact
+> shape to copy for Option A. Keep the `_offset_alias` **body byte-unchanged** — only wrap.
+
+The feed already calls `_offset_alias` at `:146` (`__init__`), `:252` (`precompute`), and
+`:395` (`window`) — memoizing benefits all three.
+
+---
+
+### `tests/unit/price/test_bar_feed.py` (test, equivalence-assert) — **4-space**
+
+**Analog (primary template):** `tests/unit/portfolio/test_realised_pnl_accumulator.py` (Phase 3
+D-03) and `tests/unit/strategy/test_type_hints_equivalence.py` (Phase 4 D-05/D-07) — both are
+the established **"audit-the-invariant + dedicated equivalence drift-lock, no hot-path runtime
+guard"** pattern that D-08 reuses verbatim.
+
+**Phase 3 / Phase 4 drift-lock docstring shape to copy** (the project house style for these
+tests — decision-tag anchored, names the oracle, explicitly states "no hot-path runtime guard
+added because re-paying the cost is what the phase removes"):
+```python
+"""Equivalence drift-lock for the PERF-04 memoized type-hint resolution (D-05/D-07).
+...
+This test is the dedicated unit-level drift lock (D-07): the "oracle" here is the
+UN-cached ``get_type_hints(cls)`` direct call. It asserts (1) ... equals ... with the SAME
+keys AND order ...; (2) two calls return the SAME object (``is``) so memoization actually
+fires; (3) ...
+The byte-exact SMA_MACD oracle + the determinism double-run are the run-path drift locks;
+... This file locks the resolution itself. No hot-path runtime guard ... is added (D-05) —
+re-paying that ... cost is exactly what the phase removes.
+"""
+```
+For Phase 6, the "oracle" is `frame.iloc[start:pos].copy()` (the old data copy); the three
+D-08 assertions map to (a) content-equality, (b) read-only-raises, (c) contract stays green.
+
+**Byte-identity assert helper to reuse** — the existing contract suite in the SAME file
+already uses `pd.testing.assert_frame_equal` as the byte-identity backstop (`:167`, `:183`):
+```python
+    pd.testing.assert_frame_equal(window, daily_base_frame.iloc[2:5])
+```
+```python
+        pd.testing.assert_frame_equal(window, expected, check_freq=False)
+```
+> Reuse `assert_frame_equal` for D-08 assertion (a) (don't hand-roll a field comparison —
+> RESEARCH "Don't Hand-Roll"). Note the existing `check_freq=False` idiom on resampled frames.
+
+**Existing fixtures to reuse** (`:78-90`, `daily_store` / `daily_feed`, plus a `daily_base_frame`
+fixture used at `:167`) and the `ts()` tz-aware timestamp helper (`:49-51`). The new drift test
+co-locates here so the contract suite (assertion c) and the new (a)/(b) assertions run as one
+unit (RESEARCH Open Question 1 — treat D-08's literal `tests/unit/price_handler/feed/` path as
+directional; co-locate in `tests/unit/price/` or a sibling `test_bar_feed_window_view.py`).
+
+**LANDMINE for assertion (b)** (RESEARCH Pitfall 1 — the load-bearing exception map under
+`filterwarnings=["error"]`): assert a **direct numpy write**, NOT a pandas chained assignment.
+```python
+    # (b) the REAL read-only proof — direct numpy buffer write raises ValueError:
+    with pytest.raises(ValueError, match="read-only"):
+        view.to_numpy(copy=False)[0, 0] = 999.0
+    # do NOT assert `view.iloc[0,0] = x` raises — that fires SettingWithCopyWarning
+    # (pandas copy-guard) BEFORE the read-only buffer is touched: false confidence.
+```
+| Mutation form | Raises (NOT the proof unless noted) |
+|---------------|-------------------------------------|
+| `view.iloc[0, 0] = x` | `SettingWithCopyWarning` (pandas guard — NOT read-only proof) |
+| `view["close"].iloc[0] = x` | `FutureWarning` (chained-assignment deprecation) |
+| `view.to_numpy(copy=False)[0, 0] = x` | **`ValueError: assignment destination is read-only`** ✅ |
+| `view._mgr.blocks[0].values[0, 0] = x` | **`ValueError: assignment destination is read-only`** ✅ |
+
+Also assert no leak: re-fetch the same window and `np.array_equal(again.to_numpy(), before)`.
+
+---
+
+### `perf/runners/run_w2_sweep.py` (perf-runner, batch+transform) — **4-space**
+
+**Analog:** `perf/runners/run_w1_benchmark.py` — the sibling runner whose `--check` /
+`--baseline-out` / `--json` plumbing is the exact pattern to mirror (D-05). Mechanizes the
+gate-(b) ≥10%-at-50-symbols verdict.
+
+**`main()` arg plumbing to copy** (`run_w1_benchmark.py:224-249`):
+```python
+def main() -> None:
+    parser = argparse.ArgumentParser(description="W1 realistic benchmark")
+    parser.add_argument("--json", action="store_true",
+                        help="emit the result dict as JSON (machine-readable)")
+    parser.add_argument("--check", action="store_true",
+                        help="compare vs W1-BASELINE.json; soft regression guard (gate b)")
+    parser.add_argument("--baseline-out", metavar="PATH",
+                        help="freeze: write the run as the committed baseline JSON")
+    args = parser.parse_args()
+    if args.baseline_out and args.check:
+        print("PERF WARNING: --baseline-out and --check together compare a run "
+              "against the baseline it just wrote (delta ~0%) ...")
+    result = run_w1()
+    if args.json:
+        print(json.dumps(_to_baseline_schema(result), indent=2))
+    if args.baseline_out:
+        _write_baseline(result, args.baseline_out)
+    if args.check:
+        sys.exit(_check_regression(result, "perf/results/W1-BASELINE.json"))
+```
+> Note `run_w2_sweep.py` today already has `--json` (`:151-158`) and the `points` list — extend
+> that `main()`, don't rewrite it.
+
+**Baseline-schema builder to copy** (`run_w1_benchmark.py:150-186` — `_to_baseline_schema` /
+`_write_baseline`). W2 keys on the **50-symbol point**; RESEARCH Code Examples gives the W2
+schema shape:
+```python
+def _to_w2_baseline_schema(points: list[dict]) -> dict:
+    p50 = next(p for p in points if p["n_symbols"] == 50)
+    return {
+        "schema_version": 1,
+        "frozen_at": dt.date.today().isoformat(),
+        "metric": {"wall_clock_s_at_50": round(p50["wall_clock_s"], 2),
+                   "peak_mem_mb_at_50": round(p50["peak_mem_mb"], 2)},
+        "sweep": {"n_symbols": _N_SYMBOLS_SWEEP, "n_bars": _N_BARS, "seed": _SEED},
+        "points": points,
+    }
+```
+
+**Regression-guard to copy AND INVERT the sense** (`run_w1_benchmark.py:189-221`
+`_check_regression`). W1's guard FAILS on a slowdown beyond a band; the W2 gate REQUIRES a win
+(≥10% improvement at 50 symbols):
+```python
+def _check_w2(points, baseline_path, min_improvement_pct=10.0) -> int:
+    base = json.load(open(baseline_path))
+    base50 = base["metric"]["wall_clock_s_at_50"]
+    now50  = next(p for p in points if p["n_symbols"] == 50)["wall_clock_s"]
+    impr = (base50 - now50) / base50 * 100.0
+    print(f"W2@50 {now50:.2f}s  improvement {impr:+.1f}%  (baseline {base50:.2f}s)")
+    return 0 if impr >= min_improvement_pct else 1
+```
+> **Carry over W1's WR-02 zero/malformed-baseline soft guard** (`run_w1_benchmark.py:208-211`):
+> non-positive `base50` → `return 1` with a message, never a `ZeroDivisionError` traceback.
+> **Thermal-drift sequencing (memory `v15-perf-gateb-thermal-drift` + RESEARCH D-05 nuance):**
+> capture the before-baseline (`--baseline-out W2-BASELINE-pre.json`) on the SAME machine/session
+> as the after `--check`; commit the AFTER run as the standing `W2-BASELINE.json` (seeds Phase 5).
+
+---
+
+### `Makefile` (config, task target) — tab (Makefile recipes use tabs by format)
+
+**Analog:** the `perf-w1` / `perf-w2` / `perf-baseline` targets (`:99-112`). Add a `--check` to
+`perf-w2` and a `perf-w2-baseline` freeze target mirroring `perf-baseline`:
+```makefile
+perf-w1:
+	@echo "⏱️  W1 benchmark + regression guard (vs frozen baseline)..."
+	poetry run python -m perf.runners.run_w1_benchmark --check
+
+perf-w2:
+	@echo "📈 W2 scaling sweep {1,10,50} symbols..."
+	poetry run python -m perf.runners.run_w2_sweep
+
+perf-baseline:
+	@echo "🧊 Freezing W1 baseline → perf/results/W1-BASELINE.json..."
+	poetry run python -m perf.runners.run_w1_benchmark --baseline-out perf/results/W1-BASELINE.json
+```
+> Add the new target name to the `.PHONY` line (`Makefile:6`). The `include .env` /
+> `.EXPORT_ALL_VARIABLES` idiom and worktree `.env`-abort caveat (memory `worktree-make-test-env-abort`)
+> apply — run perf in the main checkout, or `poetry run python -m perf.runners.run_w2_sweep` directly in the worktree.
+
+---
+
+### `perf/results/W2-BASELINE.json` (data artifact, CREATE)
+
+**Analog:** `perf/results/W1-BASELINE.json` (the committed-schema artifact). Mirror its
+`schema_version` / `frozen_at` / `metric` envelope (see `_to_w2_baseline_schema` above). Commit
+the AFTER-run 50-symbol number as the standing reference (D-05; seeds Phase 5).
+
+---
+
+## Shared Patterns
+
+### Decision-tag-anchored drift-lock docstring (test + source)
+**Source:** `tests/unit/portfolio/test_realised_pnl_accumulator.py:1-20`,
+`tests/unit/strategy/test_type_hints_equivalence.py:1-19`, `bar_feed.py` `current_bars` docstring `:335-349`.
+**Apply to:** the new D-08 test AND the `window()`/build-site changes.
+Open with a triple-quoted docstring citing the decision tags (D-01/D-06/D-07/D-08/D-09), name
+the oracle (the old `.copy()`), and state explicitly that the run-path drift locks are the
+byte-exact SMA_MACD oracle + determinism double-run, while this unit test locks the slice
+itself — and that **no hot-path runtime guard is added** (re-paying the cost is what the phase
+removes). This is the project's load-bearing-comment convention (CLAUDE.md).
+
+### `pd.testing.assert_frame_equal` byte-identity backstop
+**Source:** `tests/unit/price/test_bar_feed.py:167,183`.
+**Apply to:** D-08 assertion (a) content-equality. Don't hand-roll a field-by-field compare.
+
+### `--check`/`--baseline-out`/`--json` perf-runner CLI
+**Source:** `perf/runners/run_w1_benchmark.py:224-249` (+ `_to_baseline_schema`/`_write_baseline`/`_check_regression`).
+**Apply to:** `run_w2_sweep.py` (invert the guard sense: REQUIRE a win); carry the WR-02
+zero-baseline soft guard.
+
+### numpy read-only enforcement at build (NOT a per-tick guard)
+**Source:** RESEARCH Pattern 1 (`frame.to_numpy(copy=False).flags.writeable = False`),
+verified against pandas 2.3.3 / numpy 2.2.6.
+**Apply to:** the two `self._frames[...] =` write sites in `bar_feed.py` (D-09). One mechanism
+covers D-02 view-safety (views inherit the flag) AND master immutability.
+
+---
+
+## No Analog Found
+
+None. Every file has an exact or in-file analog. The phase is deliberately scoped to one
+source method + its build sites, a co-located test mirroring two prior drift-locks, and a
+sibling perf runner.
+
+---
+
+## Metadata
+
+**Analog search scope:** `itrader/price_handler/feed/`, `tests/unit/price/`,
+`tests/unit/portfolio/`, `tests/unit/strategy/`, `perf/runners/`, `perf/results/`, `Makefile`.
+**Files scanned:** `bar_feed.py` (target), `test_bar_feed.py` (in-file contract analog),
+`test_realised_pnl_accumulator.py` (Phase 3 D-03), `test_type_hints_equivalence.py` (Phase 4
+D-05/D-07), `run_w1_benchmark.py` (perf CLI analog), `run_w2_sweep.py` (target),
+`W1-BASELINE.json` (artifact schema), `Makefile` perf block.
+**Pattern extraction date:** 2026-06-24
+</content>
+</invoke>

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-PROFILE-FINDINGS.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-PROFILE-FINDINGS.md
@@ -1,0 +1,79 @@
+---
+type: execution-finding
+phase: 06-bar-feed-window-copies-optional-slip-able
+created: 2026-06-24
+status: open
+blocks: gate-b
+feeds: next-plan (incremental-cursor window())
+---
+
+# Phase 06 — Gate (b) measurement + profile finding
+
+**TL;DR:** 06-01 (read-only window view + memoized `_offset_alias` + read-only master
+frames) is **correct and safe** but delivers **no measurable W2 wall-clock win** (~0%, within
+noise). Gate (b)'s ≥10% W2 requirement is **not met and not reachable by 06-01's levers**. The
+profile pinpoints the real PERF-06 hotspot: the **per-tick `searchsorted` + `iloc` window slice
+(~26% of W2 CPU)**, which 06-01 never touched. Recommended next step: a planned
+**monotonic incremental-cursor `window()`** that replaces the per-tick `searchsorted`.
+
+## Gate (a) — held (unchanged by this finding)
+- `tests/integration/test_backtest_oracle.py`: **134 trades / final_equity 46189.87730727451**, determinism double-run identical.
+- Full suite **1258 passed** under `poetry run pytest tests/`; `mypy --strict` clean.
+- NOTE: `make test` shows ONE failure (`test_warn_on_mid_life_gap`) — a **pre-existing** local
+  `.env` artifact (`ITRADER_DISABLE_LOGS=true` / `ITRADER_LOG_LEVEL=ERROR` exported by `make`
+  suppress the asserted WARNING). Reproduces identically at clean base 2fe879b. Not a regression.
+
+## Gate (b) — A/B measurement (same-session, thermal-controlled)
+Runner: `perf/runners/run_w2_sweep.py` (50-symbol point, n_bars=3000, seed=42). Single variable:
+`itrader/price_handler/feed/bar_feed.py` (OPT=06-01 `9168cae` vs BASE=`2fe879b`). Runner held constant.
+
+| Round (order) | OPT 50-sym | BASE 50-sym | Δ |
+|---|---|---|---|
+| R1 (BASE→OPT) | 49.79s | 50.69s | +1.8% |
+| R2 (OPT→BASE) | 50.39s | 49.91s | −0.96% |
+| **Position-averaged** | **50.09s** | **50.30s** | **+0.41%** |
+
+- Reversed round R2 cancels position/thermal bias → **not** the `v15-perf-gateb` throttling artifact (box held 97–98% CPU).
+- Run-to-run variance (~1–1.5%) swamps the signal. Peak memory essentially unchanged (214.6 vs 215.0 MB) — the per-tick copies were short-lived.
+- `--check` against the BASE-frozen baseline printed `improvement +1.8% < required 10.0% — gate (b) FAILED`.
+
+## Scalene CPU profile (W2 sweep, `--cpu-only --program-path`)
+bar_feed.py CPU **share is flat**: **BASE 28.58% → OPT 29.71%** (06-01 did not reduce it).
+
+OPT line-level (share of total program CPU):
+- L473 `pos = frame.index.searchsorted(cutoff, side="right")` — **13.2%**  ← the hotspot
+- L486 `return frame.iloc[start:pos]` (slice) — **7.9%**
+- L474 `start = max(0, pos - max_window)` — **5.3%**
+- L470 `_offset_alias(timeframe)` — **0.04%**  ← 06-01 memoization worked; was never expensive
+- `.copy()` removal — marginal (the slice cost is the `iloc`, not the copy)
+
+Other big W2 frames (context for future phases, OUT of PERF-06 scope):
+- `logger.py` per-bar logging — **~22%** (untouched)
+- `run_w2_sweep.py` harness (tracemalloc + synthetic-gen) — **~19%** measurement overhead diluting the sweep denominator
+- `strategy_handler/base.py` — ~9%
+
+## Why 06-01 missed
+The "~22% bar-feed hotspot" that motivated PERF-06 was a profiler **CPU-share** of the bar-feed
+frames. 06-01 attacked the *reducible-looking* sub-parts (alias string compute, slice copy) which
+turned out to be **negligible** (<0.1% + marginal). The dominant, inherent cost — a fresh
+`searchsorted` over the full frame index **every tick × every symbol** (50 × 3000 = 150k calls) —
+was left in place.
+
+## Recommended next plan — monotonic incremental cursor
+In a backtest the `asof` cutoff advances **monotonically** per (ticker, timeframe). Replace the
+per-tick `searchsorted(cutoff)` with a cached cursor that only steps forward from the last
+position. Expected to remove most of the ~13% searchsorted + reduce the slice path → plausibly
+≥10% W2.
+
+Must be planned (not bolted on) because it touches look-ahead safety:
+- Preserve the **7-rule bar-timing contract** (`bar_feed.py`) and the D-08 drift lock byte-for-byte.
+- Cursor must be per-(ticker, timeframe), reset/seek-safe (screener membership changes, sparse/gap
+  frames per D-04), and must NOT leak a future bar (cutoff is exclusive-right today).
+- Keep the 06-01 read-only-view guarantee on the returned slice.
+- Re-validate Gate (a) byte-exact + the `--check` ≥10% gate on a cool machine.
+
+## State of committed work (kept)
+- `9168cae` 06-01 feat (read-only view + alias memo) — **complete, SUMMARY written**. Keep: it is a real safety improvement (look-ahead enforcement), just not a perf win.
+- `f51d7c6` 06-02 Task 1 — `run_w2_sweep.py --baseline-out/--check` + Makefile `perf-w2`/`perf-w2-baseline`. **Reusable** — the gate harness is correct; it simply has no ≥10% win to certify yet.
+- **No W2-BASELINE.json frozen** (correct — nothing to freeze until the cursor fix lands).
+- 06-02 Task 2/3 (cool-machine freeze + SUMMARY) **deferred** behind the cursor fix.

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-RESEARCH.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-RESEARCH.md
@@ -1,33 +1,45 @@
-# Phase 6: Bar-Feed Window Copies (OPTIONAL, slip-able) - Research
+# Phase 6: Bar-Feed Window Copies (OPTIONAL, slip-able) — Research
 
-**Researched:** 2026-06-24
-**Domain:** pandas 2.3.3 view/copy mechanics, numpy buffer writeability, byte-identity behavior preservation
-**Confidence:** HIGH (the two CONTEXT-deferred questions were resolved by direct empirical test against the pinned `pandas 2.3.3 / numpy 2.2.6` venv, not training data)
+**Researched:** 2026-06-24 (PIVOT re-research — supersedes the view-era body below)
+**Domain:** monotonic incremental cursor over a tz-aware DatetimeIndex; pandas 2.3.3 `.iloc` slice cost; structlog eager-f-string elimination; gate-(b) re-freeze mechanics
+**Confidence:** HIGH (the two load-bearing claims — forward-cursor byte-identity to `searchsorted(side="right")` and the int64 comparison cost — are `[VERIFIED: empirical test]` against the pinned venv, not training data)
+
+> **PIVOT NOTICE.** This research is scoped to the **post-profile pivot** (D-10–D-16). The
+> view/alias copy-reduction mechanism (D-01/D-07/D-09) **already shipped in 06-01** and is **kept as
+> the foundation** (D-12). The view-era Patterns 1–3 from the previous revision of this file are
+> reproduced at the very bottom under **"SHIPPED in 06-01 (historical — do NOT re-plan)"** for the
+> record; do not turn them into tasks. The NEW primary lever is a monotonic incremental cursor
+> (D-10) + a cheaper-slice evaluation (D-11), prepped by a denominator cleanup (D-13) and gated by a
+> re-freeze + verdict (D-14/D-15) with a drift-test extension (D-16).
 
 <user_constraints>
 ## User Constraints (from CONTEXT.md)
 
-### Locked Decisions
-- **D-01 (view-primary + memoize alias; `searchsorted` stays):** Replace `frame.iloc[start:pos]` (a per-tick data copy of N×5 float64) with a **read-only view** sharing the cached master frame's buffer. Bundle the trivial free extra: memoize `_offset_alias(timeframe)`. `window()` **keeps returning a `pd.DataFrame`**. `searchsorted` left as-is. **Rejected:** monotonic per-(ticker,tf) cursor; bounds-only caching that keeps the copy; returning a bare numpy array.
-- **D-02 (hard read-only at the feed boundary; mutation fails loudly at source — NOT a global flag):** A view aliases the cached master frame; mutation would silently poison future ticks. Enforce at the source (D-09), plus a written audit and a drift test (D-08). **Rejected:** global `pd.options.mode.copy_on_write` (process-wide blast radius + byte-identity risk; mutation copies silently instead of failing loudly); audit + test only with no runtime guard.
-- **D-03 (`window()` only):** `window()` is the oracle-relevant and symbol-scaling path. `megaframe()` (deferred screener) inherits the read-only view for free; `current_bars()` is already a dict lookup. **Rejected:** also reworking `megaframe()`'s concat.
-- **D-06 (short-circuit empty; return the existing slice unchanged):** When the cutoff lands at the frame start, return `frame.iloc[pos:pos]` (size-0) **unchanged** — empty windows bypass the view + read-only machinery entirely. **Rejected:** routing empty windows through the uniform view path.
-- **D-07 (set direction; researcher pins the exact API):** Operate on the **sliced existing frame** and mark it read-only, preserving dtype / tz-aware `DatetimeIndex` / column set+order **exactly** — do **NOT** reconstruct via a new `pd.DataFrame(...)`. Byte-identity is the hard constraint. **Rejected:** pinning the precise call now (researcher's job); fully deferring.
-- **D-08 (drift/equivalence test — all three assertions):** **(a)** view content == old-copy content across sampled ticks; **(b)** mutating a returned window **RAISES** and cannot leak into the master; **(c)** the existing 7-rule bar-timing contract tests stay green. **Home:** `tests/unit/price_handler/feed/`. **Rejected:** content + contract only; leaving assertions fully to the planner.
-- **D-09 (enforce read-only at source — mark master frames non-writeable at build; subsumes the view-safety mechanism):** Mark each master frame in `self._frames` non-writeable when built (after `__init__` base load and after each `_resampled_frame` resample). Views inherit non-writeable buffers automatically. **Researcher MUST confirm** marking frames non-writeable does not break `resample`/`searchsorted`/the `ta` reads on views; **if it does, fall back** to marking the per-view buffer non-writeable. **Rejected:** audit + test only (no hard runtime guard).
-- **D-04 (gate on W2 measurable win + W1 non-regress; re-freeze W1):** Gate (b) for THIS phase = `perf-w2` sweep shows a measurable win AND W1 **does not regress**; re-freeze `W1-BASELINE.json` after. **Rejected:** holding the standard ≥5% W1 bar; a fully soft "any W2 win" with no threshold.
-- **D-05 (commit a W2 baseline + ≥10% bar at 50 symbols):** Capture `perf-w2 --json` before/after, commit a `W2-BASELINE.json` (the 50-symbol wall-clock), require a **≥10% improvement at the 50-symbol point**. **Researcher/planner** decides whether `perf-w2` needs a `--check`/`--baseline-out` flag. **Rejected:** before/after artifacts only, no committed baseline or % bar.
+### Locked Decisions (active pivot block — verbatim)
+- **D-10 (monotonic incremental-cursor `window()` — primary lever; reverses D-01's cursor rejection):** Replace the per-tick `frame.index.searchsorted(cutoff)` (13.2% of W2 CPU) with a cached **per-(ticker, timeframe) cursor** that only steps **forward** from its last position — the backtest `asof` cutoff advances monotonically per series. Cursor is **reset/seek-safe**: a ticker that leaves and re-enters the universe (screener membership), a sparse/gap frame (D-04), or any non-forward `asof` step must NOT leak a future bar — default to a **safe rebuild via `searchsorted`** on any non-monotonic step rather than trusting stale state. Exact reset-trigger/non-monotonic handling (fail-loud vs silent rebuild) is researcher/planner territory within "never leak a future bar." Cutoff stays **exclusive-right** (today's semantics). **Rejected:** "cursor is a microsecond-class gain over O(log n) searchsorted" — empirically wrong (searchsorted at 13.2%).
+- **D-11 (cursor + cheaper slice together):** Beyond the cursor, also pursue a **cheaper slice path** to cut the per-tick `iloc[start:pos]` view construction (7.9% of W2 CPU). **Byte-identity (dtype, tz-aware `DatetimeIndex`, column set + order) is the HARD constraint** (carries D-07); exact lower-level construction is researcher/planner territory. Return type **stays `pd.DataFrame`**. **Rejected:** searchsorted-only, leaving 7.9% on the table.
+- **D-12 (keep 06-01 as foundation):** 06-01 (read-only view + alias memo + non-writeable master frames, `9168cae`) is **kept** — a real look-ahead-safety improvement AND the read-only master is the foundation the cursor builds on. The D-08 drift test carries forward (extended by D-16). **Rejected:** reverting 06-01 to rebuild from base.
+- **D-13 (clean the W2/W1 denominator BEFORE gating — prep step):** **(1)** remove the per-bar `TIME EVENT` debug log (`full_event_handler.py:116` — eager f-string built every bar, discarded at INFO; ~22% W2); **(2)** de-time the **harness overhead** in `run_w2_sweep.py` (tracemalloc + synthetic-bar-gen, ~19%) — capture peak-mem in a **separate pass**, not inside the timed run. NOTE: the log line is **outside `bar_feed.py`** — accepted because it inflates the W2 denominator. **Rejected:** gating on the raw diluted sweep; lowering the threshold.
+- **D-14 (re-freeze both baselines on the cleaned engine, then gate the cursor alone):** After D-13, re-freeze **BOTH** `W1-BASELINE.json` and `W2-BASELINE.json` on the cleaned engine, on a **cool machine** (thermal-drift lesson). THEN require the **cursor alone** to clear **≥10% W2 at 50 symbols vs the cleaned W2 baseline**, with **W1 within the existing ±5% soft non-regress band**. W1 stays the **guard, not a win** (cursor adds per-series state with ~no benefit at 1 symbol). **Rejected:** single end-of-phase re-freeze conflating cleanup+cursor; holding the cursor to a W1 improvement.
+- **D-15 (ship-and-reframe fallback if <10% honestly):** If the cursor on the cleaned baseline cannot honestly clear ≥10% W2, **ship** the cursor + cleanup anyway, **record the actual W2 % achieved**, and re-frame gate (b) → **"measurable W2 win + W1 non-regress"** (no hard ≥10% kill). The phase is **OPTIONAL/slip-able**. **Rejected:** slipping/reverting on a <10% miss; keep-iterating until ≥10%.
+- **D-16 (extend the D-08 drift test — no hot-path runtime guard):** Add to the D-08 drift suite: across sampled ticks, assert the cursor's computed `(start, pos)` **==** a fresh `searchsorted(cutoff)` on the same frame, **plus** the invariant "no bar with `time` > cutoff appears in the returned window." **Zero hot-loop cost** (test-only). **Rejected:** always-on runtime `assert cursor == searchsorted` in `window()` (re-pays the searchsorted the cursor removes); an opt-in debug-flag runtime assert.
+
+### Carried forward unchanged (cursor builds on these — do NOT relitigate)
+- **D-02 / D-09** read-only view + non-writeable single-block master at the two build sites — **shipped in 06-01**, kept. The cursor returns the same read-only `iloc` view.
+- **D-06** empty-window short-circuit (`frame.iloc[pos:pos]`) — kept; the cursor still short-circuits empty.
+- **D-07** byte-identity direction (slice the existing frame + mark read-only; NEVER reconstruct via `pd.DataFrame(...)` that drifts) — the HARD constraint on D-11's cheaper slice.
+- **D-03** `window()` only; `megaframe()`/`current_bars()` out of scope.
 
 ### Claude's Discretion
-- Exact pandas 2.3.3 view-construction API under D-07, and the precise spot to mark master frames non-writeable under D-09 — within the locked direction + byte-identity + `ta`/`resample` compatibility check.
-- Shape/placement of the `_offset_alias` memoization (D-01).
-- Exact placement/shape of the drift/equivalence test within the D-08 three-assertion contract.
-- Whether to add a `--check`/`--baseline-out` flag to `perf-w2` (vs an ad-hoc before/after capture) to mechanize the D-05 ≥10% verdict.
+- Exact storage shape of the per-(ticker, alias) cursor state and the cheapest correct monotonicity comparison primitive (within byte-identity + never-leak-a-future-bar).
+- Exact reset-trigger handling: fail-loud-then-rebuild vs silent-rebuild on a non-monotonic step (within "never leak a future bar").
+- Whether D-11's cheaper slice is adopted or the phase ships cursor-only (see Open Question 1 — the cheaper-slice candidates are NOT faster; recommendation is cursor-only).
+- Exact placement/shape of the D-16 drift assertions within the existing D-08 suite.
 
 ### Deferred Ideas (OUT OF SCOPE)
-- `megaframe()` / screener concat optimization — deferred subsystem; inherits the per-symbol view for free (D-03).
-- Monotonic per-(ticker,tf) cursor replacing `searchsorted` — microsecond-class; not worth the state (D-01).
-- Removing in-strategy/adapter re-slicing (`catalog.py` `bars[start_dt:]`) — strategy/adapter concern with byte-identity risk, outside the feed (D-01).
+- `megaframe()` / screener concat optimization (deferred subsystem; inherits the per-symbol cursor for free).
+- Removing in-strategy/adapter re-slicing (`catalog.py` `bars[start_dt:]`) — byte-identity risk, outside the feed.
+- Any money / float / Decimal change; any oracle re-baseline.
 </user_constraints>
 
 <phase_requirements>
@@ -35,30 +47,70 @@
 
 | ID | Description | Research Support |
 |----|-------------|------------------|
-| PERF-06 | Reduce per-tick bar-feed window `iloc` frame copies (reusable view / cached slice bounds), preserving the look-ahead bar-timing contract — hotspot #5 (~4% W1 / ~22% W2). | **Finding A** pins the exact pandas-2.3.3 view-construction API (it turns out the `.iloc` slice on a homogeneous float64 single-block frame is *already a view* — the headline "copy" cost is NOT the `.iloc` slice itself; see the nuance in §Summary). **Finding B** confirms marking master frames non-writeable breaks nothing (`resample`/`searchsorted`/`ta` reads all pass). **Finding C** gives the exact exception types the D-08 (b) mutation assertion must target. **Validation Architecture** maps the D-08 three-assertion drift test + gate-(b) measurement. |
+| PERF-06 *(optional)* | Per-tick bar-feed window `iloc` frame copies reduced (reusable view / **cached `searchsorted` bounds**), preserving the look-ahead bar-timing contract (the 7 rules in `feed/bar_feed.py`). Hotspot #5, ~4% W1 / ~22% W2. | **Finding A** proves a forward-only cursor over `frame.index.asi8` (int64 ns) + `Timestamp.value` is **byte-identical** to `searchsorted(cutoff, side="right")` for on-grid AND mid-gap cutoffs, at **0.14 µs/tick** vs searchsorted's **4.3 µs** — removes the full 13.2% hotspot. **Finding B** measures every cheaper-slice candidate as ≥ `iloc` (recommend cursor-only — D-15 absorbs the 7.9% miss). **Finding C** confirms the `TIME EVENT` f-string is built eagerly per bar regardless of level. **Validation Architecture** maps the D-16 cursor==searchsorted drift assertions + the re-freeze gate. |
 </phase_requirements>
 
 ## Summary
 
-The two CONTEXT-deferred questions are resolved with **HIGH confidence** by direct empirical test against the pinned venv (`pandas 2.3.3`, `numpy 2.2.6`, CoW default **OFF**), not training data.
+The profile reframed the phase: 06-01's view/alias mechanism is **correct and safe but ~0% W2** (the
+`.iloc` slice on the homogeneous float64 single-block frame was already a view, and `_offset_alias`
+was never expensive). The real reducible per-tick cost is the **fresh `searchsorted` over the full
+frame index every tick × every symbol** (13.2% of W2) plus the `iloc` wrapper construction (7.9%).
 
-**The headline finding reframes the win.** On the golden-dataset master frame — a **homogeneous, single-block float64** OHLCV DataFrame with a tz-aware `DatetimeIndex` — `frame.iloc[start:pos]` in pandas 2.3.3 **already returns a view** (`_is_view == True`, `np.shares_memory(...) == True`, **no N×5 data copy of the buffer**). The PERF-BASELINE §2 #5 "each `iloc` slice copies a frame" characterization is imprecise for this homogeneous case: the positional slice does *not* deep-copy the float64 buffer; what is paid per tick is the **DataFrame/BlockManager/axis-object construction overhead** (a new `DataFrame` wrapper, a new sliced `DatetimeIndex`, BlockManager bookkeeping) — `O(1)`-ish in row count, not the `O(N×5)` buffer copy the spike implied. This still scales with `bars × symbols` (every tick, per symbol) and is the W2 ~22% cost, so the win is real — but the planner must understand the win is from **eliminating wrapper-construction churn and (the genuine free win) the per-call `_offset_alias` string compute**, not from eliminating a large data copy that mostly isn't happening on this frame shape.
+**The cursor works exactly as D-10 intends, and the byte-identity is provable.** A forward-only
+cursor that steps from its last position `while index[pos] <= cutoff` reproduces
+`searchsorted(cutoff, side="right")` **byte-for-byte** — verified across 3000 on-grid ticks and 3000
+mid-gap cutoffs (`asof - tf + tf_base` landing between bars) `[VERIFIED: empirical test]`. The crucial
+implementation detail the planner MUST pin: **compare int64 nanoseconds, not pandas Timestamps.**
+`frame.index.asi8` is a **zero-copy cached int64 ns view** of the index (`shares_memory` stable across
+calls), and `pd.Timestamp.value` is the matching UTC int64 ns (equal element-wise even for tz-aware
+indexes). A single comparison `iv_i8[pos] <= cutoff.value` costs **0.14 µs**; the same comparison
+against boxed `frame.index[pos]` Timestamps costs **2.0 µs**, and a per-tick Timestamp→datetime64
+conversion (`np.datetime64(cutoff…)`) costs **3.3 µs** — almost as much as the searchsorted it
+replaces. **The win lives entirely in the int64 path**; a naïve Timestamp-comparison cursor would
+deliver no win.
 
-**The locked design works exactly as written, with one mechanism doing two jobs.** Marking the master frame's underlying numpy buffer `writeable=False` at build time (D-09): (1) makes views inherit `writeable=False` automatically (subsumes D-02's view-safety), and (2) breaks **nothing** that matters — `resample` produces a NEW writeable frame, `index.searchsorted` works on a non-writeable index, and the `ta`-library column reads on views build fresh Series without issue. **No fallback to per-view marking is needed** (D-09's fallback path is not triggered). A view off a non-writeable master compares **byte-identical** (values, dtype, tz-aware index, column set+order; `DataFrame.equals == True`) to today's `frame.iloc[start:pos].copy()`. The empty-window short-circuit (D-06, `frame.iloc[pos:pos]`) is unaffected and stays byte-identical.
+**The cheaper slice (D-11) is not actually cheaper — recommend cursor-only.** Every alternative to
+`frame.iloc[start:pos]` measured **slower**: `pd.DataFrame(values_view_slice, index=…, columns=…)`
+reconstruction (which D-07 forbids anyway) is **9.2 µs** vs `iloc`'s **7.3 µs**, and `frame.take(...)`
+is **21 µs**. On a single-block float64 frame `iloc` is already a near-optimal view (`_is_view`,
+`shares_memory`, inherits `writeable=False`). **There is no provably-byte-identical slice cheaper than
+`iloc` on this frame shape.** The honest recommendation (per D-11's own "if it cannot be made
+byte-identical, say so") is **keep `iloc` and rely on D-15's ship-and-reframe** for the 7.9% — the
+cursor alone removes ~36% of the `window()` path (the 4.3 µs searchsorted out of the ~11.6 µs
+search+slice), which is the larger, certain lever.
 
-**The D-08 (b) mutation assertion has a landmine the planner MUST heed.** The exception raised depends on the mutation *form*, and the project runs `filterwarnings=["error"]`. A pandas-level chained assignment (`view.iloc[0,0] = x`) raises **`SettingWithCopyWarning`** (pandas' copy-detection guard fires first, BEFORE the read-only buffer is even touched) — that does NOT prove the read-only enforcement. The assertion that genuinely proves the non-writeable buffer is a **direct numpy write** to the underlying buffer (`view.to_numpy(copy=False)[0,0] = x` or `view._mgr.blocks[0].values[0,0] = x`), which raises **`ValueError: assignment destination is read-only`**. The D-08 (b) test must target the numpy `ValueError`, optionally also asserting the pandas-path raises.
+**The denominator cleanup is real engine + measurement waste, not a metric game.** The per-bar
+`self.logger.debug(f"TIME EVENT: {event.time}")` (`full_event_handler.py:116`) builds its f-string
+**eagerly in the caller** every bar; the logger's internal `isEnabledFor(DEBUG)` gate fires *after*
+the string is already formatted, so `str(event.time)` is paid per tick and discarded at the default
+INFO level (the ~22% profile share) `[VERIFIED: code read — logger.py:258-262 gates internally]`. Plain
+removal is behavior-neutral (logs are not the oracle; the line is already DEBUG-gated to never print).
+The `run_w2_sweep.py` harness mixes `tracemalloc` + synthetic-bar generation into the timed denominator
+(~19%); D-13 moves peak-mem capture to a separate pass so the timed wall-clock measures the engine.
 
-**Primary recommendation:** Implement D-01/D-07 as: in `window()`, take the existing positional slice and explicitly mark its values buffer non-writeable (belt-and-suspenders, since it already inherits read-only from the master), memoize `_offset_alias` via an instance dict (or `functools.lru_cache` on the module function), and short-circuit empty per D-06. Mark master frames non-writeable at the two build sites (`__init__` base load `:183`, `_resampled_frame` memoize `:273`). Write the D-08 test targeting the **numpy `ValueError`** for assertion (b). Mechanize gate (b) by adding a `--baseline-out`/`--check` flag pair to `run_w2_sweep.py` mirroring `run_w1_benchmark.py`, keyed on the **50-symbol point with a ≥10% bar**.
+**Primary recommendation:** (prep) D-13 — delete the `TIME EVENT` log line and de-time the W2 harness;
+re-freeze both baselines on the cleaned engine (cool machine). (core) D-10 — add a per-(ticker, alias)
+forward cursor over `frame.index.asi8` compared against `cutoff.value` (int64 ns), with a **safe
+`searchsorted` rebuild on any non-monotonic / cold / unknown step** (cursor seek-safety), returning the
+same read-only `iloc[start:pos]` view as today. **D-11 — keep `iloc` (cursor-only; the cheaper-slice
+candidates are all slower).** D-16 — extend the existing `tests/unit/price/test_bar_feed.py` D-08 suite
+with `cursor (start,pos) == fresh searchsorted` across sampled ticks plus a no-future-bar assertion,
+driving reset/cold/gap/churn cases. (gate) D-14/D-15 — the existing 06-02 `--check`/`--baseline-out`
+harness is reusable as-is; the only change D-13 forces is re-freezing the W2 baseline on the cleaned
+engine.
 
 ## Architectural Responsibility Map
 
 | Capability | Primary Tier | Secondary Tier | Rationale |
 |------------|-------------|----------------|-----------|
-| Per-tick history-window slice | Data engine / `price_handler.feed` | — | `BacktestBarFeed.window()` is the single look-ahead-safe slice seam (module docstring); the read-only guarantee belongs in the feed, never in consumers (D-02). |
-| Master-frame immutability (read-only buffer) | Data engine / `price_handler.feed` build sites | — | The `self._frames` build sites (`__init__` `:181-188`, `_resampled_frame` `:256-274`) are the one-time, out-of-hot-loop place to mark non-writeable (D-09). |
-| Indicator compute over the window | Strategy engine / `indicators` | — | `catalog.py` reads `bars[col]` / `bars[start_dt:][col]` and builds NEW Series — pure consumer, never mutates (verified read-only audit, D-02). |
-| Behavior-preservation proof | Test tier / `tests/unit/price_handler/feed/` | `tests/unit/price/test_bar_feed.py` (existing contract tests) | D-08 three-assertion drift test; the existing `assert_frame_equal` contract tests are the byte-identity backstop. |
-| Gate-(b) measurement | Perf harness / `perf/runners/` | `perf/results/` | W2 sweep + committed `W2-BASELINE.json` (D-05); W1 non-regression guard (D-04). |
+| Per-tick history-window cutoff resolution (the cursor) | Data engine / `price_handler.feed` | — | `BacktestBarFeed.window()` is the single look-ahead-safe slice seam; the cursor state lives in the feed instance, never in a consumer (D-10). |
+| Cursor state storage (per-(ticker, alias) last position) | Data engine / `price_handler.feed` instance dict | — | Mirrors the existing per-(ticker, alias) `self._frames` keying — the feed already holds per-series state. |
+| Read-only window slice (kept from 06-01) | Data engine / `price_handler.feed` | — | The cursor returns the same `frame.iloc[start:pos]` read-only view off the locked single-block master (D-12). |
+| Per-bar flow-log waste removal | Event engine / `events_handler.full_event_handler` | — | The `TIME EVENT` debug log is in the dispatcher, not the feed; D-13 accepts the one-line out-of-`bar_feed.py` scope. |
+| Harness denominator hygiene | Perf harness / `perf/runners/run_w2_sweep` | — | tracemalloc + synth-gen are measurement scaffolding, not engine — de-time them (D-13). |
+| Cursor correctness proof | Test tier / `tests/unit/price/test_bar_feed.py` | byte-exact oracle (gate a) | D-16 extends the D-08 suite; the oracle is the run-path backstop (D-14). |
+| Gate-(b) re-freeze + verdict | Perf harness / `perf/runners/` + `perf/results/` | — | The 06-02 `--check`/`--baseline-out` harness re-freezes on the cleaned engine (D-14/D-15). |
 
 ## Standard Stack
 
@@ -67,297 +119,440 @@ No new external packages. This phase uses only the **already-pinned, already-ins
 ### Core
 | Library | Version | Purpose | Why Standard |
 |---------|---------|---------|--------------|
-| pandas | 2.3.3 | The frame/window type; `.iloc` slice, `resample`, `index.searchsorted` | Already the primary OHLCV structure across all handlers (CLAUDE.md); pinned, CoW-off transition release. `[VERIFIED: venv import]` |
-| numpy | 2.2.6 | Underlying buffer; `flags.writeable = False` is the read-only mechanism | `pandas 2.3.3` requires `numpy>=2.2.3,<2.3`; `2.2.6` is what is installed. `[VERIFIED: venv import]` |
-| ta | 0.11.0 | Indicator compute over the window (`catalog.py`) — the read-only consumer to keep working | Confirmed reads-only on views (Finding B). `[CITED: CLAUDE.md tech stack]` |
-
-> **Note on the pinned numpy:** CLAUDE.md/Technology-Stack lists `numpy >=2.2.3,<2.3`. The installed wheel is **2.2.6** (verified via `import numpy`), NOT a hypothetical 2.2.3. All empirical findings below are against 2.2.6. `[VERIFIED: venv import]`
+| pandas | 2.3.3 | Frame/window type; `index.asi8` (int64 ns view), `Timestamp.value`, `.iloc` slice, `searchsorted` (rebuild path) | Already the primary OHLCV structure; pinned. `[VERIFIED: venv import]` |
+| numpy | 2.2.6 | int64 ns comparison backing the cursor; read-only buffer flag (06-01) | `pandas 2.3.3` requires `numpy>=2.2.3,<2.3`; `2.2.6` installed. `[VERIFIED: venv import]` |
+| structlog | 24.4.0 | The logger whose eager-f-string caller waste D-13 removes | `ITraderStructLogger` gates internally; the f-string is built by the caller. `[VERIFIED: code read]` |
 
 ### Supporting
 | Library | Version | Purpose | When to Use |
 |---------|---------|---------|-------------|
-| functools.lru_cache (stdlib) | — | Optional memoization of `_offset_alias` (D-01) | If memoizing at the module-function level; an instance `dict` is the alternative (the feed already holds per-`(ticker, alias)` state). |
+| stdlib (no new import expected) | — | Cursor is a plain `dict[tuple[str,str], int]` + int64 compares | No new dependency; the feed already imports `numpy`/`pandas`. |
 
 ### Alternatives Considered
 | Instead of | Could Use | Tradeoff |
 |------------|-----------|----------|
-| `numpy.flags.writeable = False` on the values block | `pd.options.mode.copy_on_write = True` | **Rejected by D-02** — process-wide blast radius, and CoW makes a mutating consumer *silently copy* instead of *failing loudly*. The numpy-flag approach is the locked direction. |
-| Explicit per-view re-marking | Rely solely on inherited read-only from the master | Inheritance already works (Finding B: views off a non-writeable master have `writeable == False`). A belt-and-suspenders explicit re-mark on the slice costs `O(1)` and documents intent — recommended but not strictly required. |
+| `frame.index.asi8` int64 compare | `frame.index[pos]` pandas-Timestamp compare | **Rejected** — 2.0 µs vs 0.14 µs; a Timestamp-comparison cursor delivers no win (the boxing cost ≈ the searchsorted it replaces). `[VERIFIED: timeit]` |
+| `frame.index.asi8` int64 compare | per-tick `np.datetime64(cutoff)` conversion + datetime64 array compare | **Rejected** — the conversion alone is 3.3 µs/tick (≈ searchsorted's 4.3 µs). Use `cutoff.value` (O(1) int64 attribute) instead. `[VERIFIED: timeit]` |
+| `frame.iloc[start:pos]` slice (D-11 cheaper path) | `pd.DataFrame(values[start:pos], index=…, columns=…)` | **Rejected** — 9.2 µs vs 7.3 µs AND D-07 forbids reconstruction (drift risk). `[VERIFIED: timeit + assert_frame_equal]` |
+| `frame.iloc[start:pos]` slice | `frame.take(range(start,pos))` | **Rejected** — 21 µs (3× slower). `[VERIFIED: timeit]` |
 
 **Installation:** None. No package added or changed.
 
 **Version verification:**
 ```
 pandas 2.3.3   [VERIFIED: poetry run python -c "import pandas; print(pandas.__version__)"]
-numpy  2.2.6   [VERIFIED: poetry run python -c "import numpy;  print(numpy.__version__)"]
-CoW default: False   [VERIFIED: pd.options.mode.copy_on_write]
+numpy  2.2.6   [VERIFIED: import numpy]
+index.asi8 dtype int64 (UTC ns), zero-copy cached (shares_memory across calls) [VERIFIED]
+Timestamp.value == index.asi8[k] for tz-aware index, all k                     [VERIFIED]
 ```
 
 ## Package Legitimacy Audit
 
-> Not applicable — this phase installs **no external packages**. All libraries used (`pandas`, `numpy`, `ta`, stdlib `functools`) are already in `pyproject.toml`/`poetry.lock` and verified present in the venv. No registry/slopcheck pass required.
+> Not applicable — this phase installs **no external packages**. All libraries used (`pandas`,
+> `numpy`, `structlog`, stdlib) are already in `pyproject.toml`/`poetry.lock` and verified present in
+> the venv. No registry/slopcheck pass required.
 
 ## Architecture Patterns
 
-### System Architecture Diagram (the per-tick window path)
+### System Architecture Diagram (the per-tick window path, post-cursor)
 
 ```
-TimeEvent(T) ─► generate_bar_event ─► BarEvent(bars stamped T)
+TimeEvent(T) ─► EventHandler._dispatch ──[D-13: DELETE the eager TIME-EVENT debug f-string]──►
+                                            generate_bar_event ─► BarEvent(bars stamped T)
                                             │
                                             ▼
               strategies_handler.calculate_signals  (per subscribed strategy, per ticker)
-                                            │  feed.window(ticker, tf, max_window, asof=T)   [:125, and :294-295 pair]
+                                            │  feed.window(ticker, tf, max_window, asof=T)
                                             ▼
-        ┌────────────── BacktestBarFeed.window() ──────────────┐
-        │ 1. alias = _offset_alias(tf)        ◄── MEMOIZE (D-01)│
-        │ 2. frame = self._resampled_frame(ticker, alias)      │
-        │      └─ cached master frame in self._frames          │
-        │         (marked writeable=False at build, D-09)      │
-        │ 3. cutoff = asof - tf + base_tf                      │
-        │ 4. pos = frame.index.searchsorted(cutoff, "right")   │
-        │ 5a. if empty (start==pos): return frame.iloc[pos:pos]│ ◄── SHORT-CIRCUIT (D-06)
-        │ 5b. else: view = frame.iloc[start:pos]               │ ◄── ALREADY A VIEW on float64 single block
-        │          (inherits writeable=False; optionally       │     (no buffer copy; D-07)
-        │           re-mark the view buffer non-writeable)     │
-        └──────────────────────┬───────────────────────────────┘
-                               ▼  pd.DataFrame (read-only view, byte-identical to old copy)
-              strategy.evaluate(window) ── self.bars = window; self.now = window.index[-1]  [base.py:368-369]
-                               │
-                               ▼  handle.repopulate(self.bars, now, tf)
-              adapter.compute(bars, col, ...) ── reads bars[col] / bars[start_dt:][col]      [catalog.py]
-                               │                  builds NEW Series (read-only, never mutates view)
-                               ▼
-                          SignalEvent  (look-ahead contract preserved end-to-end)
+        ┌────────────── BacktestBarFeed.window() (post-cursor) ─────────────────┐
+        │ 1. alias = _offset_alias(tf)            ◄── memoized (06-01, kept)     │
+        │ 2. frame = self._resampled_frame(...)   ◄── locked single-block master │
+        │ 3. cutoff = asof - tf + base_tf         ◄── exclusive-right, unchanged  │
+        │ 4. cutoff_i8 = cutoff.value             ◄── O(1) int64 ns              │
+        │ 5. CURSOR (D-10):                                                       │
+        │    key=(ticker,alias); last=self._cursor.get(key)                      │
+        │    if last is None or cutoff_i8 < self._cursor_cut[key]:  ◄── NON-MONO │
+        │        pos = searchsorted(cutoff,"right")   # SAFE REBUILD (never leak) │
+        │    else:                                                               │
+        │        pos = last                                                      │
+        │        while pos < n and iv_i8[pos] <= cutoff_i8: pos += 1  ◄── 0.14µs │
+        │    self._cursor[key]=pos; self._cursor_cut[key]=cutoff_i8              │
+        │ 6. start = max(0, pos - max_window)                                    │
+        │ 7a. if start >= pos: return frame.iloc[pos:pos]   ◄── empty (D-06)     │
+        │ 7b. else: return frame.iloc[start:pos]            ◄── read-only view   │
+        │            (KEEP iloc — D-11 cheaper-slice candidates all slower)      │
+        └────────────────────────┬───────────────────────────────────────────────┘
+                                 ▼  pd.DataFrame (read-only view, byte-identical to today)
+              strategy.evaluate(window) ── self.bars = window; self.now = window.index[-1]
+                                 │
+                                 ▼  adapter.compute(...) reads-only (look-ahead contract preserved)
 ```
 
 ### Component Responsibilities
 | Component | File | Change in this phase |
 |-----------|------|----------------------|
-| `BacktestBarFeed.window()` | `bar_feed.py:360-399` | Memoize `_offset_alias`; short-circuit empty (D-06); return read-only view; mark view buffer non-writeable. **4-space indent.** |
-| `BacktestBarFeed.__init__` base load | `bar_feed.py:181-188` | Mark each master frame `writeable=False` after `store.read_bars` and before `_spans`/`_prebuilt` build (D-09). |
-| `BacktestBarFeed._resampled_frame` | `bar_feed.py:256-274` | Mark the newly-resampled frame `writeable=False` before `self._frames[key] = resampled` (D-09). |
-| `_offset_alias` (module fn) | `bar_feed.py:78-121` | Optionally `@lru_cache`; OR memoize in the feed. |
-| Consumers (audit only) | `strategies_handler.py:125,294-295`; `base.py:368-369`; `catalog.py`; `handle.py` | **No edits** — read-only audit evidence (D-02). Tab-indent; do NOT touch. |
+| `BacktestBarFeed.window()` | `bar_feed.py:427-486` | Add the forward cursor (D-10) replacing the per-tick `searchsorted`; keep the `iloc[start:pos]` read-only view (D-11 cursor-only). **4-space indent.** |
+| `BacktestBarFeed.__init__` | `bar_feed.py:199-263` | Initialize the cursor state dicts (`self._cursor: dict[tuple[str,str], int] = {}`, `self._cursor_cut: dict[tuple[str,str], int] = {}`); optionally cache `frame.index.asi8` per frame if not re-derived per call. **4-space.** |
+| `EventHandler._dispatch` | `full_event_handler.py:114-116` | **Delete** the `if event.type is EventType.TIME: self.logger.debug(f"TIME EVENT: {event.time}")` block (D-13). **TAB indent — never normalize.** |
+| `run_w2_sweep._run_point` | `run_w2_sweep.py:95-131` | De-time: move `tracemalloc.start()`/`get_traced_memory()` OUT of the wall-clock timed region — capture peak-mem in a separate pass (D-13). **4-space.** |
+| D-08 drift suite | `tests/unit/price/test_bar_feed.py:343-372` | Extend with D-16 `cursor==searchsorted` + no-future-bar assertions, driving cold/gap/churn cases. **4-space.** |
+| `perf/results/{W1,W2}-BASELINE.json` | data artifacts | Re-freeze BOTH on the cleaned engine, cool machine (D-14). |
 
-### Pattern 1: Mark a frame's values buffer non-writeable (D-09)
-**What:** Set the underlying numpy block's `writeable` flag to `False` after a frame is built.
-**When to use:** At the two `self._frames` write sites (`__init__` base load, `_resampled_frame` memoize).
+### Pattern 1: Monotonic forward cursor over int64 ns (D-10) — THE primary lever
+**What:** Replace the per-tick `frame.index.searchsorted(cutoff, side="right")` with a forward-only
+step from the cursor's last position, comparing **int64 nanoseconds** (not pandas Timestamps).
+**When to use:** The single `window()` cutoff-resolution step, per (ticker, timeframe).
 **Example:**
 ```python
-# Source: empirically verified against pandas 2.3.3 / numpy 2.2.6
-# After: frame = store.read_bars(ticker)   (or)  resampled = base.resample(...).agg(_AGG)
-# Mark the single float64 block non-writeable so views inherit read-only and any
-# in-place mutation of the cached master fails loudly (D-09). Homogeneous float64
-# OHLCV => single block => one flag set covers all 5 columns.
-frame.to_numpy(copy=False).flags.writeable = False        # [VERIFIED: empirical test]
-# (Equivalent lower-level form: frame._mgr.blocks[0].values.flags.writeable = False —
-#  prefer the public to_numpy(copy=False) handle; planner picks the exact accessor.)
-```
-> **Caveat the planner must verify at implement time:** `to_numpy(copy=False)` returns the underlying buffer for a single-block homogeneous frame, but pandas does NOT *contractually* guarantee zero-copy for `to_numpy` in all cases. The empirical test confirmed `np.shares_memory(frame.to_numpy(copy=False), block.values) == True` for this frame shape. The planner should assert `shares_memory` (or use the `_mgr.blocks[0].values` accessor directly) at the build site, and the D-08 test proves the flag actually took effect end-to-end. `[VERIFIED: empirical test]`
+# Source: empirically verified byte-identical to searchsorted(side="right") on pandas 2.3.3.
+# State (in __init__): self._cursor: dict[tuple[str,str], int] = {}
+#                      self._cursor_cut: dict[tuple[str,str], int] = {}
+key = (ticker, alias)
+n = len(frame.index)
+iv_i8 = frame.index.asi8          # zero-copy cached int64 ns view (UTC); stable across calls
+cutoff_i8 = cutoff.value          # O(1) int64 ns (Timestamp.value == asi8[k] for tz-aware) [VERIFIED]
 
-### Pattern 2: Return a read-only view from `window()` (D-01/D-07)
-**What:** Take the positional slice on the (already non-writeable) master and return it directly; optionally re-mark.
-**Example:**
+last_pos = self._cursor.get(key)
+last_cut = self._cursor_cut.get(key)
+if last_pos is None or last_cut is None or cutoff_i8 < last_cut:
+    # COLD or NON-MONOTONIC (universe re-entry, backwards/jumped asof, gap-frame replacement):
+    # SAFE FULL REBUILD via searchsorted — never trust stale state, never leak a future bar (D-10).
+    pos = int(frame.index.searchsorted(cutoff, side="right"))
+else:
+    pos = last_pos
+    while pos < n and iv_i8[pos] <= cutoff_i8:   # 0.14 µs/step; O(1) amortized in backtest
+        pos += 1
+self._cursor[key] = pos
+self._cursor_cut[key] = cutoff_i8
+```
+> **Byte-identity proof obligation (D-16):** verified `pos` equals
+> `int(frame.index.searchsorted(cutoff, side="right"))` for 3000 on-grid ticks AND 3000 mid-gap
+> cutoffs (`asof - tf + tf_base` landing between bars), using `asi8` + `Timestamp.value`. The
+> `<=` (not `<`) preserves **exclusive-right** semantics: `searchsorted(side="right")` returns the
+> insertion point AFTER equal elements, i.e. the count of `index <= cutoff` — exactly what the
+> forward `while index[pos] <= cutoff` loop computes. `[VERIFIED: empirical test]`
+
+> **`asi8` caveat the planner must verify at implement time:** `frame.index.asi8` returned the same
+> underlying array across calls (`np.shares_memory == True`) in the test, so re-deriving it per call
+> is cheap; but pandas does not contractually guarantee this. If the planner wants belt-and-suspenders,
+> cache `iv_i8` alongside the master frame in `self._frames`-adjacent state at build time. Either way
+> the int64 array is read-only-buffer-safe (06-01 locked the values block, not the index; the index
+> int64 backing is separate and reads fine). `[VERIFIED: shares_memory stable across calls]`
+
+### Pattern 2: Reset / seek-safety — the correctness crux (D-10)
+**What:** Detect any non-monotonic / cold / unknown step and fall back to a full `searchsorted`
+rebuild, so a stale cursor can never under-count and leak a future bar.
+
+| Trigger | Detection | Response |
+|---------|-----------|----------|
+| **First call (cold cursor)** | `key not in self._cursor` | Full `searchsorted` rebuild; seed `self._cursor[key]`. |
+| **Backwards / jumped `asof`** | `cutoff_i8 < self._cursor_cut[key]` (the last cutoff went backwards) | Full `searchsorted` rebuild from the new cutoff (a forward-only loop would NOT walk back and would over-count → could leak a future bar). |
+| **Universe re-entry (screener churn)** | Same key seen again after a gap — but the cutoff still advances monotonically, so the **forward step is still correct**; no special handling needed beyond the backwards-cutoff guard. (Re-entry does not reset `asof`; the cutoff at re-entry is ≥ the last seen cutoff.) | Forward step (no reset) — verified safe because monotonicity is on the **cutoff**, not on call contiguity. |
+| **Sparse / gap frame (D-04)** | Cutoff lands in a gap with no bar | Forward step naturally stops at the correct `pos` (the `<=` loop handles gaps; mid-gap byte-identity verified). No reset. |
+| **Frame replaced (lazy resample memoizes a NEW frame for the same key)** | The cursor key is `(ticker, alias)`; a lazy resample for a *new* alias is a *different* key, so the cursor starts cold for it — no stale-frame hazard. The base/already-memoized frame for an existing key is never mutated (06-01 invariant). | No reset needed; the key→frame mapping is stable per alias. |
+
+**Recommendation: silent safe-rebuild, not fail-loud.** A non-monotonic cutoff in a backtest is not a
+bug to crash on — the screener/membership path can legitimately re-issue an earlier `asof` for a
+re-entering ticker, and the `tf > base_tf` resampled cutoff can step in non-uniform increments. A
+silent `searchsorted` rebuild is **always correct** (it is exactly today's behavior) and **never
+leaks** (it recomputes from scratch). The D-16 test proves equivalence; a hard runtime assert is
+explicitly rejected (D-16 — it re-pays the searchsorted). The cursor is a *fast path with a correct
+fallback*, not a trust-the-state optimization.
+
+> **The canonical never-leak invariant:** `pos` is always `count(index <= cutoff)`. The forward loop
+> can only *under-run* if it starts from a `last_pos` computed against a *larger* cutoff — which is
+> exactly the `cutoff_i8 < last_cut` case the rebuild guard catches. With the guard, `pos` is provably
+> equal to `searchsorted(side="right")` on every reachable cutoff. `[VERIFIED]`
+
+### Pattern 3: D-13 denominator cleanup (prep — runs BEFORE the cursor)
+**3a — remove the per-bar `TIME EVENT` log (engine waste):**
 ```python
-# Source: bar_feed.py:395-399 today + empirical pandas 2.3.3 behavior
-alias = self._alias_for(timeframe)              # MEMOIZED (D-01) — see Pattern 3
-frame = self._resampled_frame(ticker, alias)
-cutoff = asof - timeframe + self._base_timeframe
-pos = int(frame.index.searchsorted(cutoff, side="right"))
-start = max(0, pos - max_window)
-if start >= pos:                                # D-06 empty short-circuit (unchanged semantics)
-    return frame.iloc[pos:pos]
-view = frame.iloc[start:pos]                    # ALREADY a view on the float64 single block
-# view already inherits writeable=False from the master; explicit re-mark documents intent:
-view.to_numpy(copy=False).flags.writeable = False   # [VERIFIED: harmless, idempotent on a view]
-return view
+# itrader/events_handler/full_event_handler.py:114-116  (TAB indent — do NOT normalize)
+# DELETE these three lines:
+#     if event.type is EventType.TIME:
+#         # D-21: per-tick flow log demoted from INFO to DEBUG.
+#         self.logger.debug(f"TIME EVENT: {event.time}")
+# The f-string f"TIME EVENT: {event.time}" is built EAGERLY by Python before .debug() runs;
+# the logger's internal isEnabledFor(DEBUG) gate (logger.py:260) fires AFTER the string is
+# already formatted, so str(event.time) is paid every bar and discarded at default INFO.
+# Plain removal is behavior-neutral: the line never prints at INFO; logs are NOT the oracle.
 ```
-> **Byte-identity guarantee (the hard constraint):** verified that `view` (off a non-writeable master) and today's `frame.iloc[start:pos].copy()` satisfy `np.array_equal(values)`, `dtypes.equals`, `index.equals` (incl. `tz == UTC`), identical column set+order, and `DataFrame.equals(...) == True`. `[VERIFIED: empirical test]`
+**Recommendation: plain removal, not a lazy/guarded log.** The line is *already* DEBUG-gated (it never
+prints at the default INFO level), so there is no observable behavior to preserve. A "lazy" guard
+(`if self.logger.isEnabledFor(...)`) would keep a per-bar branch for zero benefit; removal is cleaner
+and matches D-13's "genuine engine waste" framing. `[VERIFIED: code read — logger.py:258-262]`
 
-### Pattern 3: Memoize `_offset_alias` (D-01, the free win)
-**What:** Avoid the per-call string compute in `_offset_alias`.
-**Example (two options — Claude's discretion):**
+**3b — de-time the W2 harness (`run_w2_sweep._run_point`):**
 ```python
-# Option A — module-level lru_cache (timedelta is hashable):
-import functools
-
-@functools.lru_cache(maxsize=None)
-def _offset_alias(timeframe: timedelta) -> str:
-    ...  # body unchanged
-
-# Option B — per-feed instance dict (the feed already holds per-(ticker,alias) state):
-# self._alias_cache: dict[timedelta, str] = {}
-def _alias_for(self, timeframe: timedelta) -> str:
-    a = self._alias_cache.get(timeframe)
-    if a is None:
-        a = _offset_alias(timeframe)
-        self._alias_cache[timeframe] = a
-    return a
+# perf/runners/run_w2_sweep.py:119-125  (4-space). Today tracemalloc wraps the timed run:
+#     tracemalloc.start(); t0 = perf_counter(); system.run(...); wall = perf_counter()-t0
+#     _cur, peak = tracemalloc.get_traced_memory(); tracemalloc.stop()
+# tracemalloc instruments EVERY allocation -> inflates wall_clock_s (the ~19% denominator).
+# D-13: time the engine CLEAN, then capture peak-mem in a SEPARATE pass:
+def _run_point(n_symbols, tmpdir):
+    frames = make_synthetic_ohlcv(...)   # synth-gen OUTSIDE the timed region (already is)
+    ...wire system...
+    # Pass 1 — CLEAN wall-clock (no tracemalloc):
+    t0 = time.perf_counter()
+    system.run(print_summary=False)
+    wall_clock_s = time.perf_counter() - t0
+    # Pass 2 — peak memory (re-wire a fresh system; tracemalloc instrumented):
+    system2 = _wire(...)                 # identical wiring, fresh state
+    tracemalloc.start()
+    system2.run(print_summary=False)
+    _cur, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    peak_mem_mb = peak / (1024*1024)
+    return {"n_symbols": n_symbols, "wall_clock_s": wall_clock_s, "peak_mem_mb": peak_mem_mb}
 ```
-> The feed already calls `_offset_alias` at `__init__:146`, `precompute:252`, and `window:395`. Option A is the smallest diff and keeps the function self-contained; Option B avoids a process-global cache across multiple feeds. Either is correct. `[ASSUMED: stylistic — defer to planner]`
+> **Why a second run, not just moving the calls:** `tracemalloc` slows everything between
+> `start()`/`stop()`; you cannot get a clean wall-clock and a peak-mem from the *same* timed run. The
+> two-pass structure (clean timed run + separate instrumented run) is the standard fix. The synthetic
+> frames + CSVs are generated ONCE and reused across both passes (the existing `tmpdir`/`csv_paths`
+> already support this). Keep `seed=42` for determinism. `[ASSUMED: standard tracemalloc practice —
+> planner pins the exact re-wire helper]`
+
+### Pattern 4: Gate-(b) re-freeze + verdict (D-14/D-15) — the 06-02 harness is reusable as-is
+The 06-02 `run_w2_sweep.py --check/--baseline-out` (commit `f51d7c6`) is **correct and reusable**:
+`_check_w2` keys on `wall_clock_s_at_50`, requires `impr >= 10.0%` (inverted guard), carries the WR-02
+zero-baseline soft guard. **The only change D-13 forces** is that the W2 baseline must be **re-frozen
+on the cleaned engine** (after the log removal + harness de-timing land), because the de-timed harness
+produces a *different, smaller* `wall_clock_s_at_50` than the diluted one — a pre-cleanup baseline
+would mis-credit the delta.
+
+**Sequencing (D-14, cool machine):**
+1. Land D-13 (log removal + harness de-time) on the engine.
+2. On a cool machine, capture the BEFORE baseline on the **cleaned engine without the cursor**
+   (`--baseline-out perf/results/W2-BASELINE.json`) — this is the cursor's denominator.
+3. Land the cursor (D-10).
+4. `run_w2_sweep.py --check` (against the step-2 baseline) must print `improvement >= +10.0%` at 50
+   symbols, exit 0 → the **cursor alone** cleared the bar (cleanup isolated into the baseline).
+5. `make perf-w1 --check` stays within the ±5% soft band (W1 guard, not a win — D-14).
+6. Re-freeze BOTH: commit the cursor-on `W2-BASELINE.json` (the standing reference, seeds Phase 5) and
+   re-freeze `W1-BASELINE.json` (`make perf-baseline`).
+7. **D-15 fallback:** if step 4 prints `< +10.0%` honestly, **ship anyway** — record the actual W2 %
+   in the SUMMARY, commit the baselines, re-frame gate (b) → "measurable W2 win + W1 non-regress". No
+   revert.
+
+> **The de-timing changes nothing in `--check`'s code path** — `_check_w2` still reads
+> `wall_clock_s_at_50` from the points list; it does not know whether tracemalloc ran. The only
+> requirement is that BOTH the baseline and the check-run measure with the *same* (de-timed) harness.
+> `[VERIFIED: code read — run_w2_sweep.py:181-209]`
 
 ### Anti-Patterns to Avoid
-- **Reconstructing the window via `pd.DataFrame(view.values, index=..., columns=...)`** — explicitly rejected by D-07; risks tz/dtype/column-order drift → breaks byte-identity. Slice + mark only.
-- **Enabling `pd.options.mode.copy_on_write`** — rejected by D-02; makes mutation copy *silently* instead of failing loudly, and is process-wide.
-- **Asserting D-08 (b) against `SettingWithCopyWarning`** — that proves pandas' copy-detection, NOT the read-only buffer. Target the numpy `ValueError` (see Finding C / Pitfall 1).
-- **Routing the empty window through the view path** — rejected by D-06; pointless read-only marking on a zero-row buffer.
-- **"Tidying" the consumer slices in `catalog.py`** — byte-identity risk, out of scope (D-01 deferred).
-- **Normalizing indentation** — `bar_feed.py` is **4-space**; consumers are **tab**. This phase edits only the 4-space file.
+- **Comparing pandas Timestamps in the cursor loop** — `frame.index[pos] <= cutoff` is 2.0 µs/step
+  (boxing); the int64 `iv_i8[pos] <= cutoff.value` path is 0.14 µs. A Timestamp-comparison cursor
+  delivers ~no win. Use `asi8` + `.value`.
+- **Converting the cutoff to `np.datetime64` per tick** — 3.3 µs/tick, ≈ the searchsorted it replaces.
+  Use the O(1) `Timestamp.value` int64 attribute.
+- **A forward-only cursor with no backwards-cutoff guard** — under-counts on a re-issued earlier
+  `asof` → **leaks a future bar** (the slice would include bars stamped > cutoff). The
+  `cutoff_i8 < last_cut` rebuild guard is mandatory (Pattern 2).
+- **Reconstructing the window via `pd.DataFrame(values[start:pos], …)` for D-11** — slower (9.2 vs 7.3
+  µs) AND forbidden by D-07 (drift risk). Keep `iloc`.
+- **An always-on runtime `assert cursor == searchsorted` in `window()`** — re-pays the searchsorted the
+  cursor removes (rejected by D-16). Prove equivalence in the test only.
+- **A lazy/guarded `TIME EVENT` log instead of removal** — keeps a per-bar branch for zero benefit; the
+  line is already DEBUG-gated and never prints (D-13 — plain removal).
+- **Normalizing indentation** — `bar_feed.py`/`run_w2_sweep.py` are **4-space**; `full_event_handler.py`
+  is **TAB**. The D-13 log-line deletion is in the TAB file — match it.
 
 ## Don't Hand-Roll
 
 | Problem | Don't Build | Use Instead | Why |
 |---------|-------------|-------------|-----|
-| Zero-copy positional slice | A manual numpy-stride view + re-wrap in a DataFrame | `frame.iloc[start:pos]` (already a view on a float64 single block) | pandas already returns a view here; re-wrapping risks index/tz/dtype drift (D-07). |
-| Read-only enforcement | A per-tick runtime guard / wrapper class intercepting `__setitem__` | numpy `flags.writeable = False` at build (D-09) | One flag at build time, zero hot-loop cost; mutation fails loudly at the C level. |
-| Byte-identity check | A bespoke field-by-field comparison | `pd.testing.assert_frame_equal` / `DataFrame.equals` | The existing contract tests already use `assert_frame_equal` (`test_bar_feed.py:167,183`). |
+| int64 ns view of the index | Manual `[t.value for t in index]` per tick | `frame.index.asi8` (zero-copy cached int64 view) | Already materialized once; per-call comprehension is O(n) and defeats the cursor. |
+| cutoff → int64 ns | `np.datetime64(cutoff.tz_convert("UTC").tz_localize(None))` | `cutoff.value` (Timestamp attribute) | The conversion is 3.3 µs; `.value` is O(1) and equals `asi8[k]` for tz-aware indexes. `[VERIFIED]` |
+| Cheaper window slice | A numpy-stride view re-wrapped in a DataFrame, or `pd.DataFrame(values, index, columns)` | `frame.iloc[start:pos]` (kept) | Every alternative measured slower AND risks tz/dtype/column drift (D-07). `iloc` on a single block is already a view. `[VERIFIED]` |
+| Cursor==searchsorted proof | An always-on runtime assert | A dedicated drift test (D-16) | Runtime assert re-pays the cost; the test proves it once. |
+| Clean wall-clock under tracemalloc | Subtracting an estimated tracemalloc overhead | Two-pass measurement (clean timed run + separate instrumented run) | tracemalloc's per-allocation cost is not a fixed subtractable constant. |
 
-**Key insight:** The pandas/numpy primitives already do everything D-01/D-09 needs — the work is *wiring the flag at the right build sites* and *proving it with a test*, not building machinery.
+**Key insight:** The pandas/numpy primitives already do everything D-10 needs — `asi8` + `Timestamp.value`
+give a 30×-cheaper-than-searchsorted comparison. The work is *wiring the forward step with a correct
+rebuild guard* and *proving byte-identity*, not building machinery. D-11's "cheaper slice" turns out to
+not exist on this frame shape — `iloc` is already optimal.
 
 ## Runtime State Inventory
 
-> Not a rename/refactor/migration phase — this is a behavior-preserving perf change to a single in-memory code path. No stored data, live service config, OS-registered state, secrets, or build artifacts carry phase-relevant state.
->
-> - **Stored data:** None — the change is in-process per-tick slicing; no datastore keys change.
+> Not a rename/refactor/migration phase — this is a behavior-preserving perf change to in-memory code
+> paths plus a one-line log deletion and harness hygiene. No persisted or registered state carries
+> phase-relevant meaning.
+> - **Stored data:** None — cursor state is in-process, rebuilt every run; no datastore keys change. Verified: the change is `BacktestBarFeed` instance state + a dispatcher line + a perf runner.
 > - **Live service config:** None.
 > - **OS-registered state:** None.
-> - **Secrets/env vars:** None.
-> - **Build artifacts:** None — no package rename, no egg-info impact. (`perf/results/W1-BASELINE.json` is re-frozen and `W2-BASELINE.json` is newly committed, but these are data artifacts produced by the phase, not stale state needing migration.)
+> - **Secrets/env vars:** None — `ITRADER_DISABLE_LOGS`/`ITRADER_LOG_LEVEL` are read by the logger but unaffected by deleting one call site.
+> - **Build artifacts:** None — no package rename, no egg-info impact. `perf/results/{W1,W2}-BASELINE.json` are re-frozen data artifacts produced by the phase, not stale state to migrate.
 
 ## Common Pitfalls
 
-### Pitfall 1: The D-08 (b) mutation assertion targets the WRONG exception
-**What goes wrong:** A test that does `view.iloc[0, 0] = 999` and asserts it raises will catch a **`SettingWithCopyWarning`** (under `filterwarnings=["error"]`), NOT a read-only `ValueError`. This passes even if the buffer were writeable — pandas' chained-assignment copy-detection fires *before* the buffer is touched. The test would give false confidence that read-only enforcement works.
-**Why it happens:** pandas intercepts chained assignment on a slice with its own guard; the numpy read-only flag is only hit by a *direct* buffer write.
-**Empirical exception map (`pandas 2.3.3` / `numpy 2.2.6`, `filterwarnings=["error"]`):**
-| Mutation form | Raises |
-|---------------|--------|
-| `view.iloc[0, 0] = x` | `SettingWithCopyWarning` (pandas guard — NOT the read-only proof) |
-| `view["close"].iloc[0] = x` | `FutureWarning` (chained-assignment deprecation) |
-| `view._mgr.blocks[0].values[0, 0] = x` | **`ValueError: assignment destination is read-only`** ✅ |
-| `view.to_numpy(copy=False)[0, 0] = x` | **`ValueError: assignment destination is read-only`** ✅ |
-**How to avoid:** Assertion (b) MUST do a **direct numpy write** (`view.to_numpy(copy=False)[0, 0] = x` or the `_mgr.blocks[0].values` form) and assert `ValueError` with `match="read-only"`. Optionally ALSO assert the pandas-path raises (any of the three) to document the layered defense, and assert the master frame is byte-unchanged afterward (no leak). `[VERIFIED: empirical test]`
+### Pitfall 1: A Timestamp-comparison cursor delivers no win (the int64 path is load-bearing)
+**What goes wrong:** Implementing the forward step as `while frame.index[pos] <= cutoff: pos += 1`.
+Each `frame.index[pos]` boxes an int64 into a `pd.Timestamp` (2.0 µs) and the compare adds more — the
+per-step cost approaches the 4.3 µs `searchsorted` it replaces, so the W2 win evaporates.
+**Why it happens:** `frame.index[pos]` looks like cheap scalar access but pandas materializes a
+Timestamp object; `frame.index.values[pos]` / `frame.index.asi8[pos]` returns a raw numpy scalar.
+**How to avoid:** Compare int64 ns: `iv_i8 = frame.index.asi8`, `cutoff_i8 = cutoff.value`, then
+`while iv_i8[pos] <= cutoff_i8`. Measured 0.14 µs/step. `[VERIFIED: timeit — 0.14 µs int64 vs 2.0 µs Timestamp]`
 
-### Pitfall 2: Assuming the `.iloc` slice is the data copy (it isn't, for this frame)
-**What goes wrong:** Planning the change as "eliminate the N×5 float64 copy" and expecting a memory drop proportional to window size. The homogeneous float64 single-block frame's `.iloc[start:pos]` is **already a view** — there is no large buffer copy to eliminate.
-**Why it happens:** PERF-BASELINE §2 #5's "each `iloc` slice copies a frame" / "high (each `iloc` slice copies a frame)" is true for *mixed-dtype* frames (pandas copies across blocks), but the OHLCV frame is single-block. The per-tick cost is **DataFrame/Index/BlockManager wrapper construction**, not buffer copy.
-**How to avoid:** Frame the win to the planner as **wrapper-construction churn + the `_offset_alias` string compute**, and validate the win by **wall-clock** (the W2 sweep), not by a tracemalloc memory drop (which may be smaller than expected). The ≥10%-at-50-symbols bar (D-05) is wall-clock — correct. `[VERIFIED: empirical test]`
+### Pitfall 2: Forward-only cursor leaks a future bar on a backwards cutoff
+**What goes wrong:** A cursor that only ever steps forward, when handed a cutoff *earlier* than its
+last (universe re-entry that re-issues an earlier `asof`, or a test that calls `window()` out of
+order), keeps its stale (too-large) `pos` and returns a window that includes bars stamped > the new
+cutoff — a silent look-ahead breach.
+**Why it happens:** The optimization assumes monotonic cutoffs; nothing in the type system enforces it.
+**How to avoid:** Guard `if cutoff_i8 < last_cut: rebuild via searchsorted` (Pattern 2). The D-16 test
+MUST include a backwards/out-of-order tick to exercise this path. `[VERIFIED: rebuild path is byte-identical to fresh searchsorted]`
 
-### Pitfall 3: Marking the master non-writeable AFTER `_spans`/`_prebuilt` are derived
-**What goes wrong:** The `__init__` loop reads `frame.index[0]`/`frame.index[-1]` (`:184`) and `frame.iterrows()` (`:187`) from the same frame. Marking the *values* buffer non-writeable does not affect index reads or `iterrows` (verified: searchsorted and reads work on non-writeable frames), so ordering is not strictly load-bearing — but mark *after* the frame is fully populated and before it is exposed, to keep the "frames written once, then immutable" invariant honest.
-**How to avoid:** Mark immediately after assignment to `self._frames[...]`, i.e. right after `:183` and right before `:273`'s `return`. `[VERIFIED: resample/searchsorted/iterrows all pass on non-writeable frame]`
+### Pitfall 3: Re-freezing the W2 baseline on the DILUTED (pre-D-13) engine
+**What goes wrong:** Capturing the cursor's before-baseline before the log removal + harness de-timing
+land. The diluted denominator includes the ~22% log waste + ~19% harness overhead, so the cursor's
+searchsorted-removal looks like a tiny fraction of a bloated total — the ≥10% bar stays unreachable
+(exactly why 06-01's measurement failed).
+**Why it happens:** Sequencing — the cleanup is a *prep* step (D-13) and must land first.
+**How to avoid:** D-14 sequencing — land D-13, re-freeze on the cleaned engine, THEN gate the cursor
+alone. `[CITED: D-13/D-14; 06-PROFILE-FINDINGS.md]`
 
-### Pitfall 4: `_offset_alias` memoization changing the FutureWarning behavior
-**What goes wrong:** `_offset_alias` deliberately raises `ValueError` for unsupported timeframes (the Feed-owns-the-map Pitfall 2 in its docstring, guarding against the `'30m'`→MONTH-END FutureWarning). An `lru_cache` does NOT cache exceptions — each unsupported call re-raises — so caching is safe. But verify the cache key (`timedelta`) is hashable (it is) and that the existing `_offset_alias` tests still pass.
-**How to avoid:** Keep the `_offset_alias` body byte-unchanged; only wrap/memoize. Run the existing alias tests. `[VERIFIED: timedelta is hashable; lru_cache does not cache exceptions — CPython semantics]`
+### Pitfall 4: Deleting the wrong indentation in `full_event_handler.py`
+**What goes wrong:** Editing the **TAB-indented** `full_event_handler.py` with spaces (or vice versa)
+produces a mixed-indentation diff that breaks the file (CLAUDE.md indentation hazard).
+**Why it happens:** `bar_feed.py` (the main target) is 4-space; the D-13 log line is in the TAB file.
+**How to avoid:** Match `full_event_handler.py`'s TAB indent for the deletion. The three lines to
+remove are `:114-116`. `[VERIFIED: code read — file uses tabs]`
+
+### Pitfall 5: Cursor state outliving a frame it no longer matches
+**What goes wrong:** Storing the cursor keyed only on `ticker` (not `(ticker, alias)`) — a strategy
+querying two timeframes for the same ticker would share one cursor across two different frames.
+**Why it happens:** The feed's `_frames` is keyed `(ticker, alias)`; the cursor must mirror that.
+**How to avoid:** Key the cursor `(ticker, alias)` exactly like `self._frames`. Each alias has its own
+frame and its own monotonic cutoff sequence. `[CITED: bar_feed.py _frames keying]`
 
 ## Code Examples
 
-### The D-08 three-assertion drift test (skeleton)
+### The D-16 drift-test extension (skeleton — extends the existing D-08 suite)
 ```python
-# Source: synthesized from D-08 + empirical exception map; home tests/unit/price_handler/feed/
-# (planner: reconcile with the existing tests/unit/price/test_bar_feed.py — see Open Question 1)
-import numpy as np
-import pandas as pd
-import pytest
+# Source: synthesized from D-16 + the verified byte-identity; home tests/unit/price/test_bar_feed.py
+# (co-located with the existing 7-rule contract suite + the 06-01 D-08 (a)/(b) tests at :343-372)
+from datetime import timedelta
 
-def test_window_view_content_equals_old_copy(daily_feed, daily_base_frame):
-    # (a) view content == old-copy content across sampled ticks (byte-identical).
-    for asof in SAMPLED_TICKS:
-        view = daily_feed.window('BTCUSD', timedelta(days=1), max_window=3, asof=asof)
-        expected = daily_base_frame.iloc[<...>:<...>]  # the same positional slice, copied
-        pd.testing.assert_frame_equal(view, expected, check_freq=False)
+def test_cursor_equals_fresh_searchsorted_across_ticks(daily_feed, daily_base_frame):
+    # D-16: across MONOTONIC sampled ticks the cursor's (start, pos) == a fresh searchsorted,
+    # and no bar with time > cutoff appears in the returned window.
+    tf, base_tf, max_window = timedelta(days=1), timedelta(days=1), 3
+    frame = daily_base_frame
+    for asof in [ts('2020-01-02'), ts('2020-01-05'), ts('2020-01-07'), ts('2020-01-10')]:
+        cutoff = asof - tf + base_tf
+        fresh_pos = int(frame.index.searchsorted(cutoff, side="right"))
+        win = daily_feed.window('BTCUSD', tf, max_window, asof=asof)
+        # (1) end position equals fresh searchsorted (the cursor matched the rebuild)
+        if not win.empty:
+            assert frame.index.get_loc(win.index[-1]) == fresh_pos - 1
+            # (2) NO future bar: every returned stamp <= cutoff
+            assert (win.index <= cutoff).all()
 
-def test_window_view_is_read_only_and_cannot_leak(daily_feed):
-    # (b) mutating a returned window RAISES (read-only) and cannot leak into the master.
-    view = daily_feed.window('BTCUSD', timedelta(days=1), max_window=3, asof=SOME_TICK)
-    before = view.to_numpy().copy()
-    with pytest.raises(ValueError, match="read-only"):
-        view.to_numpy(copy=False)[0, 0] = 999.0          # DIRECT numpy write — the real proof
-    # master unchanged: re-fetch the same window, assert byte-identical to `before`
-    again = daily_feed.window('BTCUSD', timedelta(days=1), max_window=3, asof=SOME_TICK)
-    assert np.array_equal(again.to_numpy(), before)
+def test_cursor_safe_rebuild_on_backwards_asof(daily_feed):
+    # D-16 reset-safety: a backwards cutoff (out-of-order asof) must NOT leak a future bar.
+    tf = timedelta(days=1)
+    late = daily_feed.window('BTCUSD', tf, 5, asof=ts('2020-01-10'))   # advance the cursor
+    early = daily_feed.window('BTCUSD', tf, 5, asof=ts('2020-01-03'))  # step BACKWARDS
+    assert (early.index <= ts('2020-01-03')).all()                     # no Jan-4..10 leak
+    # byte-identical to a fresh searchsorted at the earlier cutoff
+    # (compare to a feed with a virgin cursor, or to the positional oracle)
 
-# (c) is the existing contract suite staying green — no new test, just don't break
-#     tests/unit/price/test_bar_feed.py (assert_frame_equal at :167, :183).
+def test_cursor_cold_and_gap(gappy_feed):
+    # D-16: cold cursor (first call) + a gap-frame cutoff both resolve byte-identically.
+    win = gappy_feed.window('GAPPY', timedelta(days=1), 5, asof=ts('2020-01-05'))  # Jan-5 gap day
+    assert (win.index <= ts('2020-01-05')).all()
+    assert ts('2020-01-05') not in win.index   # the gap day has no bar
+
+def test_cursor_universe_reentry(duo_feed):
+    # D-16: a ticker queried, then NOT, then queried again at a LATER tick (re-entry) —
+    # the forward step is still correct because the cutoff advanced monotonically.
+    w1 = duo_feed.window('BTCUSD', timedelta(days=1), 3, asof=ts('2020-01-04'))
+    _  = duo_feed.window('ETHUSD', timedelta(days=1), 3, asof=ts('2020-01-05'))  # other ticker
+    w2 = duo_feed.window('BTCUSD', timedelta(days=1), 3, asof=ts('2020-01-07'))  # re-entry, later
+    assert (w2.index <= ts('2020-01-07')).all()
+    assert w2.index[-1] == ts('2020-01-07')
 ```
+> The existing `test_window_view_content_equals_old_copy` (:343) and
+> `test_window_view_is_read_only_and_cannot_leak` (:359) stay green unchanged (the cursor returns the
+> same read-only `iloc` view). D-16 ADDS the cursor-equivalence + reset-safety tests above.
 
-### Mechanizing gate (b): add `--check`/`--baseline-out` to `run_w2_sweep.py`
+### Cursor wiring in `__init__` (4-space)
 ```python
-# Source: mirror run_w1_benchmark.py:150-249. Keep the {1,10,50} table for visibility;
-# add a W2-BASELINE.json keyed on the 50-symbol wall_clock_s with a ≥10% IMPROVEMENT bar.
-def _to_w2_baseline_schema(points: list[dict]) -> dict:
-    p50 = next(p for p in points if p["n_symbols"] == 50)
-    return {
-        "schema_version": 1,
-        "frozen_at": dt.date.today().isoformat(),
-        "metric": {"wall_clock_s_at_50": round(p50["wall_clock_s"], 2),
-                   "peak_mem_mb_at_50": round(p50["peak_mem_mb"], 2)},
-        "sweep": {"n_symbols": _N_SYMBOLS_SWEEP, "n_bars": _N_BARS, "seed": _SEED},
-        "points": points,
-    }
-
-def _check_w2(points, baseline_path, min_improvement_pct=10.0) -> int:
-    # PASS (return 0) iff 50-symbol wall_clock improved by >= min_improvement_pct.
-    # Mirror run_w1's soft-guard tone but invert the sense (this gate REQUIRES a win).
-    base = json.load(open(baseline_path))
-    base50 = base["metric"]["wall_clock_s_at_50"]
-    now50  = next(p for p in points if p["n_symbols"] == 50)["wall_clock_s"]
-    impr = (base50 - now50) / base50 * 100.0
-    print(f"W2@50 {now50:.2f}s  improvement {impr:+.1f}%  (baseline {base50:.2f}s)")
-    return 0 if impr >= min_improvement_pct else 1
+# In BacktestBarFeed.__init__, alongside self._frames / self._spans / self._prebuilt:
+self._cursor: dict[tuple[str, str], int] = {}      # last forward position per (ticker, alias)
+self._cursor_cut: dict[tuple[str, str], int] = {}  # last cutoff (int64 ns) per (ticker, alias)
+# No per-frame asi8 cache needed if frame.index.asi8 is re-derived per call (verified zero-copy);
+# the planner MAY cache it adjacent to _frames as a belt-and-suspenders micro-opt.
 ```
-> **D-05 sequencing nuance for the planner:** the ≥10% bar compares **after** against a **before** baseline. The before-baseline must be captured on the SAME machine in the SAME session as the after-run (per memory `v15-perf-gateb-thermal-drift` — the box is thermally sensitive; a frozen cross-session baseline can drift). Recommend: capture `--baseline-out W2-BASELINE-pre.json` immediately before the change, run `--check` after, and commit the *after* run as the standing `W2-BASELINE.json` (which seeds Phase 5). `[VERIFIED: memory note v15-perf-gateb-thermal-drift; CITED: D-05]`
 
 ## State of the Art
 
-| Old Approach | Current Approach (pandas 2.3.3) | When Changed | Impact |
-|--------------|----------------------------------|--------------|--------|
-| `.iloc` slice copy/view ambiguous; SettingWithCopyWarning era | CoW **opt-in** (default OFF in 2.3.x); homogeneous single-block `.iloc` slice returns a **view** | 2.3.x is the CoW transition release; CoW becomes default in 3.0 (Jan 2026) | This phase deliberately stays on the **CoW-off** path and enforces read-only via numpy flags (D-02 rejects global CoW). When the project eventually moves to pandas 3.0, the numpy-flag mechanism still works; CoW would *additionally* make mutations copy silently — but the explicit non-writeable buffer still raises loudly, so the D-08 guarantee survives the upgrade. |
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| Per-tick `frame.index.searchsorted(cutoff, "right")` (O(log n), 4.3 µs × 150k calls) | Monotonic forward cursor over `index.asi8` int64 ns (O(1) amortized, 0.14 µs/step) with a `searchsorted` rebuild guard | This phase (D-10) | Removes the 13.2% W2 searchsorted hotspot; byte-identical result. |
+| 06-01 view/alias (shipped, ~0% W2) | Kept as the read-only foundation; cursor sits on top (D-12) | 06-01 (`9168cae`) | No regression; the cursor returns the same read-only view. |
+| Per-bar eager `f"TIME EVENT: {event.time}"` discarded at INFO | Deleted (D-13) | This phase | Removes ~22% W2 engine waste; behavior-neutral (never printed). |
+| tracemalloc inside the W2 timed region (~19% inflation) | Two-pass: clean timed run + separate instrumented run (D-13) | This phase | Timed wall-clock measures the engine, not the harness. |
 
 **Deprecated/outdated:**
-- Global `pd.options.mode.copy_on_write` as a safety mechanism here — rejected (D-02). It is the pandas-3.0 default but is the wrong tool for "fail loudly on mutation."
+- D-01's "searchsorted is microsecond-class, not worth a cursor" — **empirically wrong** (profile: 13.2%
+  of W2). Superseded by D-10.
+- D-11's "cheaper slice" as a *separate* win — the slice has no cheaper byte-identical form; folded into
+  the D-15 ship-and-reframe (see Open Question 1).
 
 ## Assumptions Log
 
 | # | Claim | Section | Risk if Wrong |
 |---|-------|---------|---------------|
-| A1 | `_offset_alias` memoization shape (lru_cache vs instance dict) is stylistic — either is correct | Pattern 3 | Low — both verified to preserve the raise-on-unsupported behavior; planner picks. |
-| A2 | The win is wrapper-construction churn + alias string compute, not a large buffer copy | Pitfall 2 / Summary | Medium — if a future frame shape were mixed-dtype (it is not for golden OHLCV), `.iloc` WOULD copy and the win would be larger. The golden frame is verified single-block float64, so this holds for the gated path. |
-| A3 | `--check`/`--baseline-out` on `run_w2_sweep.py` is the right mechanization (vs ad-hoc) | gate (b) | Low — D-05 explicitly leaves this to researcher/planner; the mirror of `run_w1` is the established pattern and also seeds Phase 5. |
+| A1 | The two-pass tracemalloc de-time (re-wire a fresh system for the mem pass) is the right structure | Pattern 3b | Low — standard tracemalloc practice; the planner pins the exact re-wire helper. Alternative: a single clean timed run + an estimated/omitted peak-mem (peak-mem is "watched, never fails" per W1's guard). |
+| A2 | `frame.index.asi8` stays zero-copy/stable enough to re-derive per call | Pattern 1 caveat | Low — verified `shares_memory` stable; worst case cache it at build (a 1-line micro-opt). |
+| A3 | Silent safe-rebuild (not fail-loud) is the right reset policy | Pattern 2 | Low — D-10 leaves this to researcher/planner within "never leak"; a non-monotonic cutoff is legitimate (screener re-entry, resampled cutoffs), so crashing would be wrong. The rebuild is exactly today's behavior. |
+| A4 | Plain removal of the `TIME EVENT` log is behavior-neutral | Pattern 3a | Very low — verified the line is DEBUG-gated and never prints at INFO; logs are not the oracle (gate a covers it). |
 
-**Note:** The two load-bearing technical claims (view-construction API, non-writeable-breaks-nothing, exception types, byte-identity) are all `[VERIFIED: empirical test]`, not assumed.
+**Note:** The load-bearing technical claims (forward-cursor byte-identity to `searchsorted(side="right")`,
+the 0.14 µs int64 comparison cost, the cheaper-slice candidates all being slower, the eager-f-string
+caller waste) are all `[VERIFIED: empirical test / code read]`, not assumed.
 
-## Open Questions (RESOLVED)
+## Open Questions
 
-> Both questions are advisory placement/stylistic choices (not technical unknowns) and are
-> resolved in the plan action sections.
+1. **Is D-11's cheaper slice worth pursuing, or ship cursor-only?**
+   - What we know: every measured alternative to `frame.iloc[start:pos]` is *slower* (reconstruct 9.2
+     µs, take 21 µs vs iloc 7.3 µs), AND D-07 forbids the reconstruction path on byte-identity grounds.
+     On a single-block float64 frame `iloc` is already a near-optimal view. `[VERIFIED]`
+   - What's unclear: nothing technical — the data is conclusive that no cheaper byte-identical slice
+     exists on this frame shape.
+   - **Recommendation:** **Ship cursor-only.** Keep `iloc[start:pos]`. The cursor alone removes ~36% of
+     the `window()` path (the 4.3 µs searchsorted out of ~11.6 µs). The 7.9% slice cost is left on the
+     table per D-11's own escape hatch ("if the cheaper slice cannot be made provably byte-identical,
+     say so and recommend cursor-only — the gate has a D-15 ship-and-reframe fallback"). **Confirm with
+     the planner/owner** that cursor-only is acceptable, or accept a measurable-but-<10% W2 via D-15.
 
-1. **D-08 test home vs existing contract tests.** **RESOLVED:** co-locate in
-   `tests/unit/price/test_bar_feed.py` per 06-01 Task 0 action; D-08's literal
-   `tests/unit/price_handler/feed/` path is treated as directional.
-   - What we know: D-08 says home is `tests/unit/price_handler/feed/` (which does **not exist** yet). The existing 7-rule bar-timing contract tests live in `tests/unit/price/test_bar_feed.py` (383 lines, uses `assert_frame_equal` at `:167`/`:183` — the byte-identity backstop for assertion (c)).
-   - What's unclear: whether to create the new `tests/unit/price_handler/feed/` dir per D-08's literal text, or co-locate the new drift test with the existing contract tests in `tests/unit/price/test_bar_feed.py`.
-   - Recommendation: Co-locate the new drift test in `tests/unit/price/test_bar_feed.py` (or a sibling `test_bar_feed_window_view.py` in the SAME dir) so the existing contract suite (assertion (c)) and the new (a)/(b) assertions live together and run as one unit. Treat D-08's path as directional, not literal. Confirm with the planner; this is a placement decision, not a correctness one.
-
-2. **Whether to add the explicit per-view re-mark.** **RESOLVED:** include the
-   belt-and-suspenders re-mark per 06-01 Task 1 action (cheap, documents intent,
-   survives a future refactor that forgets to mark a master). Redundant for safety
-   but low-stakes positive.
+2. **Where does the cursor live relative to the per-frame state?**
+   - What we know: the cursor must be keyed `(ticker, alias)` to mirror `self._frames`; two plain dicts
+     (`_cursor`, `_cursor_cut`) are the simplest shape. A belt-and-suspenders `asi8` cache adjacent to
+     `_frames` is optional (verified zero-copy without it).
+   - **Recommendation:** Two instance dicts in `__init__`; re-derive `frame.index.asi8` per call (cheap).
+     This is a placement choice (Claude's discretion), not a correctness one.
 
 ## Environment Availability
 
 | Dependency | Required By | Available | Version | Fallback |
 |------------|------------|-----------|---------|----------|
-| pandas | window slice / resample / searchsorted | ✓ | 2.3.3 | — |
-| numpy | read-only buffer flag | ✓ | 2.2.6 | — |
-| ta | indicator reads on the view (consumer audit) | ✓ | 0.11.0 | — |
-| poetry venv | running tests + perf runners | ✓ | in-project `.venv` | — |
+| pandas | cursor (`asi8`, `searchsorted` rebuild), slice | ✓ | 2.3.3 | — |
+| numpy | int64 ns comparison | ✓ | 2.2.6 | — |
+| structlog | the logger whose caller waste D-13 removes | ✓ | 24.4.0 | — |
+| poetry venv | tests + perf runners | ✓ | in-project `.venv` | — |
+| cool machine for the gate-(b) re-freeze | D-14 measurement | ⚠️ human-gated | — | defer the re-freeze (per the pending todo + thermal-drift memory) — mechanization is reusable |
 
-**Missing dependencies with no fallback:** None.
-**Missing dependencies with fallback:** None.
+**Missing dependencies with no fallback:** None for the code work.
+**Missing dependencies with fallback:** The cool-machine re-freeze (D-14) is human-gated — Claude
+cannot guarantee thermal state; the 06-02 checkpoint pattern (`checkpoint:human-verify`) carries forward.
 
-> **Worktree note (memory `worktree-venv-shadowing` / `worktree-make-test-env-abort`):** the current branch is a worktree (`v1.5/phase-6-bar-feed-window-copies`). `make test` may abort on a missing `.env`; run `poetry run pytest tests` in the worktree and re-run `make test` in the main checkout for the gate. Prepend `PYTHONPATH="$PWD"` if the editable install shadows worktree edits.
+> **Worktree note (memory `worktree-make-test-env-abort` / `worktree-venv-shadowing`):** the current
+> branch is a worktree. `make test`/`make perf-*` may abort on a missing `.env`; run `poetry run
+> pytest tests` in the worktree and run the perf gate in the MAIN checkout. Prepend `PYTHONPATH="$PWD"`
+> if the editable install shadows worktree edits.
 
 ## Validation Architecture
 
@@ -367,52 +562,61 @@ def _check_w2(points, baseline_path, min_improvement_pct=10.0) -> int:
 | Framework | pytest 8.4.2 (`testpaths=["tests"]`, `minversion="8.0"`) |
 | Config file | `pyproject.toml` `[tool.pytest.ini_options]` (`filterwarnings=["error", ...]`, `--strict-markers`, `--strict-config`) |
 | Quick run command | `poetry run pytest tests/unit/price/test_bar_feed.py -q` |
-| Full suite command | `make test` (main checkout) / `poetry run pytest tests` (worktree) |
+| Full suite command | `poetry run pytest tests` (worktree) / `make test` (main checkout) |
 
 ### Phase Requirements → Test Map
 | Req ID | Behavior | Test Type | Automated Command | File Exists? |
 |--------|----------|-----------|-------------------|-------------|
-| PERF-06 (a) | View content == old-copy content across sampled ticks (byte-identical values/dtype/tz-index/columns) | unit | `poetry run pytest tests/unit/price/test_bar_feed.py -k content_equals -q` | ❌ Wave 0 (new drift test) |
-| PERF-06 (b) | Mutating a returned window RAISES read-only `ValueError` and cannot leak into the master | unit | `poetry run pytest tests/unit/price/test_bar_feed.py -k read_only -q` | ❌ Wave 0 (new drift test) |
-| PERF-06 (c) | Existing 7-rule bar-timing contract stays green | unit | `poetry run pytest tests/unit/price/test_bar_feed.py -q` | ✅ exists (`:124-201`, uses `assert_frame_equal`) |
+| PERF-06 / D-16 (a) | Cursor `(start,pos)` == fresh `searchsorted(cutoff,"right")` across monotonic sampled ticks | unit | `poetry run pytest tests/unit/price/test_bar_feed.py -k cursor_equals -q` | ❌ Wave 0 (new) |
+| PERF-06 / D-16 (b) | No bar with `time` > cutoff in the returned window (no-future-bar invariant) | unit | `poetry run pytest tests/unit/price/test_bar_feed.py -k cursor -q` | ❌ Wave 0 (new) |
+| PERF-06 / D-16 (reset) | Backwards `asof` / cold cursor / gap frame / universe re-entry all rebuild safely (no leak) | unit | `poetry run pytest tests/unit/price/test_bar_feed.py -k "rebuild or cold or gap or reentry" -q` | ❌ Wave 0 (new) |
+| PERF-06 / D-08 (kept) | View content == old-copy; mutation raises read-only (06-01 tests stay green) | unit | `poetry run pytest tests/unit/price/test_bar_feed.py -k "view_content or read_only" -q` | ✅ exists (`:343`, `:359`) |
+| PERF-06 / D-08 (c) | Existing 7-rule bar-timing contract stays green | unit | `poetry run pytest tests/unit/price/test_bar_feed.py -q` | ✅ exists (`:123-308`) |
+| D-13 | `TIME EVENT` log removal is behavior-neutral (suite + oracle unchanged) | integration | `poetry run pytest tests/integration/test_backtest_oracle.py -q` | ✅ exists |
 | Gate (a) | Byte-exact SMA_MACD oracle (134 / `46189.87730727451`) | integration | `poetry run pytest tests/integration/test_backtest_oracle.py -q` | ✅ exists (memory `oracle-test-location`) |
 | Gate (a) | `mypy --strict` clean | static | `poetry run mypy itrader` | ✅ infra exists |
-| Gate (a) | Determinism double-run byte-identical | integration | (run oracle twice; assert identical) | ✅ oracle is deterministic |
-| Gate (b) | W2 ≥10% improvement at 50 symbols + W1 non-regress | perf | `make perf-w2` (+ new `--check`); `make perf-w1` | ⚠️ W2 needs `--check`/`--baseline-out` (Wave 0) |
+| Gate (a) | Determinism double-run byte-identical | integration | run oracle twice; assert identical | ✅ oracle deterministic |
+| Gate (b) | W2 ≥10% at 50 symbols (cursor alone, cleaned baseline) + W1 within ±5% band | perf | `make perf-w2` (`--check`); `make perf-w1` | ✅ harness exists (06-02 `f51d7c6`); re-freeze on cleaned engine |
 
 ### Sampling Rate
-- **Per task commit:** `poetry run pytest tests/unit/price/test_bar_feed.py -q` (the drift + contract tests — fast, <30s).
-- **Per wave merge:** `make test` (full unit/integration suite) + `poetry run mypy itrader`.
+- **Per task commit:** `poetry run pytest tests/unit/price/test_bar_feed.py -q` (cursor drift + contract + 06-01 D-08 tests — fast, <30s).
+- **Per wave merge:** `poetry run pytest tests` (full unit/integration/e2e) + `poetry run mypy itrader`.
 - **Phase gate (a):** `poetry run pytest tests/integration/test_backtest_oracle.py` green (134 / `46189.87730727451`), `mypy --strict` clean, determinism double-run identical, full suite green.
-- **Phase gate (b):** `make perf-w2 --check` shows ≥10% improvement at 50 symbols AND `make perf-w1` (`--check`) shows W1 within band (no regression); then re-freeze `W1-BASELINE.json` (`make perf-baseline`) and commit `W2-BASELINE.json`.
+- **Phase gate (b):** D-14 sequencing — re-freeze BOTH baselines on the cleaned engine (cool machine), then `make perf-w2 --check` ≥10% at 50 symbols (cursor alone) AND `make perf-w1 --check` within band; D-15 fallback records the actual W2 % if <10%.
 
 ### Wave 0 Gaps
-- [ ] `tests/unit/price/test_bar_feed.py` (or sibling in same dir) — add assertions (a) content-equality and (b) read-only-raises (Open Question 1 — placement). Assertion (b) MUST target the numpy `ValueError` (Pitfall 1).
-- [ ] `perf/runners/run_w2_sweep.py` — add `--baseline-out`/`--check` flags mirroring `run_w1_benchmark.py` (D-05; Code Examples). Add `perf-w2-baseline` / `perf-w2 --check` Makefile wiring as needed.
-- [ ] `perf/results/W2-BASELINE.json` — capture and commit the after-run 50-symbol baseline (seeds Phase 5).
-- [ ] `perf/results/W1-BASELINE.json` — re-freeze after the change (D-04).
+- [ ] `tests/unit/price/test_bar_feed.py` — add the D-16 cursor-equivalence + reset-safety tests (cursor==searchsorted across monotonic ticks; no-future-bar; backwards-asof rebuild; cold cursor; gap frame; universe re-entry). The existing `daily_feed`/`gappy_feed`/`duo_feed` fixtures already supply the cold/gap/churn cases.
+- [ ] `perf/runners/run_w2_sweep.py` — de-time `_run_point` (two-pass; D-13). The `--check`/`--baseline-out` flags already exist (06-02 `f51d7c6`) — do NOT re-add them.
+- [ ] `itrader/events_handler/full_event_handler.py:114-116` — delete the `TIME EVENT` debug block (D-13; TAB indent).
+- [ ] `perf/results/W2-BASELINE.json` — capture on the cleaned engine (cursor-on), commit (seeds Phase 5). NOT YET FROZEN (correct per 06-PROFILE-FINDINGS — nothing to freeze until the cursor lands).
+- [ ] `perf/results/W1-BASELINE.json` — re-freeze on the cleaned engine after confirming non-regression (D-14).
 - Framework install: none — pytest infra already present.
 
 ## Security Domain
 
-> Not applicable in the conventional ASVS sense — this is an internal, offline backtest data-path optimization with no auth/session/network/input-validation surface. The one *integrity* concern is look-ahead/data-corruption (a future tick reading a mutated past bar), which is exactly what D-09's read-only enforcement defends — covered by the Validation Architecture (D-08 assertion (b)) above. No external `security_enforcement` config artifact is touched; no new attack surface is introduced.
+> Not applicable in the conventional ASVS sense — this is an internal, offline backtest data-path
+> optimization with no auth/session/network/input-validation surface. The single *integrity* concern is
+> look-ahead/data-corruption (a stale cursor leaking a future bar into a decision window), which is
+> exactly what D-10's rebuild guard + D-16's no-future-bar assertion defend. No `security_enforcement`
+> artifact is touched; no new attack surface is introduced.
 
 | Integrity threat | STRIDE | Mitigation (this phase) |
 |------------------|--------|-------------------------|
-| A consumer mutates a shared view → poisons a future tick (silent look-ahead breach) | Tampering | numpy `writeable=False` on the master buffer (D-09) → mutation raises `ValueError`; proven by D-08 assertion (b). |
+| A stale forward cursor under-counts on a backwards cutoff → leaks a bar stamped > cutoff (silent look-ahead breach) | Tampering | `cutoff_i8 < last_cut` → safe `searchsorted` rebuild (Pattern 2); proven by the D-16 backwards-asof + no-future-bar tests; gate-(a) byte-exact oracle is the run-path backstop. |
+| A consumer mutates the returned view → poisons a future tick | Tampering | Carried from 06-01 (D-09): the master values buffer is `writeable=False`; the cursor returns the same read-only view; the 06-01 D-08(b) test stays green. |
 
 ## Sources
 
 ### Primary (HIGH confidence)
-- **Empirical test against the pinned venv** (`pandas 2.3.3`, `numpy 2.2.6`, CoW default `False`) — the load-bearing source. Verified: `.iloc` slice on a homogeneous float64 single-block frame is already a view (`_is_view`, `shares_memory`); non-writeable master does not break `resample`/`searchsorted`/`ta` reads; view inherits `writeable=False`; byte-identity (`DataFrame.equals`, dtype/tz-index/column-order); the mutation-form→exception map (`SettingWithCopyWarning` / `FutureWarning` / `ValueError read-only`); empty-window `iloc[pos:pos]` semantics preserved. `[VERIFIED]`
-- `itrader/price_handler/feed/bar_feed.py` — target code (`window:360-399`, `_resampled_frame:256-274`, `__init__:181-188`, `_offset_alias:78-121`). `[VERIFIED: read]`
-- `itrader/strategy_handler/{strategies_handler.py,base.py,indicators/catalog.py,indicators/handle.py}` — consumer read-only audit evidence. `[VERIFIED: read]`
-- `perf/runners/{run_w1_benchmark.py,run_w2_sweep.py}`, `Makefile:99-112` — the `--check`/`--baseline-out` pattern to mirror. `[VERIFIED: read]`
-- `perf/results/PERF-BASELINE-RESULTS.md` §2 #5, §3 — the spike (authoritative hotspot source). `[VERIFIED: read]`
-- `tests/unit/price/test_bar_feed.py` — existing 7-rule contract tests + `assert_frame_equal` byte-identity backstop. `[VERIFIED: read]`
+- **Empirical test against the pinned venv** (`pandas 2.3.3`, `numpy 2.2.6`) — the load-bearing source. Verified: forward cursor over `index.asi8` + `Timestamp.value` is byte-identical to `searchsorted(cutoff, side="right")` for on-grid AND mid-gap cutoffs (3000 ticks each); int64 compare 0.14 µs vs Timestamp compare 2.0 µs vs `np.datetime64` conversion 3.3 µs vs searchsorted 4.3 µs; `index.asi8` zero-copy/stable; `Timestamp.value == asi8[k]` for tz-aware; every cheaper-slice candidate (`pd.DataFrame` reconstruct 9.2 µs, `take` 21 µs) slower than `iloc` 7.3 µs; the reconstruct path passes `assert_frame_equal` but is forbidden by D-07. `[VERIFIED]`
+- `itrader/price_handler/feed/bar_feed.py` — target (`window:427-486`, `_resampled_frame:319-341`, `__init__:199-263`, `_readonly_master:132-176`, 7-rule contract docstring `:9-55`). `[VERIFIED: read]`
+- `itrader/events_handler/full_event_handler.py:114-116` — the `TIME EVENT` debug line (TAB). `itrader/logger.py:258-262` — internal `isEnabledFor` gate (proves the f-string is built eagerly by the caller). `[VERIFIED: read]`
+- `perf/runners/run_w2_sweep.py` — `_run_point:95-131` (tracemalloc-in-timed-region to de-time), `_check_w2:181-209` + `--check`/`--baseline-out` (06-02, reusable as-is). `perf/runners/run_w1_benchmark.py` — the mirrored W1 guard. `[VERIFIED: read]`
+- `tests/unit/price/test_bar_feed.py` — existing 7-rule contract suite + the 06-01 D-08 (a)/(b) tests (`:343`, `:359`) the D-16 tests extend. `[VERIFIED: read]`
+- `.planning/phases/06-…/06-PROFILE-FINDINGS.md` — the authoritative pivot rationale (searchsorted 13.2% / iloc 7.9% / log 22% / harness 19%). `06-01-SUMMARY.md` — the shipped foundation (multi-block store frame consolidated to single-block). `06-02-PLAN.md` — the paused gate harness. `[VERIFIED: read]`
 
 ### Secondary (MEDIUM confidence)
-- pandas 2.3.0 / 3.0 whatsnew + PDEP-7 (CoW transition: opt-in in 2.3.x, default in 3.0) — confirms the CoW posture this phase deliberately avoids. `[CITED]`
+- 06-CONTEXT.md D-10–D-16 pivot block; STATE.md gate (a)/(b) text; REQUIREMENTS.md PERF-06. `[CITED]`
 
 ### Tertiary (LOW confidence)
 - None — the technical claims were promoted to HIGH via empirical verification.
@@ -420,11 +624,46 @@ def _check_w2(points, baseline_path, min_improvement_pct=10.0) -> int:
 ## Metadata
 
 **Confidence breakdown:**
-- View-construction API (D-07): **HIGH** — empirically verified `.iloc` is already a view, byte-identity confirmed.
-- Non-writeable-breaks-nothing (D-09): **HIGH** — `resample`/`searchsorted`/`ta` reads all verified passing; no fallback needed.
-- Mutation exception types (D-08 b): **HIGH** — exact map captured under `filterwarnings=["error"]`.
-- Gate-(b) mechanization (D-05): **MEDIUM** — the `--check`/`--baseline-out` mirror is the established pattern; thermal-drift sequencing per memory note.
-- Win characterization (Pitfall 2): **HIGH** — verified single-block float64 means no large buffer copy; win is wrapper churn + alias compute.
+- Cursor byte-identity to searchsorted (D-10): **HIGH** — verified on-grid + mid-gap, 3000 ticks each.
+- Cursor comparison cost (int64 vs Timestamp): **HIGH** — timeit, 0.14 µs vs 2.0 µs vs 3.3 µs.
+- Cheaper-slice infeasibility (D-11): **HIGH** — every candidate measured slower than `iloc`; D-07 forbids reconstruct.
+- `TIME EVENT` removal behavior-neutrality (D-13): **HIGH** — code read confirms eager-caller f-string, DEBUG-gated, never printed.
+- Harness de-time structure (D-13): **MEDIUM** — standard two-pass tracemalloc practice; planner pins the re-wire helper.
+- Gate-(b) re-freeze (D-14/D-15): **MEDIUM** — the 06-02 harness is reusable; the cool-machine measurement is human-gated (thermal-drift memory).
 
 **Research date:** 2026-06-24
-**Valid until:** 2026-07-24 (stable — pinned pandas/numpy; re-verify if pandas is bumped toward 3.0, which flips CoW default).
+**Valid until:** 2026-07-24 (stable — pinned pandas/numpy; re-verify if pandas is bumped toward 3.0).
+
+---
+
+## SHIPPED in 06-01 (historical — do NOT re-plan)
+
+> The following view/alias mechanism (D-01/D-02/D-06/D-07/D-09) **already landed in 06-01** (commit
+> `9168cae`, SUMMARY written) and is **kept as the foundation** (D-12). It is reproduced here for the
+> record only. **These are NOT tasks** — the cursor (above) builds on top of them.
+
+- **Read-only view from `window()` (D-01/D-07, shipped):** `window()` returns `frame.iloc[start:pos]`
+  directly — a view aliasing the locked single-block master, inheriting `writeable=False`. The `.iloc`
+  slice on a homogeneous float64 single-block frame is *already a view* (no buffer copy). The cursor
+  keeps returning this exact view.
+- **Non-writeable single-block master at build (D-09, shipped):** `_readonly_master(frame)`
+  consolidates to a single block via a byte-identical `DataFrame.copy()` (the store frame is
+  MULTI-block — the 06-01 deviation finding), then locks the block's numpy buffer
+  (`flags.writeable = False`, walking `arr if arr.flags.owndata else arr.base`, asserting
+  `np.shares_memory`). Called at both build sites (`__init__` base load, `_resampled_frame` memoize).
+  `resample`/`searchsorted`/`iterrows`/`ta` reads all verified to work on the non-writeable frame.
+- **Memoized `_offset_alias` (D-01, shipped):** `@functools.cache` on the module function (body
+  byte-unchanged; `functools.cache` does not cache exceptions so the raise-on-unsupported guard is
+  preserved). Profiled at 0.04% — never the hotspot.
+- **Empty-window short-circuit (D-06, shipped):** `if start >= pos: return frame.iloc[pos:pos]` —
+  bypasses the view machinery, byte-identical empty semantics. The cursor keeps this short-circuit.
+- **D-08 three-assertion drift lock (shipped):** `tests/unit/price/test_bar_feed.py:343-372` —
+  (a) view content == old-copy (`assert_frame_equal`); (b) direct numpy write raises
+  `ValueError(read-only)` and cannot leak (targets the numpy `ValueError`, NOT a pandas
+  `SettingWithCopyWarning`); (c) the existing 7-rule contract suite stays green. D-16 EXTENDS this
+  suite with the cursor-equivalence + reset-safety tests.
+
+**Why 06-01 gave ~0% W2 (the pivot trigger):** the view/alias attacked the *reducible-looking*
+sub-parts (alias string compute 0.04%, slice copy marginal) which were negligible. The dominant
+per-tick cost — a fresh `searchsorted` over the full frame index every tick × every symbol — was left
+in place. That is what the cursor (D-10) removes.

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-RESEARCH.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-RESEARCH.md
@@ -1,0 +1,425 @@
+# Phase 6: Bar-Feed Window Copies (OPTIONAL, slip-able) - Research
+
+**Researched:** 2026-06-24
+**Domain:** pandas 2.3.3 view/copy mechanics, numpy buffer writeability, byte-identity behavior preservation
+**Confidence:** HIGH (the two CONTEXT-deferred questions were resolved by direct empirical test against the pinned `pandas 2.3.3 / numpy 2.2.6` venv, not training data)
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+- **D-01 (view-primary + memoize alias; `searchsorted` stays):** Replace `frame.iloc[start:pos]` (a per-tick data copy of N×5 float64) with a **read-only view** sharing the cached master frame's buffer. Bundle the trivial free extra: memoize `_offset_alias(timeframe)`. `window()` **keeps returning a `pd.DataFrame`**. `searchsorted` left as-is. **Rejected:** monotonic per-(ticker,tf) cursor; bounds-only caching that keeps the copy; returning a bare numpy array.
+- **D-02 (hard read-only at the feed boundary; mutation fails loudly at source — NOT a global flag):** A view aliases the cached master frame; mutation would silently poison future ticks. Enforce at the source (D-09), plus a written audit and a drift test (D-08). **Rejected:** global `pd.options.mode.copy_on_write` (process-wide blast radius + byte-identity risk; mutation copies silently instead of failing loudly); audit + test only with no runtime guard.
+- **D-03 (`window()` only):** `window()` is the oracle-relevant and symbol-scaling path. `megaframe()` (deferred screener) inherits the read-only view for free; `current_bars()` is already a dict lookup. **Rejected:** also reworking `megaframe()`'s concat.
+- **D-06 (short-circuit empty; return the existing slice unchanged):** When the cutoff lands at the frame start, return `frame.iloc[pos:pos]` (size-0) **unchanged** — empty windows bypass the view + read-only machinery entirely. **Rejected:** routing empty windows through the uniform view path.
+- **D-07 (set direction; researcher pins the exact API):** Operate on the **sliced existing frame** and mark it read-only, preserving dtype / tz-aware `DatetimeIndex` / column set+order **exactly** — do **NOT** reconstruct via a new `pd.DataFrame(...)`. Byte-identity is the hard constraint. **Rejected:** pinning the precise call now (researcher's job); fully deferring.
+- **D-08 (drift/equivalence test — all three assertions):** **(a)** view content == old-copy content across sampled ticks; **(b)** mutating a returned window **RAISES** and cannot leak into the master; **(c)** the existing 7-rule bar-timing contract tests stay green. **Home:** `tests/unit/price_handler/feed/`. **Rejected:** content + contract only; leaving assertions fully to the planner.
+- **D-09 (enforce read-only at source — mark master frames non-writeable at build; subsumes the view-safety mechanism):** Mark each master frame in `self._frames` non-writeable when built (after `__init__` base load and after each `_resampled_frame` resample). Views inherit non-writeable buffers automatically. **Researcher MUST confirm** marking frames non-writeable does not break `resample`/`searchsorted`/the `ta` reads on views; **if it does, fall back** to marking the per-view buffer non-writeable. **Rejected:** audit + test only (no hard runtime guard).
+- **D-04 (gate on W2 measurable win + W1 non-regress; re-freeze W1):** Gate (b) for THIS phase = `perf-w2` sweep shows a measurable win AND W1 **does not regress**; re-freeze `W1-BASELINE.json` after. **Rejected:** holding the standard ≥5% W1 bar; a fully soft "any W2 win" with no threshold.
+- **D-05 (commit a W2 baseline + ≥10% bar at 50 symbols):** Capture `perf-w2 --json` before/after, commit a `W2-BASELINE.json` (the 50-symbol wall-clock), require a **≥10% improvement at the 50-symbol point**. **Researcher/planner** decides whether `perf-w2` needs a `--check`/`--baseline-out` flag. **Rejected:** before/after artifacts only, no committed baseline or % bar.
+
+### Claude's Discretion
+- Exact pandas 2.3.3 view-construction API under D-07, and the precise spot to mark master frames non-writeable under D-09 — within the locked direction + byte-identity + `ta`/`resample` compatibility check.
+- Shape/placement of the `_offset_alias` memoization (D-01).
+- Exact placement/shape of the drift/equivalence test within the D-08 three-assertion contract.
+- Whether to add a `--check`/`--baseline-out` flag to `perf-w2` (vs an ad-hoc before/after capture) to mechanize the D-05 ≥10% verdict.
+
+### Deferred Ideas (OUT OF SCOPE)
+- `megaframe()` / screener concat optimization — deferred subsystem; inherits the per-symbol view for free (D-03).
+- Monotonic per-(ticker,tf) cursor replacing `searchsorted` — microsecond-class; not worth the state (D-01).
+- Removing in-strategy/adapter re-slicing (`catalog.py` `bars[start_dt:]`) — strategy/adapter concern with byte-identity risk, outside the feed (D-01).
+</user_constraints>
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| PERF-06 | Reduce per-tick bar-feed window `iloc` frame copies (reusable view / cached slice bounds), preserving the look-ahead bar-timing contract — hotspot #5 (~4% W1 / ~22% W2). | **Finding A** pins the exact pandas-2.3.3 view-construction API (it turns out the `.iloc` slice on a homogeneous float64 single-block frame is *already a view* — the headline "copy" cost is NOT the `.iloc` slice itself; see the nuance in §Summary). **Finding B** confirms marking master frames non-writeable breaks nothing (`resample`/`searchsorted`/`ta` reads all pass). **Finding C** gives the exact exception types the D-08 (b) mutation assertion must target. **Validation Architecture** maps the D-08 three-assertion drift test + gate-(b) measurement. |
+</phase_requirements>
+
+## Summary
+
+The two CONTEXT-deferred questions are resolved with **HIGH confidence** by direct empirical test against the pinned venv (`pandas 2.3.3`, `numpy 2.2.6`, CoW default **OFF**), not training data.
+
+**The headline finding reframes the win.** On the golden-dataset master frame — a **homogeneous, single-block float64** OHLCV DataFrame with a tz-aware `DatetimeIndex` — `frame.iloc[start:pos]` in pandas 2.3.3 **already returns a view** (`_is_view == True`, `np.shares_memory(...) == True`, **no N×5 data copy of the buffer**). The PERF-BASELINE §2 #5 "each `iloc` slice copies a frame" characterization is imprecise for this homogeneous case: the positional slice does *not* deep-copy the float64 buffer; what is paid per tick is the **DataFrame/BlockManager/axis-object construction overhead** (a new `DataFrame` wrapper, a new sliced `DatetimeIndex`, BlockManager bookkeeping) — `O(1)`-ish in row count, not the `O(N×5)` buffer copy the spike implied. This still scales with `bars × symbols` (every tick, per symbol) and is the W2 ~22% cost, so the win is real — but the planner must understand the win is from **eliminating wrapper-construction churn and (the genuine free win) the per-call `_offset_alias` string compute**, not from eliminating a large data copy that mostly isn't happening on this frame shape.
+
+**The locked design works exactly as written, with one mechanism doing two jobs.** Marking the master frame's underlying numpy buffer `writeable=False` at build time (D-09): (1) makes views inherit `writeable=False` automatically (subsumes D-02's view-safety), and (2) breaks **nothing** that matters — `resample` produces a NEW writeable frame, `index.searchsorted` works on a non-writeable index, and the `ta`-library column reads on views build fresh Series without issue. **No fallback to per-view marking is needed** (D-09's fallback path is not triggered). A view off a non-writeable master compares **byte-identical** (values, dtype, tz-aware index, column set+order; `DataFrame.equals == True`) to today's `frame.iloc[start:pos].copy()`. The empty-window short-circuit (D-06, `frame.iloc[pos:pos]`) is unaffected and stays byte-identical.
+
+**The D-08 (b) mutation assertion has a landmine the planner MUST heed.** The exception raised depends on the mutation *form*, and the project runs `filterwarnings=["error"]`. A pandas-level chained assignment (`view.iloc[0,0] = x`) raises **`SettingWithCopyWarning`** (pandas' copy-detection guard fires first, BEFORE the read-only buffer is even touched) — that does NOT prove the read-only enforcement. The assertion that genuinely proves the non-writeable buffer is a **direct numpy write** to the underlying buffer (`view.to_numpy(copy=False)[0,0] = x` or `view._mgr.blocks[0].values[0,0] = x`), which raises **`ValueError: assignment destination is read-only`**. The D-08 (b) test must target the numpy `ValueError`, optionally also asserting the pandas-path raises.
+
+**Primary recommendation:** Implement D-01/D-07 as: in `window()`, take the existing positional slice and explicitly mark its values buffer non-writeable (belt-and-suspenders, since it already inherits read-only from the master), memoize `_offset_alias` via an instance dict (or `functools.lru_cache` on the module function), and short-circuit empty per D-06. Mark master frames non-writeable at the two build sites (`__init__` base load `:183`, `_resampled_frame` memoize `:273`). Write the D-08 test targeting the **numpy `ValueError`** for assertion (b). Mechanize gate (b) by adding a `--baseline-out`/`--check` flag pair to `run_w2_sweep.py` mirroring `run_w1_benchmark.py`, keyed on the **50-symbol point with a ≥10% bar**.
+
+## Architectural Responsibility Map
+
+| Capability | Primary Tier | Secondary Tier | Rationale |
+|------------|-------------|----------------|-----------|
+| Per-tick history-window slice | Data engine / `price_handler.feed` | — | `BacktestBarFeed.window()` is the single look-ahead-safe slice seam (module docstring); the read-only guarantee belongs in the feed, never in consumers (D-02). |
+| Master-frame immutability (read-only buffer) | Data engine / `price_handler.feed` build sites | — | The `self._frames` build sites (`__init__` `:181-188`, `_resampled_frame` `:256-274`) are the one-time, out-of-hot-loop place to mark non-writeable (D-09). |
+| Indicator compute over the window | Strategy engine / `indicators` | — | `catalog.py` reads `bars[col]` / `bars[start_dt:][col]` and builds NEW Series — pure consumer, never mutates (verified read-only audit, D-02). |
+| Behavior-preservation proof | Test tier / `tests/unit/price_handler/feed/` | `tests/unit/price/test_bar_feed.py` (existing contract tests) | D-08 three-assertion drift test; the existing `assert_frame_equal` contract tests are the byte-identity backstop. |
+| Gate-(b) measurement | Perf harness / `perf/runners/` | `perf/results/` | W2 sweep + committed `W2-BASELINE.json` (D-05); W1 non-regression guard (D-04). |
+
+## Standard Stack
+
+No new external packages. This phase uses only the **already-pinned, already-installed** stack.
+
+### Core
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| pandas | 2.3.3 | The frame/window type; `.iloc` slice, `resample`, `index.searchsorted` | Already the primary OHLCV structure across all handlers (CLAUDE.md); pinned, CoW-off transition release. `[VERIFIED: venv import]` |
+| numpy | 2.2.6 | Underlying buffer; `flags.writeable = False` is the read-only mechanism | `pandas 2.3.3` requires `numpy>=2.2.3,<2.3`; `2.2.6` is what is installed. `[VERIFIED: venv import]` |
+| ta | 0.11.0 | Indicator compute over the window (`catalog.py`) — the read-only consumer to keep working | Confirmed reads-only on views (Finding B). `[CITED: CLAUDE.md tech stack]` |
+
+> **Note on the pinned numpy:** CLAUDE.md/Technology-Stack lists `numpy >=2.2.3,<2.3`. The installed wheel is **2.2.6** (verified via `import numpy`), NOT a hypothetical 2.2.3. All empirical findings below are against 2.2.6. `[VERIFIED: venv import]`
+
+### Supporting
+| Library | Version | Purpose | When to Use |
+|---------|---------|---------|-------------|
+| functools.lru_cache (stdlib) | — | Optional memoization of `_offset_alias` (D-01) | If memoizing at the module-function level; an instance `dict` is the alternative (the feed already holds per-`(ticker, alias)` state). |
+
+### Alternatives Considered
+| Instead of | Could Use | Tradeoff |
+|------------|-----------|----------|
+| `numpy.flags.writeable = False` on the values block | `pd.options.mode.copy_on_write = True` | **Rejected by D-02** — process-wide blast radius, and CoW makes a mutating consumer *silently copy* instead of *failing loudly*. The numpy-flag approach is the locked direction. |
+| Explicit per-view re-marking | Rely solely on inherited read-only from the master | Inheritance already works (Finding B: views off a non-writeable master have `writeable == False`). A belt-and-suspenders explicit re-mark on the slice costs `O(1)` and documents intent — recommended but not strictly required. |
+
+**Installation:** None. No package added or changed.
+
+**Version verification:**
+```
+pandas 2.3.3   [VERIFIED: poetry run python -c "import pandas; print(pandas.__version__)"]
+numpy  2.2.6   [VERIFIED: poetry run python -c "import numpy;  print(numpy.__version__)"]
+CoW default: False   [VERIFIED: pd.options.mode.copy_on_write]
+```
+
+## Package Legitimacy Audit
+
+> Not applicable — this phase installs **no external packages**. All libraries used (`pandas`, `numpy`, `ta`, stdlib `functools`) are already in `pyproject.toml`/`poetry.lock` and verified present in the venv. No registry/slopcheck pass required.
+
+## Architecture Patterns
+
+### System Architecture Diagram (the per-tick window path)
+
+```
+TimeEvent(T) ─► generate_bar_event ─► BarEvent(bars stamped T)
+                                            │
+                                            ▼
+              strategies_handler.calculate_signals  (per subscribed strategy, per ticker)
+                                            │  feed.window(ticker, tf, max_window, asof=T)   [:125, and :294-295 pair]
+                                            ▼
+        ┌────────────── BacktestBarFeed.window() ──────────────┐
+        │ 1. alias = _offset_alias(tf)        ◄── MEMOIZE (D-01)│
+        │ 2. frame = self._resampled_frame(ticker, alias)      │
+        │      └─ cached master frame in self._frames          │
+        │         (marked writeable=False at build, D-09)      │
+        │ 3. cutoff = asof - tf + base_tf                      │
+        │ 4. pos = frame.index.searchsorted(cutoff, "right")   │
+        │ 5a. if empty (start==pos): return frame.iloc[pos:pos]│ ◄── SHORT-CIRCUIT (D-06)
+        │ 5b. else: view = frame.iloc[start:pos]               │ ◄── ALREADY A VIEW on float64 single block
+        │          (inherits writeable=False; optionally       │     (no buffer copy; D-07)
+        │           re-mark the view buffer non-writeable)     │
+        └──────────────────────┬───────────────────────────────┘
+                               ▼  pd.DataFrame (read-only view, byte-identical to old copy)
+              strategy.evaluate(window) ── self.bars = window; self.now = window.index[-1]  [base.py:368-369]
+                               │
+                               ▼  handle.repopulate(self.bars, now, tf)
+              adapter.compute(bars, col, ...) ── reads bars[col] / bars[start_dt:][col]      [catalog.py]
+                               │                  builds NEW Series (read-only, never mutates view)
+                               ▼
+                          SignalEvent  (look-ahead contract preserved end-to-end)
+```
+
+### Component Responsibilities
+| Component | File | Change in this phase |
+|-----------|------|----------------------|
+| `BacktestBarFeed.window()` | `bar_feed.py:360-399` | Memoize `_offset_alias`; short-circuit empty (D-06); return read-only view; mark view buffer non-writeable. **4-space indent.** |
+| `BacktestBarFeed.__init__` base load | `bar_feed.py:181-188` | Mark each master frame `writeable=False` after `store.read_bars` and before `_spans`/`_prebuilt` build (D-09). |
+| `BacktestBarFeed._resampled_frame` | `bar_feed.py:256-274` | Mark the newly-resampled frame `writeable=False` before `self._frames[key] = resampled` (D-09). |
+| `_offset_alias` (module fn) | `bar_feed.py:78-121` | Optionally `@lru_cache`; OR memoize in the feed. |
+| Consumers (audit only) | `strategies_handler.py:125,294-295`; `base.py:368-369`; `catalog.py`; `handle.py` | **No edits** — read-only audit evidence (D-02). Tab-indent; do NOT touch. |
+
+### Pattern 1: Mark a frame's values buffer non-writeable (D-09)
+**What:** Set the underlying numpy block's `writeable` flag to `False` after a frame is built.
+**When to use:** At the two `self._frames` write sites (`__init__` base load, `_resampled_frame` memoize).
+**Example:**
+```python
+# Source: empirically verified against pandas 2.3.3 / numpy 2.2.6
+# After: frame = store.read_bars(ticker)   (or)  resampled = base.resample(...).agg(_AGG)
+# Mark the single float64 block non-writeable so views inherit read-only and any
+# in-place mutation of the cached master fails loudly (D-09). Homogeneous float64
+# OHLCV => single block => one flag set covers all 5 columns.
+frame.to_numpy(copy=False).flags.writeable = False        # [VERIFIED: empirical test]
+# (Equivalent lower-level form: frame._mgr.blocks[0].values.flags.writeable = False —
+#  prefer the public to_numpy(copy=False) handle; planner picks the exact accessor.)
+```
+> **Caveat the planner must verify at implement time:** `to_numpy(copy=False)` returns the underlying buffer for a single-block homogeneous frame, but pandas does NOT *contractually* guarantee zero-copy for `to_numpy` in all cases. The empirical test confirmed `np.shares_memory(frame.to_numpy(copy=False), block.values) == True` for this frame shape. The planner should assert `shares_memory` (or use the `_mgr.blocks[0].values` accessor directly) at the build site, and the D-08 test proves the flag actually took effect end-to-end. `[VERIFIED: empirical test]`
+
+### Pattern 2: Return a read-only view from `window()` (D-01/D-07)
+**What:** Take the positional slice on the (already non-writeable) master and return it directly; optionally re-mark.
+**Example:**
+```python
+# Source: bar_feed.py:395-399 today + empirical pandas 2.3.3 behavior
+alias = self._alias_for(timeframe)              # MEMOIZED (D-01) — see Pattern 3
+frame = self._resampled_frame(ticker, alias)
+cutoff = asof - timeframe + self._base_timeframe
+pos = int(frame.index.searchsorted(cutoff, side="right"))
+start = max(0, pos - max_window)
+if start >= pos:                                # D-06 empty short-circuit (unchanged semantics)
+    return frame.iloc[pos:pos]
+view = frame.iloc[start:pos]                    # ALREADY a view on the float64 single block
+# view already inherits writeable=False from the master; explicit re-mark documents intent:
+view.to_numpy(copy=False).flags.writeable = False   # [VERIFIED: harmless, idempotent on a view]
+return view
+```
+> **Byte-identity guarantee (the hard constraint):** verified that `view` (off a non-writeable master) and today's `frame.iloc[start:pos].copy()` satisfy `np.array_equal(values)`, `dtypes.equals`, `index.equals` (incl. `tz == UTC`), identical column set+order, and `DataFrame.equals(...) == True`. `[VERIFIED: empirical test]`
+
+### Pattern 3: Memoize `_offset_alias` (D-01, the free win)
+**What:** Avoid the per-call string compute in `_offset_alias`.
+**Example (two options — Claude's discretion):**
+```python
+# Option A — module-level lru_cache (timedelta is hashable):
+import functools
+
+@functools.lru_cache(maxsize=None)
+def _offset_alias(timeframe: timedelta) -> str:
+    ...  # body unchanged
+
+# Option B — per-feed instance dict (the feed already holds per-(ticker,alias) state):
+# self._alias_cache: dict[timedelta, str] = {}
+def _alias_for(self, timeframe: timedelta) -> str:
+    a = self._alias_cache.get(timeframe)
+    if a is None:
+        a = _offset_alias(timeframe)
+        self._alias_cache[timeframe] = a
+    return a
+```
+> The feed already calls `_offset_alias` at `__init__:146`, `precompute:252`, and `window:395`. Option A is the smallest diff and keeps the function self-contained; Option B avoids a process-global cache across multiple feeds. Either is correct. `[ASSUMED: stylistic — defer to planner]`
+
+### Anti-Patterns to Avoid
+- **Reconstructing the window via `pd.DataFrame(view.values, index=..., columns=...)`** — explicitly rejected by D-07; risks tz/dtype/column-order drift → breaks byte-identity. Slice + mark only.
+- **Enabling `pd.options.mode.copy_on_write`** — rejected by D-02; makes mutation copy *silently* instead of failing loudly, and is process-wide.
+- **Asserting D-08 (b) against `SettingWithCopyWarning`** — that proves pandas' copy-detection, NOT the read-only buffer. Target the numpy `ValueError` (see Finding C / Pitfall 1).
+- **Routing the empty window through the view path** — rejected by D-06; pointless read-only marking on a zero-row buffer.
+- **"Tidying" the consumer slices in `catalog.py`** — byte-identity risk, out of scope (D-01 deferred).
+- **Normalizing indentation** — `bar_feed.py` is **4-space**; consumers are **tab**. This phase edits only the 4-space file.
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Zero-copy positional slice | A manual numpy-stride view + re-wrap in a DataFrame | `frame.iloc[start:pos]` (already a view on a float64 single block) | pandas already returns a view here; re-wrapping risks index/tz/dtype drift (D-07). |
+| Read-only enforcement | A per-tick runtime guard / wrapper class intercepting `__setitem__` | numpy `flags.writeable = False` at build (D-09) | One flag at build time, zero hot-loop cost; mutation fails loudly at the C level. |
+| Byte-identity check | A bespoke field-by-field comparison | `pd.testing.assert_frame_equal` / `DataFrame.equals` | The existing contract tests already use `assert_frame_equal` (`test_bar_feed.py:167,183`). |
+
+**Key insight:** The pandas/numpy primitives already do everything D-01/D-09 needs — the work is *wiring the flag at the right build sites* and *proving it with a test*, not building machinery.
+
+## Runtime State Inventory
+
+> Not a rename/refactor/migration phase — this is a behavior-preserving perf change to a single in-memory code path. No stored data, live service config, OS-registered state, secrets, or build artifacts carry phase-relevant state.
+>
+> - **Stored data:** None — the change is in-process per-tick slicing; no datastore keys change.
+> - **Live service config:** None.
+> - **OS-registered state:** None.
+> - **Secrets/env vars:** None.
+> - **Build artifacts:** None — no package rename, no egg-info impact. (`perf/results/W1-BASELINE.json` is re-frozen and `W2-BASELINE.json` is newly committed, but these are data artifacts produced by the phase, not stale state needing migration.)
+
+## Common Pitfalls
+
+### Pitfall 1: The D-08 (b) mutation assertion targets the WRONG exception
+**What goes wrong:** A test that does `view.iloc[0, 0] = 999` and asserts it raises will catch a **`SettingWithCopyWarning`** (under `filterwarnings=["error"]`), NOT a read-only `ValueError`. This passes even if the buffer were writeable — pandas' chained-assignment copy-detection fires *before* the buffer is touched. The test would give false confidence that read-only enforcement works.
+**Why it happens:** pandas intercepts chained assignment on a slice with its own guard; the numpy read-only flag is only hit by a *direct* buffer write.
+**Empirical exception map (`pandas 2.3.3` / `numpy 2.2.6`, `filterwarnings=["error"]`):**
+| Mutation form | Raises |
+|---------------|--------|
+| `view.iloc[0, 0] = x` | `SettingWithCopyWarning` (pandas guard — NOT the read-only proof) |
+| `view["close"].iloc[0] = x` | `FutureWarning` (chained-assignment deprecation) |
+| `view._mgr.blocks[0].values[0, 0] = x` | **`ValueError: assignment destination is read-only`** ✅ |
+| `view.to_numpy(copy=False)[0, 0] = x` | **`ValueError: assignment destination is read-only`** ✅ |
+**How to avoid:** Assertion (b) MUST do a **direct numpy write** (`view.to_numpy(copy=False)[0, 0] = x` or the `_mgr.blocks[0].values` form) and assert `ValueError` with `match="read-only"`. Optionally ALSO assert the pandas-path raises (any of the three) to document the layered defense, and assert the master frame is byte-unchanged afterward (no leak). `[VERIFIED: empirical test]`
+
+### Pitfall 2: Assuming the `.iloc` slice is the data copy (it isn't, for this frame)
+**What goes wrong:** Planning the change as "eliminate the N×5 float64 copy" and expecting a memory drop proportional to window size. The homogeneous float64 single-block frame's `.iloc[start:pos]` is **already a view** — there is no large buffer copy to eliminate.
+**Why it happens:** PERF-BASELINE §2 #5's "each `iloc` slice copies a frame" / "high (each `iloc` slice copies a frame)" is true for *mixed-dtype* frames (pandas copies across blocks), but the OHLCV frame is single-block. The per-tick cost is **DataFrame/Index/BlockManager wrapper construction**, not buffer copy.
+**How to avoid:** Frame the win to the planner as **wrapper-construction churn + the `_offset_alias` string compute**, and validate the win by **wall-clock** (the W2 sweep), not by a tracemalloc memory drop (which may be smaller than expected). The ≥10%-at-50-symbols bar (D-05) is wall-clock — correct. `[VERIFIED: empirical test]`
+
+### Pitfall 3: Marking the master non-writeable AFTER `_spans`/`_prebuilt` are derived
+**What goes wrong:** The `__init__` loop reads `frame.index[0]`/`frame.index[-1]` (`:184`) and `frame.iterrows()` (`:187`) from the same frame. Marking the *values* buffer non-writeable does not affect index reads or `iterrows` (verified: searchsorted and reads work on non-writeable frames), so ordering is not strictly load-bearing — but mark *after* the frame is fully populated and before it is exposed, to keep the "frames written once, then immutable" invariant honest.
+**How to avoid:** Mark immediately after assignment to `self._frames[...]`, i.e. right after `:183` and right before `:273`'s `return`. `[VERIFIED: resample/searchsorted/iterrows all pass on non-writeable frame]`
+
+### Pitfall 4: `_offset_alias` memoization changing the FutureWarning behavior
+**What goes wrong:** `_offset_alias` deliberately raises `ValueError` for unsupported timeframes (the Feed-owns-the-map Pitfall 2 in its docstring, guarding against the `'30m'`→MONTH-END FutureWarning). An `lru_cache` does NOT cache exceptions — each unsupported call re-raises — so caching is safe. But verify the cache key (`timedelta`) is hashable (it is) and that the existing `_offset_alias` tests still pass.
+**How to avoid:** Keep the `_offset_alias` body byte-unchanged; only wrap/memoize. Run the existing alias tests. `[VERIFIED: timedelta is hashable; lru_cache does not cache exceptions — CPython semantics]`
+
+## Code Examples
+
+### The D-08 three-assertion drift test (skeleton)
+```python
+# Source: synthesized from D-08 + empirical exception map; home tests/unit/price_handler/feed/
+# (planner: reconcile with the existing tests/unit/price/test_bar_feed.py — see Open Question 1)
+import numpy as np
+import pandas as pd
+import pytest
+
+def test_window_view_content_equals_old_copy(daily_feed, daily_base_frame):
+    # (a) view content == old-copy content across sampled ticks (byte-identical).
+    for asof in SAMPLED_TICKS:
+        view = daily_feed.window('BTCUSD', timedelta(days=1), max_window=3, asof=asof)
+        expected = daily_base_frame.iloc[<...>:<...>]  # the same positional slice, copied
+        pd.testing.assert_frame_equal(view, expected, check_freq=False)
+
+def test_window_view_is_read_only_and_cannot_leak(daily_feed):
+    # (b) mutating a returned window RAISES (read-only) and cannot leak into the master.
+    view = daily_feed.window('BTCUSD', timedelta(days=1), max_window=3, asof=SOME_TICK)
+    before = view.to_numpy().copy()
+    with pytest.raises(ValueError, match="read-only"):
+        view.to_numpy(copy=False)[0, 0] = 999.0          # DIRECT numpy write — the real proof
+    # master unchanged: re-fetch the same window, assert byte-identical to `before`
+    again = daily_feed.window('BTCUSD', timedelta(days=1), max_window=3, asof=SOME_TICK)
+    assert np.array_equal(again.to_numpy(), before)
+
+# (c) is the existing contract suite staying green — no new test, just don't break
+#     tests/unit/price/test_bar_feed.py (assert_frame_equal at :167, :183).
+```
+
+### Mechanizing gate (b): add `--check`/`--baseline-out` to `run_w2_sweep.py`
+```python
+# Source: mirror run_w1_benchmark.py:150-249. Keep the {1,10,50} table for visibility;
+# add a W2-BASELINE.json keyed on the 50-symbol wall_clock_s with a ≥10% IMPROVEMENT bar.
+def _to_w2_baseline_schema(points: list[dict]) -> dict:
+    p50 = next(p for p in points if p["n_symbols"] == 50)
+    return {
+        "schema_version": 1,
+        "frozen_at": dt.date.today().isoformat(),
+        "metric": {"wall_clock_s_at_50": round(p50["wall_clock_s"], 2),
+                   "peak_mem_mb_at_50": round(p50["peak_mem_mb"], 2)},
+        "sweep": {"n_symbols": _N_SYMBOLS_SWEEP, "n_bars": _N_BARS, "seed": _SEED},
+        "points": points,
+    }
+
+def _check_w2(points, baseline_path, min_improvement_pct=10.0) -> int:
+    # PASS (return 0) iff 50-symbol wall_clock improved by >= min_improvement_pct.
+    # Mirror run_w1's soft-guard tone but invert the sense (this gate REQUIRES a win).
+    base = json.load(open(baseline_path))
+    base50 = base["metric"]["wall_clock_s_at_50"]
+    now50  = next(p for p in points if p["n_symbols"] == 50)["wall_clock_s"]
+    impr = (base50 - now50) / base50 * 100.0
+    print(f"W2@50 {now50:.2f}s  improvement {impr:+.1f}%  (baseline {base50:.2f}s)")
+    return 0 if impr >= min_improvement_pct else 1
+```
+> **D-05 sequencing nuance for the planner:** the ≥10% bar compares **after** against a **before** baseline. The before-baseline must be captured on the SAME machine in the SAME session as the after-run (per memory `v15-perf-gateb-thermal-drift` — the box is thermally sensitive; a frozen cross-session baseline can drift). Recommend: capture `--baseline-out W2-BASELINE-pre.json` immediately before the change, run `--check` after, and commit the *after* run as the standing `W2-BASELINE.json` (which seeds Phase 5). `[VERIFIED: memory note v15-perf-gateb-thermal-drift; CITED: D-05]`
+
+## State of the Art
+
+| Old Approach | Current Approach (pandas 2.3.3) | When Changed | Impact |
+|--------------|----------------------------------|--------------|--------|
+| `.iloc` slice copy/view ambiguous; SettingWithCopyWarning era | CoW **opt-in** (default OFF in 2.3.x); homogeneous single-block `.iloc` slice returns a **view** | 2.3.x is the CoW transition release; CoW becomes default in 3.0 (Jan 2026) | This phase deliberately stays on the **CoW-off** path and enforces read-only via numpy flags (D-02 rejects global CoW). When the project eventually moves to pandas 3.0, the numpy-flag mechanism still works; CoW would *additionally* make mutations copy silently — but the explicit non-writeable buffer still raises loudly, so the D-08 guarantee survives the upgrade. |
+
+**Deprecated/outdated:**
+- Global `pd.options.mode.copy_on_write` as a safety mechanism here — rejected (D-02). It is the pandas-3.0 default but is the wrong tool for "fail loudly on mutation."
+
+## Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| A1 | `_offset_alias` memoization shape (lru_cache vs instance dict) is stylistic — either is correct | Pattern 3 | Low — both verified to preserve the raise-on-unsupported behavior; planner picks. |
+| A2 | The win is wrapper-construction churn + alias string compute, not a large buffer copy | Pitfall 2 / Summary | Medium — if a future frame shape were mixed-dtype (it is not for golden OHLCV), `.iloc` WOULD copy and the win would be larger. The golden frame is verified single-block float64, so this holds for the gated path. |
+| A3 | `--check`/`--baseline-out` on `run_w2_sweep.py` is the right mechanization (vs ad-hoc) | gate (b) | Low — D-05 explicitly leaves this to researcher/planner; the mirror of `run_w1` is the established pattern and also seeds Phase 5. |
+
+**Note:** The two load-bearing technical claims (view-construction API, non-writeable-breaks-nothing, exception types, byte-identity) are all `[VERIFIED: empirical test]`, not assumed.
+
+## Open Questions
+
+1. **D-08 test home vs existing contract tests.**
+   - What we know: D-08 says home is `tests/unit/price_handler/feed/` (which does **not exist** yet). The existing 7-rule bar-timing contract tests live in `tests/unit/price/test_bar_feed.py` (383 lines, uses `assert_frame_equal` at `:167`/`:183` — the byte-identity backstop for assertion (c)).
+   - What's unclear: whether to create the new `tests/unit/price_handler/feed/` dir per D-08's literal text, or co-locate the new drift test with the existing contract tests in `tests/unit/price/test_bar_feed.py`.
+   - Recommendation: Co-locate the new drift test in `tests/unit/price/test_bar_feed.py` (or a sibling `test_bar_feed_window_view.py` in the SAME dir) so the existing contract suite (assertion (c)) and the new (a)/(b) assertions live together and run as one unit. Treat D-08's path as directional, not literal. Confirm with the planner; this is a placement decision, not a correctness one.
+
+2. **Whether to add the explicit per-view re-mark.**
+   - What we know: a view off a non-writeable master already has `writeable == False` (Finding B) — the explicit re-mark in Pattern 2 is redundant for safety.
+   - What's unclear: whether the redundant re-mark is worth the extra line for documentation/defense-in-depth.
+   - Recommendation: Include it (cheap, documents intent, survives a future refactor that might forget to mark a master). Low stakes either way.
+
+## Environment Availability
+
+| Dependency | Required By | Available | Version | Fallback |
+|------------|------------|-----------|---------|----------|
+| pandas | window slice / resample / searchsorted | ✓ | 2.3.3 | — |
+| numpy | read-only buffer flag | ✓ | 2.2.6 | — |
+| ta | indicator reads on the view (consumer audit) | ✓ | 0.11.0 | — |
+| poetry venv | running tests + perf runners | ✓ | in-project `.venv` | — |
+
+**Missing dependencies with no fallback:** None.
+**Missing dependencies with fallback:** None.
+
+> **Worktree note (memory `worktree-venv-shadowing` / `worktree-make-test-env-abort`):** the current branch is a worktree (`v1.5/phase-6-bar-feed-window-copies`). `make test` may abort on a missing `.env`; run `poetry run pytest tests` in the worktree and re-run `make test` in the main checkout for the gate. Prepend `PYTHONPATH="$PWD"` if the editable install shadows worktree edits.
+
+## Validation Architecture
+
+### Test Framework
+| Property | Value |
+|----------|-------|
+| Framework | pytest 8.4.2 (`testpaths=["tests"]`, `minversion="8.0"`) |
+| Config file | `pyproject.toml` `[tool.pytest.ini_options]` (`filterwarnings=["error", ...]`, `--strict-markers`, `--strict-config`) |
+| Quick run command | `poetry run pytest tests/unit/price/test_bar_feed.py -q` |
+| Full suite command | `make test` (main checkout) / `poetry run pytest tests` (worktree) |
+
+### Phase Requirements → Test Map
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|-------------|
+| PERF-06 (a) | View content == old-copy content across sampled ticks (byte-identical values/dtype/tz-index/columns) | unit | `poetry run pytest tests/unit/price/test_bar_feed.py -k content_equals -q` | ❌ Wave 0 (new drift test) |
+| PERF-06 (b) | Mutating a returned window RAISES read-only `ValueError` and cannot leak into the master | unit | `poetry run pytest tests/unit/price/test_bar_feed.py -k read_only -q` | ❌ Wave 0 (new drift test) |
+| PERF-06 (c) | Existing 7-rule bar-timing contract stays green | unit | `poetry run pytest tests/unit/price/test_bar_feed.py -q` | ✅ exists (`:124-201`, uses `assert_frame_equal`) |
+| Gate (a) | Byte-exact SMA_MACD oracle (134 / `46189.87730727451`) | integration | `poetry run pytest tests/integration/test_backtest_oracle.py -q` | ✅ exists (memory `oracle-test-location`) |
+| Gate (a) | `mypy --strict` clean | static | `poetry run mypy itrader` | ✅ infra exists |
+| Gate (a) | Determinism double-run byte-identical | integration | (run oracle twice; assert identical) | ✅ oracle is deterministic |
+| Gate (b) | W2 ≥10% improvement at 50 symbols + W1 non-regress | perf | `make perf-w2` (+ new `--check`); `make perf-w1` | ⚠️ W2 needs `--check`/`--baseline-out` (Wave 0) |
+
+### Sampling Rate
+- **Per task commit:** `poetry run pytest tests/unit/price/test_bar_feed.py -q` (the drift + contract tests — fast, <30s).
+- **Per wave merge:** `make test` (full unit/integration suite) + `poetry run mypy itrader`.
+- **Phase gate (a):** `poetry run pytest tests/integration/test_backtest_oracle.py` green (134 / `46189.87730727451`), `mypy --strict` clean, determinism double-run identical, full suite green.
+- **Phase gate (b):** `make perf-w2 --check` shows ≥10% improvement at 50 symbols AND `make perf-w1` (`--check`) shows W1 within band (no regression); then re-freeze `W1-BASELINE.json` (`make perf-baseline`) and commit `W2-BASELINE.json`.
+
+### Wave 0 Gaps
+- [ ] `tests/unit/price/test_bar_feed.py` (or sibling in same dir) — add assertions (a) content-equality and (b) read-only-raises (Open Question 1 — placement). Assertion (b) MUST target the numpy `ValueError` (Pitfall 1).
+- [ ] `perf/runners/run_w2_sweep.py` — add `--baseline-out`/`--check` flags mirroring `run_w1_benchmark.py` (D-05; Code Examples). Add `perf-w2-baseline` / `perf-w2 --check` Makefile wiring as needed.
+- [ ] `perf/results/W2-BASELINE.json` — capture and commit the after-run 50-symbol baseline (seeds Phase 5).
+- [ ] `perf/results/W1-BASELINE.json` — re-freeze after the change (D-04).
+- Framework install: none — pytest infra already present.
+
+## Security Domain
+
+> Not applicable in the conventional ASVS sense — this is an internal, offline backtest data-path optimization with no auth/session/network/input-validation surface. The one *integrity* concern is look-ahead/data-corruption (a future tick reading a mutated past bar), which is exactly what D-09's read-only enforcement defends — covered by the Validation Architecture (D-08 assertion (b)) above. No external `security_enforcement` config artifact is touched; no new attack surface is introduced.
+
+| Integrity threat | STRIDE | Mitigation (this phase) |
+|------------------|--------|-------------------------|
+| A consumer mutates a shared view → poisons a future tick (silent look-ahead breach) | Tampering | numpy `writeable=False` on the master buffer (D-09) → mutation raises `ValueError`; proven by D-08 assertion (b). |
+
+## Sources
+
+### Primary (HIGH confidence)
+- **Empirical test against the pinned venv** (`pandas 2.3.3`, `numpy 2.2.6`, CoW default `False`) — the load-bearing source. Verified: `.iloc` slice on a homogeneous float64 single-block frame is already a view (`_is_view`, `shares_memory`); non-writeable master does not break `resample`/`searchsorted`/`ta` reads; view inherits `writeable=False`; byte-identity (`DataFrame.equals`, dtype/tz-index/column-order); the mutation-form→exception map (`SettingWithCopyWarning` / `FutureWarning` / `ValueError read-only`); empty-window `iloc[pos:pos]` semantics preserved. `[VERIFIED]`
+- `itrader/price_handler/feed/bar_feed.py` — target code (`window:360-399`, `_resampled_frame:256-274`, `__init__:181-188`, `_offset_alias:78-121`). `[VERIFIED: read]`
+- `itrader/strategy_handler/{strategies_handler.py,base.py,indicators/catalog.py,indicators/handle.py}` — consumer read-only audit evidence. `[VERIFIED: read]`
+- `perf/runners/{run_w1_benchmark.py,run_w2_sweep.py}`, `Makefile:99-112` — the `--check`/`--baseline-out` pattern to mirror. `[VERIFIED: read]`
+- `perf/results/PERF-BASELINE-RESULTS.md` §2 #5, §3 — the spike (authoritative hotspot source). `[VERIFIED: read]`
+- `tests/unit/price/test_bar_feed.py` — existing 7-rule contract tests + `assert_frame_equal` byte-identity backstop. `[VERIFIED: read]`
+
+### Secondary (MEDIUM confidence)
+- pandas 2.3.0 / 3.0 whatsnew + PDEP-7 (CoW transition: opt-in in 2.3.x, default in 3.0) — confirms the CoW posture this phase deliberately avoids. `[CITED]`
+
+### Tertiary (LOW confidence)
+- None — the technical claims were promoted to HIGH via empirical verification.
+
+## Metadata
+
+**Confidence breakdown:**
+- View-construction API (D-07): **HIGH** — empirically verified `.iloc` is already a view, byte-identity confirmed.
+- Non-writeable-breaks-nothing (D-09): **HIGH** — `resample`/`searchsorted`/`ta` reads all verified passing; no fallback needed.
+- Mutation exception types (D-08 b): **HIGH** — exact map captured under `filterwarnings=["error"]`.
+- Gate-(b) mechanization (D-05): **MEDIUM** — the `--check`/`--baseline-out` mirror is the established pattern; thermal-drift sequencing per memory note.
+- Win characterization (Pitfall 2): **HIGH** — verified single-block float64 means no large buffer copy; win is wrapper churn + alias compute.
+
+**Research date:** 2026-06-24
+**Valid until:** 2026-07-24 (stable — pinned pandas/numpy; re-verify if pandas is bumped toward 3.0, which flips CoW default).

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-RESEARCH.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-RESEARCH.md
@@ -328,17 +328,22 @@ def _check_w2(points, baseline_path, min_improvement_pct=10.0) -> int:
 
 **Note:** The two load-bearing technical claims (view-construction API, non-writeable-breaks-nothing, exception types, byte-identity) are all `[VERIFIED: empirical test]`, not assumed.
 
-## Open Questions
+## Open Questions (RESOLVED)
 
-1. **D-08 test home vs existing contract tests.**
+> Both questions are advisory placement/stylistic choices (not technical unknowns) and are
+> resolved in the plan action sections.
+
+1. **D-08 test home vs existing contract tests.** **RESOLVED:** co-locate in
+   `tests/unit/price/test_bar_feed.py` per 06-01 Task 0 action; D-08's literal
+   `tests/unit/price_handler/feed/` path is treated as directional.
    - What we know: D-08 says home is `tests/unit/price_handler/feed/` (which does **not exist** yet). The existing 7-rule bar-timing contract tests live in `tests/unit/price/test_bar_feed.py` (383 lines, uses `assert_frame_equal` at `:167`/`:183` — the byte-identity backstop for assertion (c)).
    - What's unclear: whether to create the new `tests/unit/price_handler/feed/` dir per D-08's literal text, or co-locate the new drift test with the existing contract tests in `tests/unit/price/test_bar_feed.py`.
    - Recommendation: Co-locate the new drift test in `tests/unit/price/test_bar_feed.py` (or a sibling `test_bar_feed_window_view.py` in the SAME dir) so the existing contract suite (assertion (c)) and the new (a)/(b) assertions live together and run as one unit. Treat D-08's path as directional, not literal. Confirm with the planner; this is a placement decision, not a correctness one.
 
-2. **Whether to add the explicit per-view re-mark.**
-   - What we know: a view off a non-writeable master already has `writeable == False` (Finding B) — the explicit re-mark in Pattern 2 is redundant for safety.
-   - What's unclear: whether the redundant re-mark is worth the extra line for documentation/defense-in-depth.
-   - Recommendation: Include it (cheap, documents intent, survives a future refactor that might forget to mark a master). Low stakes either way.
+2. **Whether to add the explicit per-view re-mark.** **RESOLVED:** include the
+   belt-and-suspenders re-mark per 06-01 Task 1 action (cheap, documents intent,
+   survives a future refactor that forgets to mark a master). Redundant for safety
+   but low-stakes positive.
 
 ## Environment Availability
 

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-REVIEW-FIX.iter2.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-REVIEW-FIX.iter2.md
@@ -1,0 +1,94 @@
+---
+phase: 06-bar-feed-window-copies-optional-slip-able
+fixed_at: 2026-06-24T15:40:00Z
+review_path: .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-REVIEW.md
+iteration: 1
+findings_in_scope: 5
+fixed: 4
+skipped: 1
+status: partial
+---
+
+# Phase 06: Code Review Fix Report
+
+**Fixed at:** 2026-06-24T15:40:00Z
+**Source review:** .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-REVIEW.md
+**Iteration:** 1
+
+**Summary:**
+- Findings in scope: 5 (fix_scope=all — critical/warning/info)
+- Fixed: 4
+- Skipped: 1
+
+## Fixed Issues
+
+### WR-01: Forward-step branch silently miscomputes the cursor on a tz-naive `asof`
+
+**Files modified:** `itrader/price_handler/feed/bar_feed.py`
+**Commit:** accde2d
+**Applied fix:** Added a one-time tz-awareness guard at the top of `window()` (right
+after `cutoff` is computed, before the int64 forward-cursor logic). When
+`cutoff.tzinfo is None` it raises `ValueError`, so the forward-step branch can no
+longer silently skew the int64 compare against the tz-aware index `asi8`. This
+restores the loud-fail backstop the cold/rebuild `searchsorted` path already gives
+(it raises `TypeError` on a tz-naive↔tz-aware compare) and makes both branches fail
+identically. Behavior-preserving on the engine path: `window()` is always called
+with `asof=event.time`, which is tz-aware across the whole `TimeGenerator` grid, so
+no reachable engine call is affected. Verified: `mypy --strict` clean on the file;
+all 27 `test_bar_feed.py` tests pass.
+
+### WR-02: `start`/`end` can reach `_wire_system` as `None` if the frames dict is empty
+
+**Files modified:** `perf/runners/run_w2_sweep.py`
+**Commit:** f681a36
+**Applied fix:** Added an explicit `if start is None or end is None: raise
+RuntimeError(...)` guard after the per-frame loop and before the timed passes, so an
+empty `frames` dict fails loudly instead of passing `None` into `_wire_system`'s
+typed `start: str, end: str` signature. Harness-only file; currently unreachable
+(`_N_SYMBOLS_SWEEP` is always non-empty). Verified: file parses (`ast.parse` OK);
+4-space indentation preserved (no normalization).
+
+### IN-01: Comment claims `asi8` is a "cached" view; it returns a fresh wrapper each call
+
+**Files modified:** `itrader/price_handler/feed/bar_feed.py`
+**Commit:** 0c1f1b4
+**Applied fix:** Reworded the inline comment from `# zero-copy cached int64 ns view
+(UTC)` to `# zero-copy int64 ns view (UTC; fresh wrapper, shared buffer)` so it no
+longer implies object-level memoization (`frame.index.asi8` returns a new ndarray
+object per call but shares the underlying buffer). Comment-only; no code/behavior
+change. Verified: `mypy --strict` clean; tests pass.
+
+### IN-03: No dedicated test for the equal-consecutive-cutoff forward branch
+
+**Files modified:** `tests/unit/price/test_bar_feed.py`
+**Commit:** 6d7a254
+**Applied fix:** Added `test_cursor_repeated_identical_asof_forward_branch`, which
+calls `window()` twice with an identical `asof` (exercising the `cutoff_i8 ==
+last_cut` case: forward branch, `pos == last_pos`, non-advancing while loop) and
+asserts the two returned windows are byte-identical via
+`pd.testing.assert_frame_equal`. Regression-locks the previously-untested branch.
+Verified: new test passes (27 passed total in `test_bar_feed.py`).
+
+## Skipped Issues
+
+### IN-02: `asi8` is re-derived every `window()` call rather than once per frame
+
+**File:** `itrader/price_handler/feed/bar_feed.py:505`
+**Reason:** skipped — out of strict v1 scope (performance), reviewer flagged it as a
+"consistency observation only; correctness is unaffected." This is a golden-locked,
+behavior-preserving PERF-06 phase. Caching `frame.index.asi8` alongside `self._frames`
+would touch the per-tick hot path; the reviewer notes the per-call O(1) wrapper
+construction is negligible, so applying it risks a behavior/perf regression for no
+correctness benefit. Per explicit guidance, prefer SKIP over altering the hot-path in
+a golden-locked phase. The IN-01 comment fix (committed) already corrects the
+misleading "cached" wording that IN-02 builds on.
+**Original issue:** Since each memoized master frame is immutable for the life of the
+feed, `frame.index.asi8` is invariant per `(ticker, alias)` and could be cached
+(e.g. `self._index_i8[key]`) to drop the per-tick wrapper allocation — the
+compute-once discipline already applied to `_spans`/`_prebuilt`.
+
+---
+
+_Fixed: 2026-06-24T15:40:00Z_
+_Fixer: Claude (gsd-code-fixer)_
+_Iteration: 1_

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-REVIEW-FIX.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-REVIEW-FIX.md
@@ -1,0 +1,94 @@
+---
+phase: 06-bar-feed-window-copies-optional-slip-able
+fixed_at: 2026-06-24T15:40:00Z
+review_path: .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-REVIEW.md
+iteration: 1
+findings_in_scope: 5
+fixed: 4
+skipped: 1
+status: partial
+---
+
+# Phase 06: Code Review Fix Report
+
+**Fixed at:** 2026-06-24T15:40:00Z
+**Source review:** .planning/phases/06-bar-feed-window-copies-optional-slip-able/06-REVIEW.md
+**Iteration:** 1
+
+**Summary:**
+- Findings in scope: 5 (fix_scope=all — critical/warning/info)
+- Fixed: 4
+- Skipped: 1
+
+## Fixed Issues
+
+### WR-01: Forward-step branch silently miscomputes the cursor on a tz-naive `asof`
+
+**Files modified:** `itrader/price_handler/feed/bar_feed.py`
+**Commit:** accde2d
+**Applied fix:** Added a one-time tz-awareness guard at the top of `window()` (right
+after `cutoff` is computed, before the int64 forward-cursor logic). When
+`cutoff.tzinfo is None` it raises `ValueError`, so the forward-step branch can no
+longer silently skew the int64 compare against the tz-aware index `asi8`. This
+restores the loud-fail backstop the cold/rebuild `searchsorted` path already gives
+(it raises `TypeError` on a tz-naive↔tz-aware compare) and makes both branches fail
+identically. Behavior-preserving on the engine path: `window()` is always called
+with `asof=event.time`, which is tz-aware across the whole `TimeGenerator` grid, so
+no reachable engine call is affected. Verified: `mypy --strict` clean on the file;
+all 27 `test_bar_feed.py` tests pass.
+
+### WR-02: `start`/`end` can reach `_wire_system` as `None` if the frames dict is empty
+
+**Files modified:** `perf/runners/run_w2_sweep.py`
+**Commit:** f681a36
+**Applied fix:** Added an explicit `if start is None or end is None: raise
+RuntimeError(...)` guard after the per-frame loop and before the timed passes, so an
+empty `frames` dict fails loudly instead of passing `None` into `_wire_system`'s
+typed `start: str, end: str` signature. Harness-only file; currently unreachable
+(`_N_SYMBOLS_SWEEP` is always non-empty). Verified: file parses (`ast.parse` OK);
+4-space indentation preserved (no normalization).
+
+### IN-01: Comment claims `asi8` is a "cached" view; it returns a fresh wrapper each call
+
+**Files modified:** `itrader/price_handler/feed/bar_feed.py`
+**Commit:** 0c1f1b4
+**Applied fix:** Reworded the inline comment from `# zero-copy cached int64 ns view
+(UTC)` to `# zero-copy int64 ns view (UTC; fresh wrapper, shared buffer)` so it no
+longer implies object-level memoization (`frame.index.asi8` returns a new ndarray
+object per call but shares the underlying buffer). Comment-only; no code/behavior
+change. Verified: `mypy --strict` clean; tests pass.
+
+### IN-03: No dedicated test for the equal-consecutive-cutoff forward branch
+
+**Files modified:** `tests/unit/price/test_bar_feed.py`
+**Commit:** 6d7a254
+**Applied fix:** Added `test_cursor_repeated_identical_asof_forward_branch`, which
+calls `window()` twice with an identical `asof` (exercising the `cutoff_i8 ==
+last_cut` case: forward branch, `pos == last_pos`, non-advancing while loop) and
+asserts the two returned windows are byte-identical via
+`pd.testing.assert_frame_equal`. Regression-locks the previously-untested branch.
+Verified: new test passes (27 passed total in `test_bar_feed.py`).
+
+## Skipped Issues
+
+### IN-02: `asi8` is re-derived every `window()` call rather than once per frame
+
+**File:** `itrader/price_handler/feed/bar_feed.py:505`
+**Reason:** skipped — out of strict v1 scope (performance), reviewer flagged it as a
+"consistency observation only; correctness is unaffected." This is a golden-locked,
+behavior-preserving PERF-06 phase. Caching `frame.index.asi8` alongside `self._frames`
+would touch the per-tick hot path; the reviewer notes the per-call O(1) wrapper
+construction is negligible, so applying it risks a behavior/perf regression for no
+correctness benefit. Per explicit guidance, prefer SKIP over altering the hot-path in
+a golden-locked phase. The IN-01 comment fix (committed) already corrects the
+misleading "cached" wording that IN-02 builds on.
+**Original issue:** Since each memoized master frame is immutable for the life of the
+feed, `frame.index.asi8` is invariant per `(ticker, alias)` and could be cached
+(e.g. `self._index_i8[key]`) to drop the per-tick wrapper allocation — the
+compute-once discipline already applied to `_spans`/`_prebuilt`.
+
+---
+
+_Fixed: 2026-06-24T15:40:00Z_
+_Fixer: Claude (gsd-code-fixer)_
+_Iteration: 1_

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-REVIEW.iter2.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-REVIEW.iter2.md
@@ -1,0 +1,135 @@
+---
+phase: 06-bar-feed-window-copies-optional-slip-able
+reviewed: 2026-06-24T15:40:00Z
+depth: standard
+files_reviewed: 4
+files_reviewed_list:
+  - itrader/price_handler/feed/bar_feed.py
+  - itrader/events_handler/full_event_handler.py
+  - perf/runners/run_w2_sweep.py
+  - tests/unit/price/test_bar_feed.py
+findings:
+  critical: 0
+  warning: 2
+  info: 3
+  total: 5
+status: issues_found
+---
+
+# Phase 06: Code Review Report
+
+**Reviewed:** 2026-06-24T15:40:00Z
+**Depth:** standard
+**Files Reviewed:** 4
+**Status:** issues_found
+
+## Summary
+
+This is a behavior-preserving PERF-06 phase. The central change is the per-(ticker, alias)
+monotonic int64 forward cursor that replaces the per-tick `frame.index.searchsorted(cutoff,
+side="right")` inside `BacktestBarFeed.window()`. The review focused adversarially on the
+LOOK-AHEAD INVARIANT (no bar with `time > cutoff` may leak) and on byte-identity with the old
+`searchsorted` path.
+
+**The core cursor logic is correct.** I brute-forced the forward-step walk against a fresh
+`searchsorted(side="right")` oracle over a gappy tz-aware index across cold / monotonic-forward /
+multi-bar-step / duplicate-cutoff / backwards-jump streams — every position matched byte-for-byte.
+The `<=` comparison reproduces `side="right"` exactly; the `cutoff_i8 < last_cut` rebuild guard
+fires on every backwards/jumped cutoff and never trusts stale state; the equal-consecutive-cutoff
+case (`cutoff_i8 == last_cut`) correctly takes the forward branch and does not advance. The
+read-only view, the empty-window short-circuit (`frame.iloc[pos:pos]`), and byte-identity
+(dtype/tz-aware index/column set+order) are all preserved. All 26 unit tests pass; `mypy --strict`
+is clean on the changed file. The 7-rule bar-timing contract docstring is intact.
+
+The `full_event_handler.py` change is a clean removal of a single per-tick DEBUG log line; the
+`EventType.TIME` dispatch route is byte-unchanged and indentation stays tabs (134 tab lines, 0
+space lines). The `run_w2_sweep.py` split into a timed PASS 1 + un-timed tracemalloc PASS 2 is a
+harness-only change; `bar_feed.py` and `run_w2_sweep.py` remain 4-space, no normalization.
+
+Two WARNINGs below concern robustness regressions that are NOT reachable on the golden/live engine
+path (so not BLOCKERs), plus three INFO items.
+
+## Narrative Findings (AI reviewer)
+
+## Warnings
+
+### WR-01: Forward-step branch silently miscomputes the cursor on a tz-naive `asof`
+
+**File:** `itrader/price_handler/feed/bar_feed.py:510-524`
+**Issue:** The forward-step branch compares `cutoff_i8 = pd.Timestamp(cutoff).value` (raw ns since
+the UTC epoch) directly against `iv_i8 = frame.index.asi8`. The cold/rebuild branch still calls
+`frame.index.searchsorted(cutoff, side="right")`, which **raises `TypeError` ("Cannot compare
+tz-naive and tz-aware datetime-like objects")** when `cutoff` is tz-naive against the tz-aware
+index. The two branches therefore DIVERGE for a tz-naive `asof`: the old code (and the cold/rebuild
+path) fails loudly, but the forward-step path silently compares mismatched int64 values offset by
+the tz offset — producing a WRONG cursor position that can leak or hide a bar. Confirmed empirically:
+for a `Europe/Rome` index, a tz-naive `2020-01-03` yields `value=1578009600000000000` vs the
+tz-aware `asi8[2]=1578006000000000000` (a 1-hour skew), while `searchsorted` raises.
+
+This is NOT reachable on the engine path — `window()` is always called with `asof=event.time`, and
+`TimeEvent.time` is tz-aware across the whole `TimeGenerator` grid — so it is a robustness
+regression, not a live look-ahead leak. But it removes the loud-fail backstop the old path gave a
+future caller/test that passes a tz-naive time, replacing a `TypeError` with silent miscomputation.
+**Fix:** Add a one-time normalization or guard so the forward path matches the rebuild path's
+loud-fail behavior, e.g. assert tz-awareness once at the top of `window()`:
+```python
+# guard tz-parity with the index so the forward branch cannot silently
+# skew the int64 compare (the cold/rebuild searchsorted path raises here today)
+if getattr(cutoff, "tzinfo", None) is None:
+    raise ValueError(
+        f"window() asof must be tz-aware to match the tz-aware index; got {asof!r}")
+```
+or convert via `pd.Timestamp(cutoff, tz="UTC")` semantics consistently. At minimum, add a unit test
+asserting a tz-naive `asof` still raises (locking the old loud-fail contract).
+
+### WR-02: `start`/`end` can reach `_wire_system` as `None` (typed `str`) if the frames dict is empty
+
+**File:** `perf/runners/run_w2_sweep.py:131-150`
+**Issue:** `start = None` / `end = None` are only assigned inside `if start is None:` within the
+`for ticker, frame in frames.items()` loop. If `make_synthetic_ohlcv` ever returned an empty dict,
+the loop body never runs and `_wire_system(csv_paths, None, None, [])` is called, passing `None`
+where the signature declares `start: str, end: str` — a latent `TypeError`/silent-misbehavior. This
+is currently unreachable (`_N_SYMBOLS_SWEEP = [1, 10, 50]` is always non-empty) and is a perf-harness
+file, not engine code, so it is a WARNING not a BLOCKER. The two-pass refactor moved the wiring into
+a helper but carried the latent `None`-init forward.
+**Fix:** Guard explicitly before the passes, e.g.:
+```python
+if start is None or end is None:
+    raise RuntimeError("W2 sweep produced no frames — cannot wire the system")
+```
+
+## Info
+
+### IN-01: Comment claims `asi8` is a "cached" view; it returns a fresh wrapper each call
+
+**File:** `itrader/price_handler/feed/bar_feed.py:505`
+**Issue:** The inline comment reads `# zero-copy cached int64 ns view (UTC)`. `frame.index.asi8`
+returns a NEW ndarray object on every call (verified: `a is b` is False) though it shares the
+underlying buffer (`np.shares_memory` is True). The per-call O(1) wrapper construction is
+negligible, so this is not a defect — but "cached" overstates it. Consider "zero-copy int64 ns
+view (UTC; fresh wrapper, shared buffer)" to avoid implying object-level memoization.
+
+### IN-02: `asi8` is re-derived every `window()` call rather than once per frame
+
+**File:** `itrader/price_handler/feed/bar_feed.py:505`
+**Issue:** Since each memoized master frame is immutable (read-only buffer) for the life of the feed,
+`frame.index.asi8` is invariant per `(ticker, alias)` and could be cached alongside `self._frames`
+(e.g. `self._index_i8[key]`) to drop the per-tick wrapper allocation entirely — the same compute-once
+discipline already applied to `_spans`/`_prebuilt`. Out of strict v1 scope (performance), noted as a
+consistency observation only; correctness is unaffected.
+
+### IN-03: No dedicated test for the equal-consecutive-cutoff forward branch
+
+**File:** `tests/unit/price/test_bar_feed.py:403-484`
+**Issue:** The D-16 cursor suite covers cold, monotonic-forward (multi-step), backwards-rebuild,
+cold+gap, and universe-reentry — strong coverage. The one untested branch is two consecutive calls
+with an IDENTICAL `asof` (`cutoff_i8 == last_cut`), which takes the forward branch with `pos =
+last_pos` and a non-advancing while loop. I verified it behaves correctly through the real feed
+(both windows byte-identical), but it is not regression-locked. Consider adding an assertion that a
+repeated identical `asof` returns an identical window to harden the equivalence proof.
+
+---
+
+_Reviewed: 2026-06-24T15:40:00Z_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: standard_

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-REVIEW.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-REVIEW.md
@@ -1,6 +1,6 @@
 ---
 phase: 06-bar-feed-window-copies-optional-slip-able
-reviewed: 2026-06-24T15:40:00Z
+reviewed: 2026-06-24T18:21:00Z
 depth: standard
 files_reviewed: 4
 files_reviewed_list:
@@ -10,126 +10,84 @@ files_reviewed_list:
   - tests/unit/price/test_bar_feed.py
 findings:
   critical: 0
-  warning: 2
-  info: 3
-  total: 5
-status: issues_found
+  warning: 0
+  info: 1
+  total: 1
+status: clean
 ---
 
-# Phase 06: Code Review Report
+# Phase 06: Code Review Report (iteration 2 — fix re-review)
 
-**Reviewed:** 2026-06-24T15:40:00Z
+**Reviewed:** 2026-06-24T18:21:00Z
 **Depth:** standard
 **Files Reviewed:** 4
-**Status:** issues_found
+**Status:** clean
 
 ## Summary
 
-This is a behavior-preserving PERF-06 phase. The central change is the per-(ticker, alias)
-monotonic int64 forward cursor that replaces the per-tick `frame.index.searchsorted(cutoff,
-side="right")` inside `BacktestBarFeed.window()`. The review focused adversarially on the
-LOOK-AHEAD INVARIANT (no bar with `time > cutoff` may leak) and on byte-identity with the old
-`searchsorted` path.
+This is a re-review of the four files touched by fix commits `accde2d` (WR-01
+tz-naive guard in `bar_feed.window()`), `0c1f1b4` (IN-01 comment correction),
+`f681a36` (WR-02 empty-frames guard in `run_w2_sweep.py`), and `6d7a254` (IN-03
+regression test). The review focused adversarially on whether each fix is
+correct and whether any of them introduced a regression on the behavior-preserving
+PERF-06 golden-master path.
 
-**The core cursor logic is correct.** I brute-forced the forward-step walk against a fresh
-`searchsorted(side="right")` oracle over a gappy tz-aware index across cold / monotonic-forward /
-multi-bar-step / duplicate-cutoff / backwards-jump streams — every position matched byte-for-byte.
-The `<=` comparison reproduces `side="right"` exactly; the `cutoff_i8 < last_cut` rebuild guard
-fires on every backwards/jumped cutoff and never trusts stale state; the equal-consecutive-cutoff
-case (`cutoff_i8 == last_cut`) correctly takes the forward branch and does not advance. The
-read-only view, the empty-window short-circuit (`frame.iloc[pos:pos]`), and byte-identity
-(dtype/tz-aware index/column set+order) are all preserved. All 26 unit tests pass; `mypy --strict`
-is clean on the changed file. The 7-rule bar-timing contract docstring is intact.
+**Verdict: all four fixes are correct and behavior-preserving. No actionable
+findings remain.** Verification performed:
 
-The `full_event_handler.py` change is a clean removal of a single per-tick DEBUG log line; the
-`EventType.TIME` dispatch route is byte-unchanged and indentation stays tabs (134 tab lines, 0
-space lines). The `run_w2_sweep.py` split into a timed PASS 1 + un-timed tracemalloc PASS 2 is a
-harness-only change; `bar_feed.py` and `run_w2_sweep.py` remain 4-space, no normalization.
+- **WR-01 (tz-naive guard)** — verified the guard `getattr(cutoff, "tzinfo",
+  None) is None` correctly detects tz-naive cutoffs for both `pd.Timestamp` and
+  plain `datetime` (`cutoff` inherits tz from the `asof` arithmetic). The
+  forward-step int64 compare (`cutoff_i8 = pd.Timestamp(cutoff).value` vs
+  `index.asi8`) is instant-correct even across differing tz-aware timezones
+  (both reduce to UTC-epoch ns — confirmed empirically). On the engine path the
+  guard is a pure no-op (every caller passes tz-aware `TimeEvent.time`), so it
+  is byte-identical to the prior behavior under golden-master discipline. The
+  exception type for a tz-naive cold/rebuild call changes from `TypeError`
+  (searchsorted) to `ValueError` (the guard), but no test or caller depends on
+  the old type, so this is a benign, deliberate unification ("both branches fail
+  loudly and identically").
+- **WR-02 (empty-frames guard)** — `start`/`end` are assigned together inside
+  the loop; the guard checks both and fires before either pass, and after the
+  guard mypy narrows both `str | None` to `str` for the typed `_wire_system`
+  call. Correctly catches the latent `None`-propagation defect (e.g. a future
+  `n_symbols=0` point); currently unreachable, fails loudly.
+- **IN-01 (comment)** — the reworded `asi8` comment ("fresh wrapper, shared
+  buffer") is accurate; `frame.index.asi8` returns a new ndarray object aliasing
+  the underlying buffer. Comment-only; no code change.
+- **IN-03 (regression test)** — verified the new test genuinely exercises the
+  `cutoff_i8 == last_cut` forward branch: a second identical-`asof` call leaves
+  the cursor at the same position with a non-advancing `while` loop, and the
+  second window is asserted byte-identical to the first. Meaningful lock, not a
+  vacuous test.
 
-Two WARNINGs below concern robustness regressions that are NOT reachable on the golden/live engine
-path (so not BLOCKERs), plus three INFO items.
-
-## Narrative Findings (AI reviewer)
-
-## Warnings
-
-### WR-01: Forward-step branch silently miscomputes the cursor on a tz-naive `asof`
-
-**File:** `itrader/price_handler/feed/bar_feed.py:510-524`
-**Issue:** The forward-step branch compares `cutoff_i8 = pd.Timestamp(cutoff).value` (raw ns since
-the UTC epoch) directly against `iv_i8 = frame.index.asi8`. The cold/rebuild branch still calls
-`frame.index.searchsorted(cutoff, side="right")`, which **raises `TypeError` ("Cannot compare
-tz-naive and tz-aware datetime-like objects")** when `cutoff` is tz-naive against the tz-aware
-index. The two branches therefore DIVERGE for a tz-naive `asof`: the old code (and the cold/rebuild
-path) fails loudly, but the forward-step path silently compares mismatched int64 values offset by
-the tz offset — producing a WRONG cursor position that can leak or hide a bar. Confirmed empirically:
-for a `Europe/Rome` index, a tz-naive `2020-01-03` yields `value=1578009600000000000` vs the
-tz-aware `asi8[2]=1578006000000000000` (a 1-hour skew), while `searchsorted` raises.
-
-This is NOT reachable on the engine path — `window()` is always called with `asof=event.time`, and
-`TimeEvent.time` is tz-aware across the whole `TimeGenerator` grid — so it is a robustness
-regression, not a live look-ahead leak. But it removes the loud-fail backstop the old path gave a
-future caller/test that passes a tz-naive time, replacing a `TypeError` with silent miscomputation.
-**Fix:** Add a one-time normalization or guard so the forward path matches the rebuild path's
-loud-fail behavior, e.g. assert tz-awareness once at the top of `window()`:
-```python
-# guard tz-parity with the index so the forward branch cannot silently
-# skew the int64 compare (the cold/rebuild searchsorted path raises here today)
-if getattr(cutoff, "tzinfo", None) is None:
-    raise ValueError(
-        f"window() asof must be tz-aware to match the tz-aware index; got {asof!r}")
-```
-or convert via `pd.Timestamp(cutoff, tz="UTC")` semantics consistently. At minimum, add a unit test
-asserting a tz-naive `asof` still raises (locking the old loud-fail contract).
-
-### WR-02: `start`/`end` can reach `_wire_system` as `None` (typed `str`) if the frames dict is empty
-
-**File:** `perf/runners/run_w2_sweep.py:131-150`
-**Issue:** `start = None` / `end = None` are only assigned inside `if start is None:` within the
-`for ticker, frame in frames.items()` loop. If `make_synthetic_ohlcv` ever returned an empty dict,
-the loop body never runs and `_wire_system(csv_paths, None, None, [])` is called, passing `None`
-where the signature declares `start: str, end: str` — a latent `TypeError`/silent-misbehavior. This
-is currently unreachable (`_N_SYMBOLS_SWEEP = [1, 10, 50]` is always non-empty) and is a perf-harness
-file, not engine code, so it is a WARNING not a BLOCKER. The two-pass refactor moved the wiring into
-a helper but carried the latent `None`-init forward.
-**Fix:** Guard explicitly before the passes, e.g.:
-```python
-if start is None or end is None:
-    raise RuntimeError("W2 sweep produced no frames — cannot wire the system")
-```
+Cross-checks: indentation is intact (bar_feed.py and run_w2_sweep.py remain
+4-space with 0 leading tabs; test file 4-space; full_event_handler.py was NOT
+touched by these commits and remains tab-indented — no normalization).
+`full_event_handler.py` is in config scope but received no changes this
+iteration and has no new defects (dispatch KeyError handling, fail-fast error
+seam, and the defensive `getattr` on optional ErrorEvent fields are all sound).
+`mypy --strict` clean on `bar_feed.py`; all 27 `test_bar_feed.py` tests pass.
 
 ## Info
 
-### IN-01: Comment claims `asi8` is a "cached" view; it returns a fresh wrapper each call
+### IN-01: `asi8` recomputed once per `window()` call (carried from prior IN-02 — out of scope)
 
-**File:** `itrader/price_handler/feed/bar_feed.py:505`
-**Issue:** The inline comment reads `# zero-copy cached int64 ns view (UTC)`. `frame.index.asi8`
-returns a NEW ndarray object on every call (verified: `a is b` is False) though it shares the
-underlying buffer (`np.shares_memory` is True). The per-call O(1) wrapper construction is
-negligible, so this is not a defect — but "cached" overstates it. Consider "zero-copy int64 ns
-view (UTC; fresh wrapper, shared buffer)" to avoid implying object-level memoization.
-
-### IN-02: `asi8` is re-derived every `window()` call rather than once per frame
-
-**File:** `itrader/price_handler/feed/bar_feed.py:505`
-**Issue:** Since each memoized master frame is immutable (read-only buffer) for the life of the feed,
-`frame.index.asi8` is invariant per `(ticker, alias)` and could be cached alongside `self._frames`
-(e.g. `self._index_i8[key]`) to drop the per-tick wrapper allocation entirely — the same compute-once
-discipline already applied to `_spans`/`_prebuilt`. Out of strict v1 scope (performance), noted as a
-consistency observation only; correctness is unaffected.
-
-### IN-03: No dedicated test for the equal-consecutive-cutoff forward branch
-
-**File:** `tests/unit/price/test_bar_feed.py:403-484`
-**Issue:** The D-16 cursor suite covers cold, monotonic-forward (multi-step), backwards-rebuild,
-cold+gap, and universe-reentry — strong coverage. The one untested branch is two consecutive calls
-with an IDENTICAL `asof` (`cutoff_i8 == last_cut`), which takes the forward branch with `pos =
-last_pos` and a non-advancing while loop. I verified it behaves correctly through the real feed
-(both windows byte-identical), but it is not regression-locked. Consider adding an assertion that a
-repeated identical `asof` returns an identical window to harden the equivalence proof.
+**File:** `itrader/price_handler/feed/bar_feed.py:517`
+**Issue:** `iv_i8 = frame.index.asi8` allocates a fresh ndarray wrapper on every
+`window()` call (the comment now correctly says so). It could be cached per
+`(ticker, alias)` alongside `_cursor`/`_cursor_cut` to avoid the per-call
+wrapper allocation. This is the prior review's IN-02, explicitly deferred as
+out-of-scope performance/consistency-only for this phase. Recorded here as Info
+only per the iteration instructions — NOT an actionable warning. No correctness
+impact: the buffer is shared and read-only, and the value is identical every
+call.
+**Fix:** Optional future micro-opt — memoize the `asi8` view keyed by
+`(ticker, alias)` if a later profiling pass shows the wrapper allocation is
+material. No change recommended for this phase.
 
 ---
 
-_Reviewed: 2026-06-24T15:40:00Z_
+_Reviewed: 2026-06-24T18:21:00Z_
 _Reviewer: Claude (gsd-code-reviewer)_
 _Depth: standard_

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-REVIEW.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-REVIEW.md
@@ -1,0 +1,135 @@
+---
+phase: 06-bar-feed-window-copies-optional-slip-able
+reviewed: 2026-06-24T15:40:00Z
+depth: standard
+files_reviewed: 4
+files_reviewed_list:
+  - itrader/price_handler/feed/bar_feed.py
+  - itrader/events_handler/full_event_handler.py
+  - perf/runners/run_w2_sweep.py
+  - tests/unit/price/test_bar_feed.py
+findings:
+  critical: 0
+  warning: 2
+  info: 3
+  total: 5
+status: issues_found
+---
+
+# Phase 06: Code Review Report
+
+**Reviewed:** 2026-06-24T15:40:00Z
+**Depth:** standard
+**Files Reviewed:** 4
+**Status:** issues_found
+
+## Summary
+
+This is a behavior-preserving PERF-06 phase. The central change is the per-(ticker, alias)
+monotonic int64 forward cursor that replaces the per-tick `frame.index.searchsorted(cutoff,
+side="right")` inside `BacktestBarFeed.window()`. The review focused adversarially on the
+LOOK-AHEAD INVARIANT (no bar with `time > cutoff` may leak) and on byte-identity with the old
+`searchsorted` path.
+
+**The core cursor logic is correct.** I brute-forced the forward-step walk against a fresh
+`searchsorted(side="right")` oracle over a gappy tz-aware index across cold / monotonic-forward /
+multi-bar-step / duplicate-cutoff / backwards-jump streams — every position matched byte-for-byte.
+The `<=` comparison reproduces `side="right"` exactly; the `cutoff_i8 < last_cut` rebuild guard
+fires on every backwards/jumped cutoff and never trusts stale state; the equal-consecutive-cutoff
+case (`cutoff_i8 == last_cut`) correctly takes the forward branch and does not advance. The
+read-only view, the empty-window short-circuit (`frame.iloc[pos:pos]`), and byte-identity
+(dtype/tz-aware index/column set+order) are all preserved. All 26 unit tests pass; `mypy --strict`
+is clean on the changed file. The 7-rule bar-timing contract docstring is intact.
+
+The `full_event_handler.py` change is a clean removal of a single per-tick DEBUG log line; the
+`EventType.TIME` dispatch route is byte-unchanged and indentation stays tabs (134 tab lines, 0
+space lines). The `run_w2_sweep.py` split into a timed PASS 1 + un-timed tracemalloc PASS 2 is a
+harness-only change; `bar_feed.py` and `run_w2_sweep.py` remain 4-space, no normalization.
+
+Two WARNINGs below concern robustness regressions that are NOT reachable on the golden/live engine
+path (so not BLOCKERs), plus three INFO items.
+
+## Narrative Findings (AI reviewer)
+
+## Warnings
+
+### WR-01: Forward-step branch silently miscomputes the cursor on a tz-naive `asof`
+
+**File:** `itrader/price_handler/feed/bar_feed.py:510-524`
+**Issue:** The forward-step branch compares `cutoff_i8 = pd.Timestamp(cutoff).value` (raw ns since
+the UTC epoch) directly against `iv_i8 = frame.index.asi8`. The cold/rebuild branch still calls
+`frame.index.searchsorted(cutoff, side="right")`, which **raises `TypeError` ("Cannot compare
+tz-naive and tz-aware datetime-like objects")** when `cutoff` is tz-naive against the tz-aware
+index. The two branches therefore DIVERGE for a tz-naive `asof`: the old code (and the cold/rebuild
+path) fails loudly, but the forward-step path silently compares mismatched int64 values offset by
+the tz offset — producing a WRONG cursor position that can leak or hide a bar. Confirmed empirically:
+for a `Europe/Rome` index, a tz-naive `2020-01-03` yields `value=1578009600000000000` vs the
+tz-aware `asi8[2]=1578006000000000000` (a 1-hour skew), while `searchsorted` raises.
+
+This is NOT reachable on the engine path — `window()` is always called with `asof=event.time`, and
+`TimeEvent.time` is tz-aware across the whole `TimeGenerator` grid — so it is a robustness
+regression, not a live look-ahead leak. But it removes the loud-fail backstop the old path gave a
+future caller/test that passes a tz-naive time, replacing a `TypeError` with silent miscomputation.
+**Fix:** Add a one-time normalization or guard so the forward path matches the rebuild path's
+loud-fail behavior, e.g. assert tz-awareness once at the top of `window()`:
+```python
+# guard tz-parity with the index so the forward branch cannot silently
+# skew the int64 compare (the cold/rebuild searchsorted path raises here today)
+if getattr(cutoff, "tzinfo", None) is None:
+    raise ValueError(
+        f"window() asof must be tz-aware to match the tz-aware index; got {asof!r}")
+```
+or convert via `pd.Timestamp(cutoff, tz="UTC")` semantics consistently. At minimum, add a unit test
+asserting a tz-naive `asof` still raises (locking the old loud-fail contract).
+
+### WR-02: `start`/`end` can reach `_wire_system` as `None` (typed `str`) if the frames dict is empty
+
+**File:** `perf/runners/run_w2_sweep.py:131-150`
+**Issue:** `start = None` / `end = None` are only assigned inside `if start is None:` within the
+`for ticker, frame in frames.items()` loop. If `make_synthetic_ohlcv` ever returned an empty dict,
+the loop body never runs and `_wire_system(csv_paths, None, None, [])` is called, passing `None`
+where the signature declares `start: str, end: str` — a latent `TypeError`/silent-misbehavior. This
+is currently unreachable (`_N_SYMBOLS_SWEEP = [1, 10, 50]` is always non-empty) and is a perf-harness
+file, not engine code, so it is a WARNING not a BLOCKER. The two-pass refactor moved the wiring into
+a helper but carried the latent `None`-init forward.
+**Fix:** Guard explicitly before the passes, e.g.:
+```python
+if start is None or end is None:
+    raise RuntimeError("W2 sweep produced no frames — cannot wire the system")
+```
+
+## Info
+
+### IN-01: Comment claims `asi8` is a "cached" view; it returns a fresh wrapper each call
+
+**File:** `itrader/price_handler/feed/bar_feed.py:505`
+**Issue:** The inline comment reads `# zero-copy cached int64 ns view (UTC)`. `frame.index.asi8`
+returns a NEW ndarray object on every call (verified: `a is b` is False) though it shares the
+underlying buffer (`np.shares_memory` is True). The per-call O(1) wrapper construction is
+negligible, so this is not a defect — but "cached" overstates it. Consider "zero-copy int64 ns
+view (UTC; fresh wrapper, shared buffer)" to avoid implying object-level memoization.
+
+### IN-02: `asi8` is re-derived every `window()` call rather than once per frame
+
+**File:** `itrader/price_handler/feed/bar_feed.py:505`
+**Issue:** Since each memoized master frame is immutable (read-only buffer) for the life of the feed,
+`frame.index.asi8` is invariant per `(ticker, alias)` and could be cached alongside `self._frames`
+(e.g. `self._index_i8[key]`) to drop the per-tick wrapper allocation entirely — the same compute-once
+discipline already applied to `_spans`/`_prebuilt`. Out of strict v1 scope (performance), noted as a
+consistency observation only; correctness is unaffected.
+
+### IN-03: No dedicated test for the equal-consecutive-cutoff forward branch
+
+**File:** `tests/unit/price/test_bar_feed.py:403-484`
+**Issue:** The D-16 cursor suite covers cold, monotonic-forward (multi-step), backwards-rebuild,
+cold+gap, and universe-reentry — strong coverage. The one untested branch is two consecutive calls
+with an IDENTICAL `asof` (`cutoff_i8 == last_cut`), which takes the forward branch with `pos =
+last_pos` and a non-advancing while loop. I verified it behaves correctly through the real feed
+(both windows byte-identical), but it is not regression-locked. Consider adding an assertion that a
+repeated identical `asof` returns an identical window to harden the equivalence proof.
+
+---
+
+_Reviewed: 2026-06-24T15:40:00Z_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: standard_

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-VALIDATION.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-VALIDATION.md
@@ -1,0 +1,73 @@
+---
+phase: 6
+slug: bar-feed-window-copies-optional-slip-able
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-06-24
+---
+
+# Phase 6 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | pytest 8.x |
+| **Config file** | pyproject.toml (`[tool.pytest.ini_options]`, `filterwarnings=["error"]`, `--strict-markers`) |
+| **Quick run command** | `poetry run pytest tests/unit/price -q` |
+| **Full suite command** | `make test` |
+| **Estimated runtime** | ~quick: <30s · full: minutes |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run `poetry run pytest tests/unit/price -q`
+- **After every plan wave:** Run `make test`
+- **Before `/gsd:verify-work`:** Full suite + byte-exact oracle (`tests/integration/test_backtest_oracle.py`) must be green
+- **Max feedback latency:** ~30 seconds (quick)
+
+---
+
+## Per-Task Verification Map
+
+| Task ID | Plan | Wave | Requirement | Threat Ref | Secure Behavior | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|------------|-----------------|-----------|-------------------|-------------|--------|
+| 6-01-01 | 01 | 1 | PERF-06 | — | N/A | unit | `poetry run pytest tests/unit/price -q` | ❌ W0 | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+*Planner fills the full task-to-test map. Hard anchors: D-08 drift/equivalence test (content-equality across sampled ticks; mutation of a returned window RAISES `ValueError` via a direct numpy write — NOT a pandas `.iloc` assignment which raises a copy-warning under `filterwarnings=error`; 7-rule bar-timing contract green). Gate (a) = byte-exact oracle (134 / `46189.87730727451`). Gate (b) = `perf-w2` ≥10% at 50 symbols + W1 non-regression.*
+
+---
+
+## Wave 0 Requirements
+
+- [ ] Drift/equivalence test stub under `tests/unit/price/` (co-located with the existing 7-rule contract tests in `tests/unit/price/test_bar_feed.py`, per RESEARCH open-question on D-08 home) — covers PERF-06 behavior-preservation
+- [ ] Existing pytest infrastructure covers the rest (oracle, e2e, contract tests already present)
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| Gate (b) W2 ≥10% @ 50 symbols + W1 non-regression | PERF-06 | Wall-clock benchmark; thermal-drift sensitive — same-session/same-machine before/after capture | Run `perf-w2`/`perf-w1` before and after on a cool machine; commit `W2-BASELINE.json`, re-freeze `W1-BASELINE.json` |
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers all MISSING references
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 30s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending

--- a/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-VERIFICATION.md
+++ b/.planning/phases/06-bar-feed-window-copies-optional-slip-able/06-VERIFICATION.md
@@ -1,0 +1,128 @@
+---
+phase: 06-bar-feed-window-copies-optional-slip-able
+verified: 2026-06-24T18:00:00Z
+status: passed
+score: 6/6 must-haves verified
+overrides_applied: 0
+re_verification: null
+gaps: []
+deferred: []
+human_verification: []
+---
+
+# Phase 06: Bar-Feed Window Copies — Verification Report
+
+**Phase Goal:** PERF-06 — reduce the per-tick bar-feed window-construction cost in BacktestBarFeed.window() (hotspot #5, ~4% W1 / ~22% W2), behavior-preserving, contract-gated by the 7-rule look-ahead bar-timing invariant. Gate (a): byte-exact SMA_MACD oracle (134 trades / final_equity 46189.87730727451) + mypy --strict clean + determinism byte-identical. Gate (b): a measurable W2 win + W1 non-regress.
+**Verified:** 2026-06-24T18:00:00Z
+**Status:** passed
+**Re-verification:** No — initial verification
+
+## Pivot Context
+
+This phase pivoted mid-stream (D-10–D-16 in 06-CONTEXT.md). The original view/alias approach (06-01) profiled at ~0% W2 win. The real lever was identified as the per-tick `searchsorted` (13.2% of W2). The phase then added:
+- 06-01 (kept): read-only view + alias memoization + non-writeable master frames — a real look-ahead-safety win, ~0% W2 perf.
+- 06-02 (Task 1 only): W2 gate harness committed; Tasks 2/3 superseded/absorbed into 06-05.
+- 06-03: Denominator cleanup — TIME EVENT debug log removed + W2 harness de-timed.
+- 06-04: D-10 monotonic int64 forward cursor in window() — the primary perf lever.
+- 06-05: D-15 ship-and-reframe — +1.9% W2 at 50 symbols honestly, gate (b) reframed per pre-agreed fallback.
+
+Gate (b) target was reframed from >=10% to "measurable W2 win + W1 non-regress" via D-15 — the documented pre-agreed fallback for this OPTIONAL/slip-able phase.
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | Per-tick window materialization reduces frame copies (reusable view / cached searchsorted bounds) on the BacktestBarFeed.window path (SC-1) | VERIFIED | `window()` returns `frame.iloc[start:pos]` — a VIEW on the locked single-block non-writeable master (D-09/D-07). `_readonly_master()` helper at bar_feed.py:132. The per-tick searchsorted is replaced by a monotonic int64 cursor. |
+| 2 | The look-ahead bar-timing contract is preserved — all 7 rules in feed/bar_feed.py hold; no future bar becomes visible and no window content changes (SC-2) | VERIFIED | 7-rule contract docstring intact at bar_feed.py:1-55 byte-for-byte. D-16 drift suite: 4 cursor tests pass (cursor==searchsorted, no-future-bar, backwards-asof rebuild, cold/gap, universe re-entry). `poetry run pytest tests/unit/price/test_bar_feed.py -k cursor -q` → 4 passed. |
+| 3 | Gate (a): byte-exact SMA_MACD oracle (134 trades / final_equity 46189.87730727451) green, mypy --strict clean, determinism double-run byte-identical (SC-3) | VERIFIED | `poetry run pytest tests/integration/test_backtest_oracle.py -q` → 3 passed (confirmed live). `poetry run mypy itrader` → "Success: no issues found in 187 source files" (confirmed live). Determinism byte-identical per 06-04 SUMMARY. |
+| 4 | Gate (b) — measurable W2 win + W1 non-regress: +1.9% W2 at 50 symbols (cursorless 14.31s → cursor-on 14.04s, same-session A/B); W1 flat (1-symbol A/B confirms thermal, not regression) (SC-4, reframed via D-15) | VERIFIED | perf/results/W2-BASELINE.json committed (13.61s @ 50 symbols, cursor-on). W1-BASELINE.json kept at prior 238.5s (not overwritten with thermally-inflated 259.1s). D-15 ship-and-reframe invoked per documented pre-agreed fallback for OPTIONAL phase. |
+| 5 | D-10 monotonic int64 cursor in window() with cold/non-monotonic searchsorted rebuild guard, keyed (ticker, alias), never leaks a future bar | VERIFIED | bar_feed.py:503-526: `self._cursor / self._cursor_cut` dicts, `iv_i8 = frame.index.asi8`, `cutoff_i8 = pd.Timestamp(cutoff).value`, `if last_pos is None or last_cut is None or cutoff_i8 < last_cut: pos = int(frame.index.searchsorted(...))`. No unconditional searchsorted per tick. No hot-loop runtime assert (`grep 'assert.*searchsorted' bar_feed.py` → empty). |
+| 6 | D-13 denominator cleanup: per-bar TIME EVENT debug log removed from event dispatcher; W2 sweep harness de-timed (two-pass: clean wall-clock + separate tracemalloc peak-mem) | VERIFIED | `grep 'TIME EVENT'` in full_event_handler.py → no output. EventType.TIME route entry still present (line 69: the dispatch route). run_w2_sweep.py:143-154: PASS 1 (perf_counter, no tracemalloc), PASS 2 (tracemalloc, fresh re-wired system). |
+
+**Score:** 6/6 truths verified
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `itrader/price_handler/feed/bar_feed.py` | Monotonic int64 forward cursor in window() with searchsorted rebuild guard; _readonly_master helper; _cursor/_cursor_cut state dicts in __init__; @functools.cache on _offset_alias | VERIFIED | Lines 85-86 (@functools.cache), 132-176 (_readonly_master), 263-264 (_cursor/_cursor_cut dicts), 503-526 (cursor logic in window()). All key patterns confirmed: asi8 at :505, cutoff_i8 at :510, rebuild guard at :513, forward step at :523. |
+| `tests/unit/price/test_bar_feed.py` | D-16 cursor==searchsorted + no-future-bar + reset/cold/gap/re-entry tests co-located with kept D-08 suite | VERIFIED | Lines 375-488: D-16 section header, 4 tests: test_cursor_equals_fresh_searchsorted_across_ticks (:403), test_cursor_safe_rebuild_on_backwards_asof (:426), test_cursor_cold_and_gap (:457), test_cursor_universe_reentry (:473). D-08 tests kept at :343/:359. All 26 tests pass. |
+| `perf/results/W2-BASELINE.json` | Committed cursor-on 50-symbol W2 reference (seeds Phase 5); records actual W2 result | VERIFIED | File exists: 13.61s @ 50 symbols, peak 214.58 MB, frozen_at 2026-06-24. schema_version=1, sweep n_symbols=[1,10,50]. |
+| `perf/results/W1-BASELINE.json` | Re-frozen W1 reference (or kept at prior value per thermal discipline) | VERIFIED | File exists: wall_clock_s=238.5 (prior value deliberately kept — 259.1s thermal run NOT committed per D-15 thermal discipline). oracle_provenance confirms 134 trades / 46189.87730727451 green_at_freeze. |
+| `itrader/events_handler/full_event_handler.py` | Per-bar TIME EVENT debug log removed (D-13); EventType.TIME route intact | VERIFIED | No "TIME EVENT" string in file. EventType.TIME route at line 69 intact. |
+| `perf/runners/run_w2_sweep.py` | Two-pass _run_point: clean timed PASS 1 (no tracemalloc) + peak-mem PASS 2; --check/--baseline-out flags; _wire_system helper | VERIFIED | _wire_system at :95, two-pass _run_point at :118-154. PASS 1 at :143-147 (perf_counter only), PASS 2 at :149-154 (tracemalloc). --check/:246, --baseline-out/:244, _check_w2/:211. |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|-----|--------|---------|
+| BacktestBarFeed.window() | frame.index.asi8 / pd.Timestamp(cutoff).value | Forward int64-ns cursor step with cutoff_i8 < last_cut rebuild guard | VERIFIED | bar_feed.py:505 `iv_i8 = frame.index.asi8`, :510 `cutoff_i8 = pd.Timestamp(cutoff).value`, :513 rebuild condition, :523 forward step `while pos < n and iv_i8[pos] <= cutoff_i8` |
+| tests/unit/price/test_bar_feed.py D-16 tests | frame.index.searchsorted(cutoff, side="right") | cursor (start,pos) == fresh searchsorted across sampled ticks | VERIFIED | test_cursor_equals_fresh_searchsorted_across_ticks at :403 asserts equivalence across advancing asof; test_cursor_safe_rebuild_on_backwards_asof at :426 asserts no-future-bar after backwards step |
+| run_w2_sweep.py --check | perf/results/W2-BASELINE.json | 50-symbol wall_clock_s improvement gate (D-15 reframed) | VERIFIED | _check_w2 at :211 reads W2-BASELINE.json; W2-BASELINE.json exists with 50-symbol cursor-on reference |
+| _readonly_master (build sites) | self._frames[(ticker, alias)] | Non-writeable single-block master → window() views inherit read-only | VERIFIED | :245 `frame = _readonly_master(store.read_bars(ticker))`, :352 `resampled = _readonly_master(resampled)`. D-08(b) test at :359 confirms in-place mutation raises ValueError. |
+
+### Data-Flow Trace (Level 4)
+
+Not applicable. This is a perf-optimization phase with no dynamic data rendering or new user-visible data paths. The changes are internal to the window-slice hot path (not a new component producing UI-visible data). The oracle test confirms data flow integrity end-to-end.
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+|----------|---------|--------|--------|
+| Cursor tests pass | `poetry run pytest tests/unit/price/test_bar_feed.py -k cursor -q` | 4 passed | PASS |
+| Oracle (gate a) green | `poetry run pytest tests/integration/test_backtest_oracle.py -q` | 3 passed (134 / 46189.87730727451) | PASS |
+| mypy --strict clean | `poetry run mypy itrader` | Success: no issues found in 187 source files | PASS |
+| Full bar feed suite | `poetry run pytest tests/unit/price/test_bar_feed.py -q` | 26 passed | PASS |
+| No hot-loop runtime assert | `grep 'assert.*searchsorted' itrader/price_handler/feed/bar_feed.py` | (no output) | PASS |
+| TIME EVENT log absent | `grep 'TIME EVENT' itrader/events_handler/full_event_handler.py` | (no output) | PASS |
+| W2-BASELINE.json committed | file exists with cursor-on 50-symbol reference | 13.61s @ 50 symbols | PASS |
+
+### Probe Execution
+
+No probe scripts declared for this phase. Behavioral spot-checks substitute.
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+|-------------|------------|-------------|--------|----------|
+| PERF-06 | 06-04-PLAN.md (requirements: [PERF-06]), 06-05-PLAN.md (requirements_completed: [PERF-06]) | Per-tick bar-feed window iloc frame copies are reduced (reusable view / cached slice bounds), preserving the look-ahead bar-timing contract | SATISFIED | window() returns read-only iloc view; searchsorted replaced by monotonic cursor; 7-rule contract intact; oracle byte-exact; +1.9% W2 win measured; W1 non-regressive. REQUIREMENTS.md marks PERF-06 as [x] Complete. |
+
+### Anti-Patterns Found
+
+| File | Line | Pattern | Severity | Impact |
+|------|------|---------|----------|--------|
+| (none) | — | No TBD/FIXME/XXX/TODO/HACK/PLACEHOLDER markers found in modified files | — | — |
+
+No stub patterns detected. The implementation is substantive: real cursor logic in window(), real test coverage in test_bar_feed.py, real artifact in W2-BASELINE.json.
+
+### Human Verification Required
+
+None. All success criteria are verifiable programmatically:
+- Gate (a): oracle test run live — 3 passed.
+- Gate (b): W2 measurement documented in 06-05-SUMMARY.md with concrete before/after numbers (+1.9% at 50 symbols); D-15 ship-and-reframe is the documented pre-agreed fallback. W2-BASELINE.json committed. W1 thermal discipline documented and justified.
+- Look-ahead correctness: proven by D-16 drift suite (4 tests, cursor==searchsorted + no-future-bar invariant across cold/backwards/gap/reentry scenarios).
+
+### Gaps Summary
+
+No gaps. All 6 must-haves are VERIFIED:
+
+1. The read-only view return from window() is implemented (D-07/D-09, 06-01).
+2. The 7-rule look-ahead bar-timing contract is intact and test-locked (D-08/D-16).
+3. Gate (a) confirmed live: oracle 3 passed (134 / 46189.87730727451), mypy clean (187 files).
+4. Gate (b) measured and documented: +1.9% W2 at 50 symbols; D-15 ship-and-reframe applied per pre-agreed fallback; W2-BASELINE.json committed.
+5. D-10 monotonic cursor is implemented in window(), correctly keyed (ticker, alias), with cold/non-monotonic searchsorted rebuild guard that never leaks a future bar.
+6. D-13 denominator cleanup is complete: TIME EVENT debug log removed; run_w2_sweep is two-pass (clean wall-clock + separate tracemalloc).
+
+**One carried todo (not a gap):** W1-BASELINE.json absolute re-freeze on a verified-cool isolated run. The prior 238.5s reference is still valid (W1 non-regression confirmed by same-session 1-symbol A/B); the carried todo defers the cleaned-engine absolute re-freeze due to thermal contamination, consistent with the D-15 discipline and documented in 06-05-SUMMARY.md.
+
+**Two code review WARNINGs from 06-REVIEW.md** (recorded for awareness, not blockers):
+- WR-01: Forward-step branch silently miscomputes on a tz-naive `asof` (not reachable on the engine path — TimeEvent.time is always tz-aware). Robustness regression vs the old loud-fail searchsorted behavior.
+- WR-02: `start`/`end` can reach `_wire_system` as None in run_w2_sweep.py if frames dict is empty (perf harness, not engine code; not reachable with the current sweep sizes).
+Neither is reachable on the golden/live engine path.
+
+---
+
+_Verified: 2026-06-24T18:00:00Z_
+_Verifier: Claude (gsd-verifier)_

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ include .env
 .EXPORT_ALL_VARIABLES:
 
 # Define the default target commands
-.PHONY: init-env clean test test-unit test-integration test-e2e test-cov backtest normalize-data precommit typecheck perf-w1 perf-w2 perf-baseline perf-profile perf-view
+.PHONY: init-env clean test test-unit test-integration test-e2e test-cov backtest normalize-data precommit typecheck perf-w1 perf-w2 perf-baseline perf-w2-baseline perf-profile perf-view
 
 # Initialize Poetry environment in the service directory
 init-env:
@@ -100,16 +100,24 @@ perf-w1:
 	@echo "⏱️  W1 benchmark + regression guard (vs frozen baseline)..."
 	poetry run python -m perf.runners.run_w1_benchmark --check
 
-# W2 synthetic scaling sweep {1,10,50} symbols (human table; --json for machine output).
+# W2 synthetic scaling sweep {1,10,50} symbols + gate (b) guard. The --check REQUIRES
+# a >=10% wall-clock win at 50 symbols vs perf/results/W2-BASELINE.json (inverted sense
+# vs W1's slowdown guard — this gate must SEE the win). --json for machine output.
 perf-w2:
-	@echo "📈 W2 scaling sweep {1,10,50} symbols..."
-	poetry run python -m perf.runners.run_w2_sweep
+	@echo "📈 W2 scaling sweep {1,10,50} symbols + gate (b) win guard..."
+	poetry run python -m perf.runners.run_w2_sweep --check
 
 # RE-FREEZE the W1 baseline: clean run, write committed perf/results/W1-BASELINE.json
 # (TOOL-04, consumed in plan 02). Run BEFORE any optimization.
 perf-baseline:
 	@echo "🧊 Freezing W1 baseline → perf/results/W1-BASELINE.json..."
 	poetry run python -m perf.runners.run_w1_benchmark --baseline-out perf/results/W1-BASELINE.json
+
+# FREEZE the W2 baseline: clean sweep, write committed perf/results/W2-BASELINE.json
+# (D-05, seeds Phase 5). The AFTER-run reference the --check guard then diffs against.
+perf-w2-baseline:
+	@echo "🧊 Freezing W2 baseline → perf/results/W2-BASELINE.json..."
+	poetry run python -m perf.runners.run_w2_sweep --baseline-out perf/results/W2-BASELINE.json
 
 # Scalene CPU profile (manual review). NEVER wraps the gated run.
 # Two steps: run (writes JSON) then `scalene view` (native viewer) — it serves the

--- a/itrader/events_handler/full_event_handler.py
+++ b/itrader/events_handler/full_event_handler.py
@@ -111,9 +111,6 @@ class EventHandler(object):
 		drops are a tampering risk, T-04-18). Unexpected handler
 		exceptions route through the ``_on_handler_error`` policy seam.
 		"""
-		if event.type is EventType.TIME:
-			# D-21: per-tick flow log demoted from INFO to DEBUG.
-			self.logger.debug(f"TIME EVENT: {event.time}")
 		try:
 			handlers = self.routes[event.type]
 		except KeyError:

--- a/itrader/price_handler/feed/bar_feed.py
+++ b/itrader/price_handler/feed/bar_feed.py
@@ -250,6 +250,19 @@ class BacktestBarFeed(BarFeed):
                 for ts, row in frame.iterrows()
             }
 
+        # D-10 (PERF-06): monotonic forward-cursor state for window(), keyed
+        # (ticker, alias) EXACTLY like self._frames (Pitfall 5 — keying on
+        # ticker alone would share one cursor across two timeframes). The
+        # backtest asof cutoff advances monotonically per (ticker, alias), so
+        # window() steps a cached position FORWARD over frame.index.asi8 int64
+        # ns instead of re-running searchsorted every tick (the 13.2% W2
+        # hotspot). _cursor holds the last forward position; _cursor_cut holds
+        # the last cutoff (int64 ns) so a backwards/jumped cutoff is detected
+        # (cutoff_i8 < last_cut) and SAFE-REBUILT via searchsorted — never
+        # trusting stale state, never leaking a future bar (D-10 reset-safety).
+        self._cursor: dict[tuple[str, str], int] = {}
+        self._cursor_cut: dict[tuple[str, str], int] = {}
+
         # Run-path bindings for the BarEvent factory (Plan 07-02, D-20) —
         # set by the trading system at wiring time via ``bind``. The queue
         # is optional (unbound: the factory RETURNS the event); membership
@@ -432,8 +445,9 @@ class BacktestBarFeed(BarFeed):
         ``cutoff = asof - timeframe + base_timeframe`` (degenerating to
         ``asof`` when ``timeframe == base_timeframe``, rule 3 — both
         branches agree, D-02); a bucket stamped ``B`` is included iff
-        ``B <= cutoff``. The lookup is a pure ``searchsorted`` positional
-        slice — zero resample calls on this path (M5-03).
+        ``B <= cutoff``. The cutoff is resolved by a per-(ticker, alias)
+        monotonic forward cursor over the index int64 ns (D-10, replacing the
+        per-tick ``searchsorted``); zero resample calls on this path (M5-03).
 
         Parameters
         ----------
@@ -459,18 +473,57 @@ class BacktestBarFeed(BarFeed):
         ValueError
             If ``timeframe`` maps to no supported pandas offset alias.
         """
-        # PERF-06 (D-01/D-06/D-07/D-09): return a READ-ONLY VIEW on the cached
-        # master frame instead of materializing a fresh wrapper every tick.
-        # Mirrors the current_bars() de-pandas precedent above — the win is
-        # wall-clock per-tick wrapper-construction churn (the W2 ~22%, validated
-        # by wall-clock NOT tracemalloc) plus the now-memoized _offset_alias
-        # string compute; it is NOT a buffer-copy/memory drop — on the
-        # homogeneous float64 single-block OHLCV frame frame.iloc[start:pos] is
-        # ALREADY a view, no large copy was ever happening (RESEARCH Pitfall 2).
+        # PERF-06 (D-01/D-06/D-07/D-09/D-12): return a READ-ONLY VIEW on the
+        # cached master frame instead of materializing a fresh wrapper every
+        # tick (06-01, kept). On the homogeneous float64 single-block OHLCV
+        # frame frame.iloc[start:pos] is ALREADY a view — no large copy ever
+        # happened. The PIVOT (D-10/D-11, post-profile 06-04) sits ON TOP of
+        # that view: the real reducible per-tick cost is the fresh
+        # searchsorted over the full index every tick × every symbol (13.2% of
+        # W2), now replaced by the monotonic int64 forward cursor below. The
+        # iloc slice is KEPT cursor-only (D-11): every cheaper-slice candidate
+        # measured SLOWER than iloc on this single-block frame (reconstruct 9.2
+        # vs iloc 7.3 µs; take 21 µs) and D-07 forbids pd.DataFrame(...)
+        # reconstruction (tz/dtype/column-order drift) — D-11's separate
+        # cheaper-slice idea is recorded as investigated + empirically
+        # infeasible, superseded by research; the 7.9% iloc cost is accepted
+        # via the D-15 ship-and-reframe fallback (06-05).
         alias = _offset_alias(timeframe)
         frame = self._resampled_frame(ticker, alias)
         cutoff = asof - timeframe + self._base_timeframe
-        pos = int(frame.index.searchsorted(cutoff, side="right"))
+        # D-10: per-(ticker, alias) monotonic forward cursor over int64 ns —
+        # byte-identical to int(frame.index.searchsorted(cutoff, side="right"))
+        # on every reachable cutoff (VERIFIED on-grid + mid-gap; proven by the
+        # D-16 drift suite). The int64 path is load-bearing: iv_i8[pos] <=
+        # cutoff_i8 is 0.14 µs/step; a pandas-Timestamp compare (2.0 µs) or a
+        # per-tick np.datetime64 conversion (3.3 µs ≈ the searchsorted it
+        # replaces) deliver NO win — use asi8 + Timestamp.value (Pitfall 1).
+        # The `<=` (not `<`) reproduces searchsorted side="right" exactly: pos
+        # is count(index <= cutoff), the exclusive-right cutoff (rule 4).
+        key = (ticker, alias)
+        n = len(frame.index)
+        iv_i8 = frame.index.asi8          # zero-copy cached int64 ns view (UTC)
+        # O(1) int64 ns; == asi8[k] for the tz-aware index (Timestamp.value).
+        # asof arrives as a pd.Timestamp at run time but is typed `datetime`, so
+        # the pd.Timestamp(...) wrap is a no-op box that keeps mypy --strict
+        # happy (datetime has no `.value`) without a per-tick datetime64 convert.
+        cutoff_i8 = pd.Timestamp(cutoff).value
+        last_pos = self._cursor.get(key)
+        last_cut = self._cursor_cut.get(key)
+        if last_pos is None or last_cut is None or cutoff_i8 < last_cut:
+            # COLD (key unseen) or NON-MONOTONIC (backwards/jumped cutoff —
+            # universe re-entry re-issuing an earlier asof, resampled cutoffs):
+            # SAFE FULL REBUILD via searchsorted. Never trust stale state, never
+            # leak a future bar; silent rebuild (NOT fail-loud — a non-monotonic
+            # cutoff is legitimate, RESEARCH A3). Byte-identical to today.
+            pos = int(frame.index.searchsorted(cutoff, side="right"))
+        else:
+            # MONOTONIC forward step from the cached position (0.14 µs/step).
+            pos = last_pos
+            while pos < n and iv_i8[pos] <= cutoff_i8:
+                pos += 1
+        self._cursor[key] = pos
+        self._cursor_cut[key] = cutoff_i8
         start = max(0, pos - max_window)
         if start >= pos:
             # D-06: empty window (cutoff at frame start) returns the size-0

--- a/itrader/price_handler/feed/bar_feed.py
+++ b/itrader/price_handler/feed/bar_feed.py
@@ -514,7 +514,7 @@ class BacktestBarFeed(BarFeed):
         # is count(index <= cutoff), the exclusive-right cutoff (rule 4).
         key = (ticker, alias)
         n = len(frame.index)
-        iv_i8 = frame.index.asi8          # zero-copy cached int64 ns view (UTC)
+        iv_i8 = frame.index.asi8          # zero-copy int64 ns view (UTC; fresh wrapper, shared buffer)
         # O(1) int64 ns; == asi8[k] for the tz-aware index (Timestamp.value).
         # asof arrives as a pd.Timestamp at run time but is typed `datetime`, so
         # the pd.Timestamp(...) wrap is a no-op box that keeps mypy --strict

--- a/itrader/price_handler/feed/bar_feed.py
+++ b/itrader/price_handler/feed/bar_feed.py
@@ -491,6 +491,18 @@ class BacktestBarFeed(BarFeed):
         alias = _offset_alias(timeframe)
         frame = self._resampled_frame(ticker, alias)
         cutoff = asof - timeframe + self._base_timeframe
+        # WR-01 guard: the forward-step branch compares cutoff_i8 (raw ns since
+        # the UTC epoch) against the tz-aware index's asi8. A tz-naive cutoff
+        # would skew that int64 compare by the tz offset and SILENTLY return a
+        # wrong cursor (leak/hide a bar), whereas the cold/rebuild searchsorted
+        # path raises TypeError on a tz-naive↔tz-aware compare. Assert
+        # tz-awareness once so BOTH branches fail loudly and identically — the
+        # engine path always passes tz-aware asof (TimeEvent.time), so this only
+        # restores the loud-fail backstop for a future tz-naive caller/test.
+        if getattr(cutoff, "tzinfo", None) is None:
+            raise ValueError(
+                "window() asof must be tz-aware to match the tz-aware index; "
+                f"got {asof!r}")
         # D-10: per-(ticker, alias) monotonic forward cursor over int64 ns —
         # byte-identical to int(frame.index.searchsorted(cutoff, side="right"))
         # on every reachable cutoff (VERIFIED on-grid + mid-gap; proven by the

--- a/itrader/price_handler/feed/bar_feed.py
+++ b/itrader/price_handler/feed/bar_feed.py
@@ -54,10 +54,12 @@ Plan 07-02, D-20): the data engine produces the per-tick BarEvent and may
 log the missing-ticker warning (RESEARCH OQ4).
 """
 
+import functools
 import queue
 from datetime import datetime, timedelta
 from typing import Any, Optional
 
+import numpy as np
 import pandas as pd
 
 from itrader.core.bar import Bar
@@ -75,6 +77,12 @@ _AGG = {"open": "first", "high": "max", "low": "min",
         "close": "last", "volume": "sum"}
 
 
+# D-01 (PERF-06): memoize the per-call offset-alias string compute — it fires
+# ONCE per distinct timeframe across __init__/precompute/the per-tick window()
+# path. timedelta is hashable; functools.cache does NOT cache exceptions, so the
+# raise-on-unsupported ValueError guard inside is preserved (RESEARCH Pitfall 4).
+# The function BODY is byte-unchanged — only this decorator was added.
+@functools.cache
 def _offset_alias(timeframe: timedelta) -> str:
     """Map a timeframe to its canonical pandas offset alias.
 
@@ -119,6 +127,53 @@ def _offset_alias(timeframe: timedelta) -> str:
     raise ValueError(
         f"unsupported resample timeframe {timeframe!r} — supported units "
         "are minutes, hours, days and weeks (months are not supported)")
+
+
+def _readonly_master(frame: pd.DataFrame) -> pd.DataFrame:
+    """Return a SINGLE-BLOCK float64 frame with its values buffer read-only (D-09).
+
+    The PERF-06 read-only enforcement: lock the underlying numpy buffer so a
+    per-tick ``window()`` VIEW inherits read-only and a consumer in-place
+    mutation raises ``ValueError(read-only)`` instead of silently poisoning a
+    future tick (RESEARCH Pattern 1, verified pandas 2.3.3 / numpy 2.2.6).
+
+    Two steps, both byte-identity-preserving:
+
+    1. **Consolidate to a single block.** The store's canonical OHLCV frame is
+       NOT always a single homogeneous float64 block — ``read_csv`` + the
+       ``astype(float)`` + ``.loc`` window slice can leave it MULTI-block (e.g.
+       4×N and 1×N). On a multi-block frame ``to_numpy(copy=False)`` returns a
+       fresh CONSOLIDATED COPY, so locking individual block buffers would NOT
+       be observable through ``to_numpy`` and a consumer's
+       ``view.to_numpy(copy=False)[i,j] = x`` would write to a throwaway copy
+       (no protection, no leak — but the guarantee is unobservable). A plain
+       ``frame.copy()`` consolidates to ONE block while preserving values,
+       float64 dtype, the tz-aware ``DatetimeIndex`` and column set+order
+       byte-identically (``assert_frame_equal`` passes). A frame that is
+       already single-block is copied harmlessly.
+    2. **Lock the single block's buffer.** For the consolidated single-block
+       frame ``to_numpy(copy=False)`` returns a non-owning VIEW whose ``.base``
+       IS the block's writeable buffer — the flag must be set on that base
+       buffer, NOT on the returned view (a view carries its own ``writeable``
+       flag; clearing it leaves the buffer writeable). The ``np.shares_memory``
+       assert proves the handle aliases the frame's own buffer (RESEARCH
+       Pattern 1 caveat — ``to_numpy(copy=False)`` is not contractually
+       zero-copy); after the ``copy()`` consolidation it always does.
+
+    ``resample``/``searchsorted``/``iterrows`` and the ``ta`` reads all work on
+    a non-writeable frame — no D-09 per-view fallback is triggered.
+    """
+    master = frame.copy()  # consolidate to a single block (byte-identical)
+    arr = master.to_numpy(copy=False)
+    # Walk to the buffer the frame actually owns: the block buffer is `arr.base`
+    # for a non-owning view, else `arr` itself.
+    buffer: "np.ndarray[Any, np.dtype[Any]]" = (
+        arr if arr.flags.owndata else arr.base)
+    assert np.shares_memory(buffer, master.to_numpy(copy=False)), (
+        "to_numpy(copy=False) did not alias the frame's own buffer after "
+        "consolidation — read-only flag would not take effect (D-09 fallback)")
+    buffer.flags.writeable = False
+    return master
 
 
 class BacktestBarFeed(BarFeed):
@@ -179,7 +234,15 @@ class BacktestBarFeed(BarFeed):
         # so a cache would serve zero hits.
         self._prebuilt: dict[str, dict[datetime, Bar]] = {}
         for ticker in self._symbols:
-            frame = store.read_bars(ticker)
+            # D-09 (PERF-06): store a SINGLE-BLOCK, read-only master so every
+            # per-tick window VIEW inherits a non-writeable buffer and any
+            # in-place mutation fails loudly (ValueError) instead of silently
+            # poisoning a future tick (the look-ahead invariant, hard-enforced
+            # at the feed source — subsumes D-02 view-safety). The consolidation
+            # is byte-identical to the store frame (Pitfall 3: the index[0]/[-1]
+            # reads and frame.iterrows() below both work on a non-writeable
+            # frame). The store frame is returned UNTOUCHED — we lock our copy.
+            frame = _readonly_master(store.read_bars(ticker))
             self._frames[(ticker, self._base_alias)] = frame
             self._spans[ticker] = (frame.index[0], frame.index[-1])
             self._prebuilt[ticker] = {
@@ -270,6 +333,10 @@ class BacktestBarFeed(BarFeed):
             raise MissingPriceDataError(
                 ticker, "ticker not loaded in BacktestBarFeed")
         resampled = base.resample(alias, label="left", closed="left").agg(_AGG)
+        # D-09 (PERF-06): resample produced a NEW writeable frame, so lock it
+        # (single-block + read-only buffer) before any window() view aliases it.
+        # Same one-time, out-of-hot-loop mark as the __init__ base load.
+        resampled = _readonly_master(resampled)
         self._frames[key] = resampled
         return resampled
 
@@ -392,11 +459,31 @@ class BacktestBarFeed(BarFeed):
         ValueError
             If ``timeframe`` maps to no supported pandas offset alias.
         """
+        # PERF-06 (D-01/D-06/D-07/D-09): return a READ-ONLY VIEW on the cached
+        # master frame instead of materializing a fresh wrapper every tick.
+        # Mirrors the current_bars() de-pandas precedent above — the win is
+        # wall-clock per-tick wrapper-construction churn (the W2 ~22%, validated
+        # by wall-clock NOT tracemalloc) plus the now-memoized _offset_alias
+        # string compute; it is NOT a buffer-copy/memory drop — on the
+        # homogeneous float64 single-block OHLCV frame frame.iloc[start:pos] is
+        # ALREADY a view, no large copy was ever happening (RESEARCH Pitfall 2).
         alias = _offset_alias(timeframe)
         frame = self._resampled_frame(ticker, alias)
         cutoff = asof - timeframe + self._base_timeframe
         pos = int(frame.index.searchsorted(cutoff, side="right"))
-        return frame.iloc[max(0, pos - max_window):pos]
+        start = max(0, pos - max_window)
+        if start >= pos:
+            # D-06: empty window (cutoff at frame start) returns the size-0
+            # slice UNCHANGED — bypass the view/read-only machinery entirely,
+            # preserving byte-identical empty semantics base.py relies on.
+            return frame.iloc[pos:pos]
+        # D-07: slice the existing (already non-writeable, single-block) float64
+        # master — do NOT reconstruct via pd.DataFrame(...) (tz/dtype/column-order
+        # drift risk; byte-identity is the hard constraint) and do NOT re-copy
+        # (that would defeat the view return). The slice is a VIEW that aliases
+        # the master's read-only buffer, so it inherits writeable=False for free
+        # (D-09) — a consumer in-place mutation raises ValueError(read-only).
+        return frame.iloc[start:pos]
 
     # -- Multi-symbol megaframe (screener path, D-19) --------------------------
 

--- a/perf/results/W2-BASELINE.json
+++ b/perf/results/W2-BASELINE.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "frozen_at": "2026-06-24",
+  "metric": {
+    "wall_clock_s_at_50": 13.61,
+    "peak_mem_mb_at_50": 214.58
+  },
+  "sweep": {
+    "n_symbols": [
+      1,
+      10,
+      50
+    ],
+    "n_bars": 3000,
+    "seed": 42
+  },
+  "points": [
+    {
+      "n_symbols": 1,
+      "wall_clock_s": 0.42534391600929666,
+      "peak_mem_mb": 6.480985641479492
+    },
+    {
+      "n_symbols": 10,
+      "wall_clock_s": 3.0719342079974012,
+      "peak_mem_mb": 41.0096321105957
+    },
+    {
+      "n_symbols": 50,
+      "wall_clock_s": 13.605414667006698,
+      "peak_mem_mb": 214.58047485351562
+    }
+  ]
+}

--- a/perf/runners/run_w2_sweep.py
+++ b/perf/runners/run_w2_sweep.py
@@ -140,6 +140,14 @@ def _run_point(n_symbols: int, tmpdir: Path) -> dict[str, Any]:
             end = (frame.index[-1] + pd.Timedelta(days=1)).strftime("%Y-%m-%d")
     tickers = list(frames.keys())
 
+    # WR-02 guard: start/end are only assigned inside the per-frame loop, so an
+    # empty frames dict would leave them None and pass None into _wire_system's
+    # typed `start: str, end: str` signature (latent TypeError/silent misbehavior).
+    # Currently unreachable (_N_SYMBOLS_SWEEP is always non-empty) — fail loudly
+    # rather than carry the None forward.
+    if start is None or end is None:
+        raise RuntimeError("W2 sweep produced no frames — cannot wire the system")
+
     # PASS 1 — clean wall-clock: NO tracemalloc anywhere in the timed region.
     system = _wire_system(csv_paths, start, end, tickers)
     t0 = time.perf_counter()

--- a/perf/runners/run_w2_sweep.py
+++ b/perf/runners/run_w2_sweep.py
@@ -13,7 +13,9 @@ trivial strategy is sufficient. Determinism: seed 42 throughout. Profiling
 """
 
 import argparse
+import datetime as dt
 import json
+import sys
 import tempfile
 import time
 import tracemalloc
@@ -148,14 +150,90 @@ def run_w2() -> list[dict[str, Any]]:
     return points
 
 
+def _to_w2_baseline_schema(points: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build the W2 committed-baseline payload from a run_w2() points list.
+
+    Mirrors the W1 envelope (`run_w1_benchmark._to_baseline_schema`) but keys the
+    metric on the 50-symbol sweep point — that is the most W2-visible scaling
+    number gate (b) for this phase is judged on (D-05). The full {1,10,50} points
+    list is carried verbatim so the standing reference also seeds Phase 5.
+    """
+    p50 = next(p for p in points if p["n_symbols"] == 50)
+    return {
+        "schema_version": 1,
+        "frozen_at": dt.date.today().isoformat(),
+        "metric": {
+            "wall_clock_s_at_50": round(p50["wall_clock_s"], 2),
+            "peak_mem_mb_at_50": round(p50["peak_mem_mb"], 2),
+        },
+        "sweep": {"n_symbols": _N_SYMBOLS_SWEEP, "n_bars": _N_BARS, "seed": _SEED},
+        "points": points,
+    }
+
+
+def _write_w2_baseline(points: list[dict[str, Any]], out_path: str) -> None:
+    """Freeze a sweep as the committed W2-BASELINE.json (mirrors _write_baseline)."""
+    with open(out_path, "w") as fh:
+        json.dump(_to_w2_baseline_schema(points), fh, indent=2)
+        fh.write("\n")
+
+
+def _check_w2(
+    points: list[dict[str, Any]],
+    baseline_path: str,
+    min_improvement_pct: float = 10.0,
+) -> int:
+    """Gate (b) for this W2-dominant phase. The sense is INVERTED vs W1's soft
+    guard: W1 FAILS only on a slowdown beyond a band, whereas this gate REQUIRES
+    the win — PASS (return 0) iff the 50-symbol wall-clock improved by at least
+    ``min_improvement_pct`` against the frozen baseline. ALWAYS print the line.
+
+    WR-02 soft guard (carried from run_w1_benchmark._check_regression:208-211): a
+    zeroed/malformed/hand-edited baseline (non-positive base50) must degrade
+    gracefully — print a message and return 1, never raise a ZeroDivisionError.
+    """
+    with open(baseline_path) as fh:
+        base = json.load(fh)
+    base50 = base["metric"]["wall_clock_s_at_50"]
+    now50 = next(p for p in points if p["n_symbols"] == 50)["wall_clock_s"]
+    if base50 <= 0:
+        print(f"PERF GUARD: baseline wall_clock_s_at_50 is {base50} — refusing to "
+              "compute a delta against a zero/invalid baseline")
+        return 1
+    impr = (base50 - now50) / base50 * 100.0
+    print(f"W2@50 {now50:.2f}s  improvement {impr:+.1f}%  (baseline {base50:.2f}s)")
+    if impr < min_improvement_pct:
+        print(f"PERF GATE (b): improvement {impr:+.1f}% < required "
+              f"{min_improvement_pct:.1f}% at 50 symbols — gate (b) FAILED")
+        return 1
+    return 0
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="W2 synthetic scaling sweep")
     parser.add_argument("--json", action="store_true",
                         help="emit the scaling points as JSON (machine-readable)")
+    parser.add_argument("--check", action="store_true",
+                        help="compare vs W2-BASELINE.json; gate (b) REQUIRES a "
+                             ">=10%% wall-clock win at 50 symbols (inverted guard)")
+    parser.add_argument("--baseline-out", metavar="PATH",
+                        help="freeze: write the sweep as the committed W2 baseline JSON")
     args = parser.parse_args()
+    # IN-01 (mirrors run_w1_benchmark): --baseline-out + --check together would
+    # re-check a run against the baseline it JUST wrote (impr ~0%, a meaningless
+    # self-comparison that can never reach the >=10% bar). The Makefile never
+    # combines them; warn loudly so an ad-hoc invocation does not trust it.
+    if args.baseline_out and args.check:
+        print("PERF WARNING: --baseline-out and --check together compare a run "
+              "against the baseline it just wrote (improvement ~0%) — the gate "
+              "cannot pass. Run --check against a PREVIOUSLY frozen baseline.")
     points = run_w2()                       # human table prints by default (D-06)
     if args.json:
         print(json.dumps(points, indent=2))
+    if args.baseline_out:
+        _write_w2_baseline(points, args.baseline_out)
+    if args.check:
+        sys.exit(_check_w2(points, "perf/results/W2-BASELINE.json"))
 
 
 if __name__ == "__main__":

--- a/perf/runners/run_w2_sweep.py
+++ b/perf/runners/run_w2_sweep.py
@@ -92,8 +92,41 @@ def _write_kline_csv(frame: pd.DataFrame, path: Path) -> None:
     out[_KLINE_HEADER].to_csv(path, index=False)
 
 
+def _wire_system(
+    csv_paths: dict[str, str], start: str, end: str, tickers: list[str]
+) -> BacktestTradingSystem:
+    """Build a fresh, identically-wired BacktestTradingSystem for one pass.
+
+    Both the timed pass (PASS 1) and the peak-mem pass (PASS 2) re-wire through
+    this helper from the SAME csv_paths/start/end so the two passes measure the
+    same engine work on the same seeded input — only the instrumentation differs.
+    The wiring parameters (exchange="csv", cash, strategy/tickers, seed=_SEED via
+    _TIMEFRAME-pinned synthetic frames) are identical across passes.
+    """
+    system = BacktestTradingSystem(
+        exchange="csv", csv_paths=csv_paths,
+        start_date=start, end_date=end, timeframe=_TIMEFRAME,
+    )
+    strategy = _TrivialBuyStrategy(timeframe=_TIMEFRAME, tickers=tickers)
+    system.strategies_handler.add_strategy(strategy)
+    pid = system.portfolio_handler.add_portfolio(
+        user_id=1, name="W2_pf", exchange="csv", cash=Decimal("1000000"))
+    strategy.subscribe_portfolio(pid)
+    return system
+
+
 def _run_point(n_symbols: int, tmpdir: Path) -> dict[str, Any]:
-    """Generate, wire, run one sweep point; return timing + memory."""
+    """Generate, wire, run one sweep point; return timing + memory.
+
+    D-13 part 2 — DE-TIMED two-pass structure. The synthetic frames/CSVs are
+    generated ONCE (outside both passes) and reused. PASS 1 times ONLY
+    ``system.run()`` with ``perf_counter`` and NO tracemalloc in the timed
+    region, so ``wall_clock_s`` measures engine work clean (not ~19% harness
+    allocation-tracking overhead). PASS 2 re-wires a fresh system from the same
+    csv_paths/start/end (same seed=42) and captures peak memory under
+    tracemalloc in a SEPARATE, un-timed pass.
+    """
+    # Synthetic generation — ONCE, outside any measured region; reused by both passes.
     frames = make_synthetic_ohlcv(_N_BARS, n_symbols, seed=_SEED)
     csv_paths: dict[str, str] = {}
     start = None
@@ -105,21 +138,18 @@ def _run_point(n_symbols: int, tmpdir: Path) -> dict[str, Any]:
         if start is None:
             start = frame.index[0].strftime("%Y-%m-%d")
             end = (frame.index[-1] + pd.Timedelta(days=1)).strftime("%Y-%m-%d")
+    tickers = list(frames.keys())
 
-    system = BacktestTradingSystem(
-        exchange="csv", csv_paths=csv_paths,
-        start_date=start, end_date=end, timeframe=_TIMEFRAME,
-    )
-    strategy = _TrivialBuyStrategy(timeframe=_TIMEFRAME, tickers=list(frames.keys()))
-    system.strategies_handler.add_strategy(strategy)
-    pid = system.portfolio_handler.add_portfolio(
-        user_id=1, name="W2_pf", exchange="csv", cash=Decimal("1000000"))
-    strategy.subscribe_portfolio(pid)
-
-    tracemalloc.start()
+    # PASS 1 — clean wall-clock: NO tracemalloc anywhere in the timed region.
+    system = _wire_system(csv_paths, start, end, tickers)
     t0 = time.perf_counter()
     system.run(print_summary=False)
     wall_clock_s = time.perf_counter() - t0
+
+    # PASS 2 — peak memory: fresh re-wired system (same seed/input), instrumented.
+    mem_system = _wire_system(csv_paths, start, end, tickers)
+    tracemalloc.start()
+    mem_system.run(print_summary=False)
     _current, peak_bytes = tracemalloc.get_traced_memory()
     tracemalloc.stop()
     peak_mem_mb = peak_bytes / (1024 * 1024)

--- a/tests/unit/price/test_bar_feed.py
+++ b/tests/unit/price/test_bar_feed.py
@@ -372,6 +372,118 @@ def test_window_view_is_read_only_and_cannot_leak(daily_feed):
     assert np.array_equal(again.to_numpy(), before)
 
 
+# -- 7c. PERF-06 / D-16: monotonic-cursor == searchsorted drift-lock + no-leak ----
+
+"""D-16 cursor-equivalence + reset-safety lock for the D-10 monotonic cursor.
+
+This EXTENDS the D-08 drift suite (above) onto the cursor that replaces the
+per-tick ``frame.index.searchsorted(cutoff, side="right")`` inside
+``window()`` (D-10, built on the kept 06-01 read-only view — D-12). The
+"oracle" for every assertion here is a FRESH
+``int(frame.index.searchsorted(cutoff, side="right"))`` on the same frame:
+the cursor's resolved ``pos`` must equal it byte-for-byte on every reachable
+cutoff (cold / monotonic-forward / backwards-rebuild / gap), AND the returned
+window must never carry a bar stamped ``> cutoff`` (the look-ahead invariant,
+contract rule 4).
+
+By design these tests stay GREEN against BOTH the un-cursored (searchsorted)
+window() and the post-cursor window() — they encode the INVARIANT, not the
+implementation. The cursor is byte-identical to ``searchsorted(side="right")``
+(VERIFIED across 3000 on-grid + 3000 mid-gap ticks, 06-RESEARCH Finding A), so
+proving the invariant proves the cursor.
+
+NO hot-path runtime guard is added to ``window()`` (D-16): an always-on
+``assert cursor == searchsorted`` would re-pay the per-tick searchsorted the
+cursor exists to remove. The equivalence is proven HERE, in the test, once —
+matching the audit-the-invariant + dedicated-test house style (Phase 3 D-03,
+Phase 4 D-06/07, this phase's D-08/D-09).
+"""
+
+
+def test_cursor_equals_fresh_searchsorted_across_ticks(daily_feed,
+                                                       daily_base_frame):
+    # D-10/D-16 (a): across MONOTONIC advancing ticks the cursor's resolved end
+    # position == a fresh searchsorted(cutoff, side="right") on the same frame
+    # (the window's last bar is at fresh_pos - 1), AND (b) NO returned stamp is
+    # > cutoff (no future-bar leak). Oracle = fresh searchsorted; tf == base so
+    # the base frame IS the resampled frame.
+    tf = timedelta(days=1)
+    base_tf = timedelta(days=1)
+    max_window = 3
+    frame = daily_base_frame
+    for asof in [ts('2020-01-02'), ts('2020-01-05'),
+                 ts('2020-01-07'), ts('2020-01-10')]:
+        cutoff = asof - tf + base_tf
+        fresh_pos = int(frame.index.searchsorted(cutoff, side="right"))
+        win = daily_feed.window('BTCUSD', tf, max_window, asof=asof)
+        if not win.empty:
+            # (a) the cursor matched the fresh searchsorted end position
+            assert frame.index.get_loc(win.index[-1]) == fresh_pos - 1
+        # (b) no-future-bar invariant: every returned stamp <= cutoff
+        assert (win.index <= cutoff).all()
+
+
+def test_cursor_safe_rebuild_on_backwards_asof(daily_feed, daily_store,
+                                               daily_base_frame):
+    # D-10/D-16 reset-safety: advance the cursor to a LATE asof, then query an
+    # EARLIER asof on the SAME feed — the `cutoff_i8 < last_cut` rebuild guard
+    # must fire so the early window leaks NO future bar (no Jan-4..10 stamp),
+    # and it must be byte-identical to a virgin-cursor feed's window at that
+    # same early asof (the fresh searchsorted oracle).
+    tf = timedelta(days=1)
+    base_tf = timedelta(days=1)
+    max_window = 5
+    early_asof = ts('2020-01-03')
+    early_cutoff = early_asof - tf + base_tf
+
+    daily_feed.window('BTCUSD', tf, max_window, asof=ts('2020-01-10'))  # advance
+    early = daily_feed.window('BTCUSD', tf, max_window, asof=early_asof)  # back
+
+    # no-future-bar: nothing later than the early cutoff leaked through
+    assert (early.index <= early_cutoff).all()
+    assert early.index[-1] == ts('2020-01-03')
+
+    # byte-identical to a fresh-cursor feed queried at the same early asof
+    virgin = BacktestBarFeed(daily_store, timedelta(days=1))
+    virgin_early = virgin.window('BTCUSD', tf, max_window, asof=early_asof)
+    pd.testing.assert_frame_equal(early, virgin_early, check_freq=False)
+    # and equal to the fresh searchsorted positional oracle
+    fresh_pos = int(daily_base_frame.index.searchsorted(early_cutoff,
+                                                        side="right"))
+    expected = daily_base_frame.iloc[max(0, fresh_pos - max_window):fresh_pos]
+    pd.testing.assert_frame_equal(early, expected, check_freq=False)
+
+
+def test_cursor_cold_and_gap(gappy_feed):
+    # D-10/D-16 reset-safety: the FIRST call for a key (cold cursor) AND a cutoff
+    # landing on the MISSING Jan-5 gap day both resolve with no future-bar leak
+    # and the gap day absent from the window. GAPPY has bars Jan 1..4, 6..10.
+    tf = timedelta(days=1)
+    base_tf = timedelta(days=1)
+    asof = ts('2020-01-05')          # the missing gap day
+    cutoff = asof - tf + base_tf      # == Jan 5 (tf == base)
+
+    win = gappy_feed.window('GAPPY', tf, 5, asof=asof)  # cold first call
+    assert not win.empty
+    assert (win.index <= cutoff).all()          # no future-bar leak
+    assert ts('2020-01-05') not in win.index    # the gap day has no bar
+    assert win.index[-1] == ts('2020-01-04')    # last visible bar before the gap
+
+
+def test_cursor_universe_reentry(duo_feed):
+    # D-10/D-16 reset-safety: BTC queried, then ETH (a DIFFERENT key — cold for
+    # ETH, leaves BTC's cursor untouched), then BTC again at a LATER tick. BTC's
+    # forward step is still correct because its cutoff advanced monotonically;
+    # no leak, ends at the expected last bar.
+    tf = timedelta(days=1)
+    w1 = duo_feed.window('BTCUSD', tf, 3, asof=ts('2020-01-04'))
+    assert w1.index[-1] == ts('2020-01-04')
+    _ = duo_feed.window('ETHUSD', tf, 3, asof=ts('2020-01-05'))  # other key
+    w2 = duo_feed.window('BTCUSD', tf, 3, asof=ts('2020-01-07'))  # re-entry later
+    assert (w2.index <= ts('2020-01-07')).all()   # no future-bar leak
+    assert w2.index[-1] == ts('2020-01-07')
+
+
 # -- 8. BarEvent factory (relocated from DynamicUniverse — Plan 07-02, D-20) ------
 
 def test_generate_bar_event_unbound_returns_the_bar_event(daily_feed):

--- a/tests/unit/price/test_bar_feed.py
+++ b/tests/unit/price/test_bar_feed.py
@@ -23,6 +23,7 @@ from datetime import timedelta
 from decimal import Decimal
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -305,6 +306,70 @@ def test_minutes_precompute_resamples_without_futurewarning(tmp_path):
                          asof=ts('2020-03-02 09:59:00'))
     assert list(window.index) == [ts('2020-03-02 09:00:00'),
                                   ts('2020-03-02 09:30:00')]
+
+
+# -- 7b. PERF-06 / D-08: window() read-only-view drift-lock ----------------------
+
+"""D-08 drift/equivalence lock for the PERF-06 read-only-view window() (D-01/
+D-06/D-07/D-09).
+
+This is the dedicated unit-level drift lock co-located with the 7-rule
+bar-timing contract suite above (the contract suite IS D-08 assertion (c) —
+it stays green). The "oracle" here is the OLD ``frame.iloc[start:pos].copy()``
+data copy that ``window()`` returned before this phase; the new ``window()``
+returns a read-only VIEW that must be byte-identical to that copy.
+
+Two assertions land here:
+- (a) ``test_window_view_content_equals_old_copy`` — the returned view's
+  content (values, float64 dtype, tz-aware ``DatetimeIndex``, column set+order)
+  equals the matching positional slice of the base frame across sampled ticks,
+  via ``pd.testing.assert_frame_equal`` (the existing byte-identity backstop).
+- (b) ``test_window_view_is_read_only_and_cannot_leak`` — a DIRECT numpy write
+  to the returned view's buffer raises ``ValueError(read-only)`` and cannot
+  leak into the master (re-fetching the window yields the unchanged values).
+  The proof targets the numpy ``ValueError`` (RESEARCH Pitfall 1) — NOT a
+  pandas ``view.iloc[...] = x`` chained assignment, which fires
+  ``SettingWithCopyWarning`` under ``filterwarnings=["error"]`` BEFORE the
+  read-only buffer is touched (false confidence).
+
+The run-path drift locks are the byte-exact SMA_MACD oracle + the determinism
+double-run; this file locks the slice itself. NO hot-path runtime guard is
+added (D-09) — re-paying the per-tick wrapper-construction cost is exactly what
+the phase removes; the read-only enforcement is a one-time numpy flag at the
+master-frame build sites.
+"""
+
+
+def test_window_view_content_equals_old_copy(daily_feed, daily_base_frame):
+    # (a) view content == old-copy content across sampled ticks (byte-identical).
+    # Same-timeframe (tf == base) so the positional slice on the base frame is
+    # the exact oracle the old `frame.iloc[start:pos].copy()` produced.
+    tf = timedelta(days=1)
+    max_window = 3
+    base_tf = timedelta(days=1)
+    for asof in [ts('2020-01-03'), ts('2020-01-05'),
+                 ts('2020-01-07'), ts('2020-01-10')]:
+        cutoff = asof - tf + base_tf
+        pos = int(daily_base_frame.index.searchsorted(cutoff, side="right"))
+        expected = daily_base_frame.iloc[max(0, pos - max_window):pos]
+        view = daily_feed.window('BTCUSD', tf, max_window=max_window, asof=asof)
+        pd.testing.assert_frame_equal(view, expected, check_freq=False)
+
+
+def test_window_view_is_read_only_and_cannot_leak(daily_feed):
+    # (b) a DIRECT numpy write to the returned window RAISES read-only and cannot
+    # leak into the master. Target the numpy ValueError (RESEARCH Pitfall 1) —
+    # a pandas `view.iloc[0,0] = x` would fire SettingWithCopyWarning first.
+    view = daily_feed.window('BTCUSD', timedelta(days=1), max_window=3,
+                             asof=ts('2020-01-07'))
+    assert not view.empty
+    before = view.to_numpy(copy=False).copy()
+    with pytest.raises(ValueError, match="read-only"):
+        view.to_numpy(copy=False)[0, 0] = 999.0
+    # No leak: re-fetch the same window, assert byte-identical to `before`.
+    again = daily_feed.window('BTCUSD', timedelta(days=1), max_window=3,
+                              asof=ts('2020-01-07'))
+    assert np.array_equal(again.to_numpy(), before)
 
 
 # -- 8. BarEvent factory (relocated from DynamicUniverse — Plan 07-02, D-20) ------

--- a/tests/unit/price/test_bar_feed.py
+++ b/tests/unit/price/test_bar_feed.py
@@ -484,6 +484,19 @@ def test_cursor_universe_reentry(duo_feed):
     assert w2.index[-1] == ts('2020-01-07')
 
 
+def test_cursor_repeated_identical_asof_forward_branch(daily_feed):
+    # IN-03: two CONSECUTIVE calls with an IDENTICAL asof exercise the
+    # `cutoff_i8 == last_cut` case — it takes the forward branch (NOT the
+    # `cutoff_i8 < last_cut` rebuild) with pos == last_pos and a non-advancing
+    # while loop. Regression-lock that the second window is byte-identical to the
+    # first (the forward branch must not advance or skew on an unchanged cutoff).
+    tf = timedelta(days=1)
+    asof = ts('2020-01-05')
+    first = daily_feed.window('BTCUSD', tf, 3, asof=asof)
+    second = daily_feed.window('BTCUSD', tf, 3, asof=asof)  # same cutoff
+    pd.testing.assert_frame_equal(first, second, check_freq=False)
+
+
 # -- 8. BarEvent factory (relocated from DynamicUniverse — Plan 07-02, D-20) ------
 
 def test_generate_bar_event_unbound_returns_the_bar_event(daily_feed):


### PR DESCRIPTION
## PERF-06: Bar-feed window cursor — eliminate per-tick `searchsorted`

### What
Reduces the per-tick window-construction cost in `BacktestBarFeed.window()` (profiled hotspot: ~4% W1 / ~22% W2), behavior-preserving and gated by the 7-rule look-ahead bar-timing contract.

### Changes
- **Monotonic int64 forward cursor** (`bar_feed.py`) replaces the per-tick `frame.index.searchsorted` with a forward-stepping `(ticker, alias)`-keyed cursor over `index.asi8`, plus a rebuild guard that falls back to `searchsorted` on a cold start or backwards `asof` — so it can never leak a future bar.
- **Read-only window views** — `window()` returns an `iloc` view on a locked, non-writeable single-block master frame (`_readonly_master`), a look-ahead-safety win in its own right.
- **Denominator cleanup** — removed the per-bar `TIME EVENT` debug log from the dispatcher; made the W2 sweep harness two-pass (clean wall-clock + separate tracemalloc peak-mem).

### Verification
- **Gate (a):** SMA_MACD oracle byte-exact (134 trades / final_equity `46189.87730727451`), `mypy --strict` clean (187 files), determinism byte-identical.
- **Gate (b):** +1.9% W2 at 50 symbols (same-session A/B), W1 non-regressive — gate reframed from ≥10% to "measurable W2 win" per the pre-agreed D-15 fallback for this OPTIONAL phase.
- **Look-ahead correctness:** D-16 drift suite (cursor == fresh searchsorted, no-future-bar across cold/backwards/gap/re-entry); full bar-feed suite 26 passed.

### Notes
- `W2-BASELINE.json` committed (13.61s @ 50 symbols, cursor-on); `W1-BASELINE.json` deliberately kept at 238.5s — the thermally-inflated run was not committed. One carried todo: absolute W1 re-freeze on a verified-cool machine.
- Two non-blocking review WARNINGs (WR-01 tz-naive `asof`, WR-02 empty-frames guard), neither reachable on the golden/live engine path.