### PR TITLE
V1.7/05.1 bug fixes

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -224,6 +224,7 @@ Active program constraints live in PROJECT.md. v1.7-relevant locked decisions (d
 | fast | Remove OKX cred diagnostic script + diagnose-okx make target (redundant — test_okx_connectivity.py auth test now verifies creds via OkxConnector) | 2026-07-03 | 8f7acd0c | — (fast, inline) |
 | 260703-hl5 | Persist `venue_trade_id` on the transactions table (tail of CR-01 fill-dedup): nullable column + chained Alembic migration + both sql_storage mappers + Postgres round-trip test | 2026-07-03 | b142cbc5 | [260703-hl5-persist-venue-trade-id-on-the-transactio](./quick/260703-hl5-persist-venue-trade-id-on-the-transactio/) |
 | 260705-fqe | Adapt e2e OKX sandbox recon test to run against a non-flat demo account (seed engine position to live venue balance; assert BUY delta) — unblocks online settlement proof on OKX-seeded ~1 BTC EEA account | 2026-07-05 | f2070431 | [260705-fqe-adapt-e2e-okx-sandbox-recon-test-to-run-](./quick/260705-fqe-adapt-e2e-okx-sandbox-recon-test-to-run-/) |
+| fast | Make ARCH-3 capture best-effort + fix OKX fetch_my_trades param (limit=100, no paginate — sCode 51000) — online settlement proof now fully GREEN (3/3) | 2026-07-05 | 81fc39aa | — (fast, inline) |
 | Phase 03 P01 | 3min | 2 tasks | 4 files |
 | Phase 03 P02 | 9min | 2 tasks | 2 files |
 | Phase 03 P03 | 3min | 1 tasks | 2 files |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -31,7 +31,7 @@ deterministic, cross-validated numbers (oracle 134 / `46189.87730727451`; v1.5 W
 Phase: 05.2
 Plan: Not started
 Status: Ready to plan
-Last activity: 2026-07-04
+Last activity: 2026-07-05 - Completed quick task 260705-fqe: adapt e2e OKX sandbox recon test for a non-flat demo account
 
 Progress: [██████████] 98%
 
@@ -223,6 +223,7 @@ Active program constraints live in PROJECT.md. v1.7-relevant locked decisions (d
 | 260703-dob | Add OKX live-connectivity integration test + new `live` pytest marker (creds-free public reachability + creds-gated demo auth via OkxConnector); fence default `make test`/`test-integration` with `not live`, add `make test-live` | 2026-07-03 | b97690d5 | [260703-dob-okx-live-connectivity-marker](./quick/260703-dob-okx-live-connectivity-marker/) |
 | fast | Remove OKX cred diagnostic script + diagnose-okx make target (redundant — test_okx_connectivity.py auth test now verifies creds via OkxConnector) | 2026-07-03 | 8f7acd0c | — (fast, inline) |
 | 260703-hl5 | Persist `venue_trade_id` on the transactions table (tail of CR-01 fill-dedup): nullable column + chained Alembic migration + both sql_storage mappers + Postgres round-trip test | 2026-07-03 | b142cbc5 | [260703-hl5-persist-venue-trade-id-on-the-transactio](./quick/260703-hl5-persist-venue-trade-id-on-the-transactio/) |
+| 260705-fqe | Adapt e2e OKX sandbox recon test to run against a non-flat demo account (seed engine position to live venue balance; assert BUY delta) — unblocks online settlement proof on OKX-seeded ~1 BTC EEA account | 2026-07-05 | f2070431 | [260705-fqe-adapt-e2e-okx-sandbox-recon-test-to-run-](./quick/260705-fqe-adapt-e2e-okx-sandbox-recon-test-to-run-/) |
 | Phase 03 P01 | 3min | 2 tasks | 4 files |
 | Phase 03 P02 | 9min | 2 tasks | 2 files |
 | Phase 03 P03 | 3min | 1 tasks | 2 files |

--- a/.planning/debug/05.1-confb-2026-07-05.md
+++ b/.planning/debug/05.1-confb-2026-07-05.md
@@ -1,0 +1,41 @@
+# CONF-B (D-20) online settlement + ARCH-3 finalization — 2026-07-05
+
+> Auto-captured by `tests/e2e/test_okx_sandbox_recon.py` on the human-triggered
+> online run. Payload SHAPES / ids / counts only — no OKX_API_* secrets (T-05.1-16).
+
+## Wave-1 settlement assertions (GREEN gate)
+
+- position qty (settled): `1.0008991`
+- position before (seeded baseline): `1.0007992`
+- position delta (fill-induced): `0.0000999`
+- venue-filled qty: `0.0001`
+- fill cost (quote notional): `5.95130`
+- cash before / after: `99952.3896` -> `99946.43830`
+- cash delta (cost+fee): `5.95130`
+- system status: `running` (must NOT be `halted`)
+- fetch_positions(BTC/USDC): `[]` (expected `[]`)
+
+## ARCH-3 finalization point 1 — fetch_my_trades (window / pagination / ids)
+
+- since (ms, oldest = order submit): `1783252879510`
+- pagination: explicit `limit=100`, no `paginate` (the paginated/None-limit form is rejected by OKX with sCode 51000 'Parameter limit error')
+- trades returned: `1`
+- all have unified `id` (tradeId): `True`
+- all have unified `order` (ordId): `True`
+- any top-level `clientOrderId` present: `False`
+
+## ARCH-3 finalization point 2 — balance payload shape
+
+- currency keys in `total`: `['BTC', 'ETC', 'ETH', 'USD', 'USDC', 'USDG', 'XRP']`
+- quote `total[USDC]`: `99946.4383`  free: `99946.4383`  used: `0.0`
+- base `total[BTC]`: `1.0008991`  free: `1.0008991`  used: `0.0`
+
+## ARCH-3 finalization point 3 — spot fetch_positions() == []
+
+- fetch_positions(BTC/USDC): `[]` (structurally `[]` — spot instType excluded)
+
+## ARCH-3 finalization point 4 — post-fill venue / order id
+
+- stored order.venue_order_id: `None`
+- emitted venue_id (from fill stream): `3716169447336067072`
+- resolved: `False` — PENDING (expected until D-06 / Phase 05.2)

--- a/.planning/debug/resolved/okx-venue-cash-double-count.md
+++ b/.planning/debug/resolved/okx-venue-cash-double-count.md
@@ -1,0 +1,120 @@
+---
+status: resolved
+trigger: Live-path cash double-count in the OKX venue-backed account — a single real demo BUY fill debits portfolio cash by 2x the notional while position is single-counted
+created: 2026-07-05
+updated: 2026-07-05
+---
+
+# Debug Session: okx-venue-cash-double-count
+
+## Symptoms
+
+**Expected behavior:** A single spot BUY fill of 0.0001 BTC @ 59513 (notional 5.9513 USDC, venue fee 1e-07 BTC) should debit the portfolio's available cash by ~5.9513 (one notional + tiny fee). `_assert_settlement` in `tests/e2e/test_okx_sandbox_recon.py::test_demo_order_produces_real_fill_event` should pass: `cash_before - cash_after` within `[fill_cost*(1-band), fill_cost*(1+band)]`.
+
+**Actual behavior:** Cash drops by `11.9026001` = **exactly 2x the 5.9513 notional**, while the POSITION delta is correct (single-counted ~0.0001 BTC). So the same fill settles cash twice but position once. Fails:
+```
+AssertionError: cash decrease 11.9026001 exceeds cost 5.95130 + fee band — unexpected debit
+assert Decimal('11.9026001') <= (Decimal('5.95130') * (Decimal('1') + Decimal('0.02')))
+```
+
+**Error messages:** see above (test_okx_sandbox_recon.py:504). The position-delta assertion immediately above it PASSED, so the divergence is cash-only.
+
+**Timeline:** First observed 2026-07-05 on the first successful online settlement run after quick task 260705-fqe adapted the e2e test to seed the believed position so `start()` reaches RUNNING on a non-flat demo account. Before that, the test halted at `start()` (baseline-residual) and never reached settlement — so this cash path had never been exercised online.
+
+**Reproduction:** `make test-e2e-live` (or `poetry run pytest tests/e2e/test_okx_sandbox_recon.py -m live -v`) with OKX demo creds in `.env`. Places one real demo BUY on the OKX sandbox (`sandbox=True` asserted before submit; demo = no real money).
+
+## Evidence (pre-gathered — do not re-derive)
+
+- timestamp: 2026-07-05 — `fetch_my_trades('BTC/USDC')` shows each fill: `price=59513.0 amount=0.0001 cost=5.9513 fee={currency: 'BTC', cost: 1e-07}`. Fee is genuinely tiny → `commission` is NOT the source of the 2x.
+- `Transaction.net_cash_delta` (transaction.py:121) for BUY = `-(price*quantity + commission)` = `-(5.9513 + 1e-7)` for ONE fill — a single notional.
+- `transact_shares → process_transaction → _process_transaction_spot` (portfolio.py:326-404) applies EXACTLY ONE `apply_fill_cash_flow(amount=net_delta)` per transaction.
+- CR-01 dedup guard `_settled_venue_trade_ids` (portfolio_handler.py:877 reject / 931 mark) gates position+cash atomically — a duplicate FillEvent would double BOTH; position is single-counted, so a re-dispatched same-id FillEvent is ruled out.
+- Live available-cash is venue-snapshot-backed: `VenueAccount.balance = _venue_balance (cached) + _ledger_delta` (venue.py:325-344). Test line 72: portfolio cash "superseded by the VenueAccount cache on start()". `snapshot()` refreshes `_venue_balance` from the venue (already reflects the -5.95 trade) and is documented to reset `_ledger_delta` to zero (venue.py ~141/319).
+- The recently-committed test seed (quick 260705-fqe) only calls `set_position` on position storage; it never touches venue cash or `_ledger_delta`, so this is a real live-path settlement bug, not a test artifact.
+- timestamp: 2026-07-05 (this session) — `snapshot()` DOES reset `_ledger_delta` to zero (venue.py:315-320) — so the original snapshot-centric hypothesis is REFUTED. The culprit is `_stream_account` (venue.py:254-258): `if balance is not None: self._venue_balance = balance` with NO ledger reset. Two independent cash channels both reflect the fill → 2x.
+- timestamp: 2026-07-05 — Grep confirms NO consumer reads `_venue_balance` alone: every reader (`balance`, `available_balance`, `assert_funds_invariant`, `reserve`) reads `_venue_balance + _ledger_delta`. The engine-thread drift compare (venue_reconciler.py:336, live_trading_system.py:605) reads ONLY `.positions`, never `.balance`. So removing the stream's cash-baseline write has no cash-side reader that needs a live venue balance — the D-01 `snapshot()`-baseline + `_ledger_delta` model fully covers cash.
+- timestamp: 2026-07-05 — `test_account_conformance.py::test_buy_settlement_through_transact_shares` PINS the shared ABC contract: "venue leaf moves its local fill-ledger" and `available_balance == before - 10` after a BUY (snapshot-only, no stream). So the `_ledger_delta` channel is the mandated cash channel and CANNOT be dropped → the stream's cash-baseline write is the channel to remove.
+
+## Current Focus
+
+**hypothesis (CONFIRMED — corrected from the original snapshot-centric theory):** The double count is NOT in `snapshot()` — `snapshot()` (venue.py:315-320) correctly resets `_ledger_delta` to zero when it refreshes `_venue_balance`. The culprit is the async balance stream writer `_stream_account` (venue.py:254-258): it refreshes `_venue_balance = balance` from the venue's post-fill `watch_balance` push WITHOUT resetting `_ledger_delta`. Cash is a TWO-channel surface — `balance = _venue_balance + _ledger_delta` — where BOTH channels reflect the same fill: `apply_fill_cash_flow` (the ABC settlement primitive, portfolio.py:398, shared with the Simulated leaves) moves `_ledger_delta` by -5.9513, AND the balance stream moves `_venue_balance` to the fill-inclusive venue value. Position is single-counted because it has only ONE source (`_venue_positions`, no ledger overlay). Fix B (reset ledger on stream write) is NOT robust: on the live path the venue `watch_balance` push routinely LEADS the engine-thread `on_fill` apply (queue latency), so resetting-then-applying double-counts in the opposite order. The robust fix is single-channel cash.
+
+**test:** Deterministic OFFLINE regression (`tests/unit/portfolio/test_venue_cash_no_double_count.py`): snapshot a spot `VenueAccount` to a pre-fill baseline, `apply_fill_cash_flow(-5.9513)` (assert balance = 94.0487), then drive the balance-stream cache write with a post-fill push carrying `total[USDC]=94.0487` + `total[BTC]=0.0001`; assert `balance == 94.0487` (single count, NOT 88.0974) and `positions == {BTC/USDC: 0.0001}` (position liveness preserved). No network, no demo order.
+
+**expecting:** Before the fix the push double-debits cash to 88.0974 (RED). After the fix the stream leaves the cash baseline to `snapshot()` (D-01 reconcile point) and cash stays single-counted at 94.0487 while spot position liveness is preserved.
+
+**next_action:** extract `_stream_account`'s cache write into a testable `_write_balance_stream` helper (behavior-preserving), add the RED regression test, then apply the fix (stream writes POSITIONS only, never the cash baseline) and verify GREEN.
+
+**reasoning_checkpoint:**
+- hypothesis: `_stream_account` refreshes `_venue_balance` to the fill-inclusive venue push while `_ledger_delta` still holds the same fill applied by `apply_fill_cash_flow` → `balance = _venue_balance + _ledger_delta` double-counts cash; position (single-sourced from `_venue_positions`) does not.
+- confirming_evidence: (1) `balance` property is literally `_venue_balance + _ledger_delta` (venue.py:344). (2) `apply_fill_cash_flow` mutates `_ledger_delta` for every fill (venue.py:456) and is called once per spot settle (portfolio.py:398). (3) `_stream_account` writes `_venue_balance = balance` with NO ledger reset (venue.py:255-256), unlike `snapshot()` which DOES reset (venue.py:320). (4) The asymmetry — cash 2x, position 1x — is explained exactly by cash having two channels and position one.
+- falsification_test: if the offline harness shows `balance == 94.0487` even with the CURRENT (unfixed) stream write, the two-channel theory is wrong. (It shows 88.0974 → confirms.)
+- fix_rationale: cash must be single-channel. The `apply_fill_cash_flow`/`_ledger_delta` channel is the shared Account-ABC settlement contract (backtest depends on it; `test_account_conformance` pins it). Therefore the redundant channel — the stream's cash-baseline write — is removed. `snapshot()` remains the sole cash-reconcile point (D-01), which atomically re-baselines `_venue_balance` AND resets `_ledger_delta`. Robust against stream/fill ordering because only one channel ever moves cash between snapshots.
+- blind_spots: (a) DERIVATIVE market type shares the same latent double-count; the fix is uniform, which invalidates the DERIVATIVE `_venue_balance` premise of the already-RED future-work gate `test_supervisor_catchall_venue_stream_survives_networkerror` (Phase 05.3 / D-11) — flagged, not modified. (b) `test_push_stream_mutates_cache` asserts the stream writes the cash baseline (the buggy behavior) and must be updated. (c) Reconcile's snapshot()-then-adopt-fill path is unchanged by this fix; not re-examined here.
+
+**tdd_checkpoint:** RED test written first against a behavior-preserving `_write_balance_stream` extraction, then fix flips it GREEN.
+
+## Eliminated
+
+- hypothesis: commission/fee inflates net_cash_delta — ELIMINATED: venue fee is 1e-07 BTC (fetch_my_trades), far too small; 2x tracks the notional exactly, not the fee.
+- hypothesis: duplicate FillEvent (same venue_trade_id) settled twice — ELIMINATED by the position being single-counted while the CR-01 guard gates position+cash atomically (both would double, or neither).
+
+## Resolution
+
+root_cause: >
+  The venue-cached cash surface `VenueAccount.balance = _venue_balance + _ledger_delta`
+  (venue.py:344) had TWO independent channels both reflecting each fill. Channel 1: the
+  shared Account-ABC settlement primitive `apply_fill_cash_flow` (venue.py:456), called
+  once per fill by `Portfolio._process_transaction_spot` (portfolio.py:398), moves
+  `_ledger_delta` by the signed net cash delta (-5.9513 for the demo BUY). Channel 2: the
+  async balance stream writer `_stream_account` (venue.py, old lines 254-258) refreshed
+  `_venue_balance = balance` from the venue's post-fill `watch_balance` push — which
+  ALREADY reflects the -5.9513 — WITHOUT resetting `_ledger_delta`. Net: the same fill was
+  debited twice (2x = 11.9026001). Position was single-counted because it has only ONE
+  source (`_venue_positions`), with no ledger overlay — exactly the observed cash-2x /
+  position-1x asymmetry. `snapshot()` was NOT the culprit (it correctly resets
+  `_ledger_delta`, venue.py:320) — the original snapshot-centric hypothesis was refuted.
+
+fix: >
+  Make cash single-channel. `apply_fill_cash_flow`/`_ledger_delta` is the mandated ABC
+  settlement channel (backtest depends on it; `test_account_conformance` pins it), so the
+  REDUNDANT channel — the stream's cash-baseline write — is removed. Extracted
+  `_stream_account`'s cache write into a testable `_write_balance_stream` helper and made
+  it write POSITIONS only (spot `total[BASE]` liveness for the drift compare), NEVER the
+  cash baseline `_venue_balance`. `snapshot()` remains the SOLE cash-reconcile point (D-01):
+  it atomically re-baselines `_venue_balance` AND resets `_ledger_delta`. Robust against
+  stream/fill ordering (the live venue push routinely LEADS the engine on_fill apply) because
+  only one channel ever moves cash between snapshots. Backtest (`SimulatedCashAccount`) is
+  untouched → SMA_MACD golden oracle unaffected.
+
+verification: >
+  RED/GREEN offline regression `tests/unit/portfolio/test_venue_cash_no_double_count.py`
+  (deterministic, no network, no demo order): with the buggy cash-baseline write restored it
+  fails at balance==88.0974 (the 2x); with the fix it passes at 94.0487 and preserves spot
+  position liveness. Full `tests/unit/portfolio/` = 343 passed. `tests/integration/
+  test_backtest_oracle.py` = 3 passed (golden oracle intact). `mypy --strict` clean on
+  venue.py. Updated `test_venue_account_cache.py::test_push_stream_mutates_positions_cache`
+  (the old assertion encoded the buggy stream-writes-cash-baseline behavior). No new failures
+  introduced (the only remaining reds — test_supervisor_catchall, test_submit_timeout_inflight,
+  test_venue_order_id_persist, test_redeliver_dedup — are pre-existing Phase 05.2/05.3 RED
+  gates, confirmed failing on the pristine tree). ONLINE proof (`make test-e2e-live`) is
+  human-gated (places one real demo BUY) — proposed as a checkpoint, not run unprompted.
+
+files_changed:
+  - itrader/portfolio_handler/account/venue.py (extract _write_balance_stream; stop writing cash baseline from the stream)
+  - tests/unit/portfolio/test_venue_cash_no_double_count.py (new offline regression lock)
+  - tests/unit/portfolio/test_venue_account_cache.py (update stream-cache test to positions-only contract)
+
+follow_ups:
+  - Phase 05.3 / D-11: `test_supervisor_catchall_venue_stream_survives_networkerror` asserts the
+    DERIVATIVE balance stream writes `_venue_balance` — that premise is invalidated by this fix
+    (the stream no longer moves the cash baseline for either market type). When the supervisor
+    lands, re-express that test's survival assertion (e.g. via a write-spy or positions) rather
+    than via `_venue_balance`.
+
+## Constraints
+
+- OKX demo account is authorized for live-sandbox tests (demo creds, no real money) — but ASSERT `connector.sandbox is True` before any order.
+- Each instrumented online run places one real demo BUY (venue BTC currently ~1.0002; harmless on demo). Prefer an OFFLINE harness driving VenueAccount's snapshot/ledger sequence if it can reproduce the ordering without the network.
+- Money is Decimal end-to-end; `float()` only at serialization/logging edges.
+- Live suite is `-m live` + credential gated; default `make test` excludes it.

--- a/.planning/debug/resolved/spot-base-fee-drift-halt.md
+++ b/.planning/debug/resolved/spot-base-fee-drift-halt.md
@@ -1,0 +1,97 @@
+---
+status: resolved
+trigger: Spot base-currency fee not modeled — live engine spuriously HALTs ('drift') on every OKX spot BUY and the position is overstated by the base-fee
+created: 2026-07-05
+updated: 2026-07-05
+---
+
+# Debug Session: spot-base-fee-drift-halt
+
+## Symptoms
+
+**Expected behavior:** A clean spot BUY fill on the live OKX path settles without halting the engine, and the engine's believed position equals the venue base balance (no reconcile drift). `test_demo_order_produces_real_fill_event` should pass its `status != HALTED` assertion, and `test_venue_account_reconciles_post_fill_within_tolerance` should pass.
+
+**Actual behavior:** After the cash double-count fix (commit 30cfb73), the online run `make test-e2e-live` (2026-07-05) shows:
+- `test_demo_order_produces_real_fill_event` → fails at `AssertionError: engine HALTED after a clean demo fill: 'drift'`.
+- `test_venue_account_reconciles_post_fill_within_tolerance` → fails: `engine 1.0003997 vs venue 1.0003996` (diff 1e-7) beyond `is_within_single_unit_tolerance(precision=8)` = 1e-8.
+
+**Error messages:** `'halted' != 'halted'` (status is HALTED, reason `'drift'`); drift `1.0003997 vs 1.0003996`.
+
+**Timeline:** Surfaced 2026-07-05 immediately after the cash fix let `test_demo_order` reach the not-HALTED assertion. This code path was never exercised online before the seed adaptation (quick 260705-fqe) unblocked `start()`.
+
+**Reproduction:** `make test-e2e-live` (OKX demo creds in `.env`). Places one real demo BUY on the OKX sandbox (`sandbox=True` asserted; demo = no real money).
+
+## Root Cause (CONFIRMED — go straight to fix)
+
+OKX charges the spot **BUY** taker fee in the **BASE** currency (BTC). `fetch_my_trades('BTC/USDC')` confirms `fee={currency: 'BTC', cost: 1e-07}` on a 0.0001 BTC buy. The venue credits `amount - base_fee` BTC, but the engine records the **full** fill `amount` as the position:
+- `OkxExchange._emit_fill` (execution_handler/exchanges/okx.py:451-453) reads only `fee.get('cost')` (via `abs(to_money(str(fee_cost)))`) and **drops** `fee.get('currency')`; `FillEvent.quantity = amount`.
+- Portfolio settlement adds the full `amount` to the position and debits cash `-(price*qty + commission)` — treating the base-fee as a (tiny, unit-mismatched) cash debit rather than a base reduction.
+
+Result: `engine_qty` = `venue_qty + base_fee`. The on-fill drift compare (`portfolio_handler.py::_compare_symbol_drift`, ~line 760) sees the mismatch; its spurious-halt absorber (line 772) only forgives the "venue hasn't streamed the fill yet" case (`venue ≈ engine - fill_qty`), but the venue **has** caught up — to `engine - fee` — so it falls through and calls `halt('drift')` (freeze-in-place). The drift also accumulates `N*fee` across N buys in production, so widening the band is NOT a real fix (and leaves the position overstated).
+
+## Chosen Fix (LOCKED by user — full fee-currency-aware settlement)
+
+Carry the fee **currency** on the `FillEvent` (frozen dataclass, events_handler/events/fill.py; update `FillEvent.new_fill` + all construction sites; optional/defaulted so simulated fills stay unaffected). Branch settlement on fee currency:
+- fee in the pair's **BASE** asset → deduct it from the **position** quantity (net base received = `amount - base_fee`), do NOT debit cash for it.
+- fee in the **QUOTE** asset → debit **cash** (current `Transaction.net_cash_delta` behavior, transaction/transaction.py:121).
+Handle BUY (base-fee on OKX) and SELL (quote-fee on OKX). After the fix engine position == venue base balance (drift eliminated at the source, no halt) and cash is debited the correct leg only.
+
+## Current Focus
+
+**hypothesis:** CONFIRMED above — engine overstates the position by the base-denominated fee, tripping the on-fill drift halt.
+
+**test:** Offline unit regression (write FIRST, RED): a base-denominated-fee BUY fill settles `position = amount - fee` and `cash -= amount*price` (no cash fee debit); a quote-fee SELL settles `cash += amount*price - fee` and `position -= amount`. Then the settlement produces engine position == (amount - base_fee) so a subsequent drift compare against a venue balance of (amount - base_fee) is within band.
+
+**expecting:** RED before fix (position = amount, drift = fee > 1e-8). GREEN after (position = amount - base_fee, drift = 0).
+
+**next_action:** write the RED offline regression lock, then implement the fee-currency-aware settlement, then verify oracle + unit suite + mypy --strict; propose the online proof as a human-gated checkpoint.
+
+**reasoning_checkpoint:**
+- hypothesis: The engine records the full fill `amount` as the spot position and debits the base-denominated fee as a quote cash outflow, so `engine_qty = venue_qty + base_fee` — tripping the on-fill drift halt.
+- confirming_evidence: OKX `fetch_my_trades('BTC/USDC')` returns `fee={currency:'BTC', cost:1e-07}`; `OkxExchange._emit_fill` (okx.py:451-453) reads only `fee.get('cost')` and drops `fee.get('currency')`; `_process_transaction_spot` adds full `amount` to the position and `net_cash_delta` subtracts commission from cash.
+- falsification_test: After carrying fee.currency and netting a base fee out of the position, the offline unit regression must show `position.net_quantity == amount - fee` and `cash == amount*price` (no fee cash debit); if the position still equals `amount`, the branch is not reached.
+- fix_rationale: Fee-currency-aware settlement models the venue's actual base credit (`amount - base_fee`), so `engine_qty == venue_qty` EXACTLY at the source — the drift is eliminated, not masked by a wider band.
+- blind_spots: Margin arm base-fee is out of scope (live demo is spot, enable_margin=False); avg_price cost-basis for base-fee positions carries the fee as an immediate equity reduction (economically correct) rather than folding it into avg_price.
+
+**tdd_checkpoint:**
+  test_file: tests/unit/portfolio/test_spot_base_fee_settlement.py
+  test_names: test_base_fee_buy_reduces_position_not_cash, test_quote_fee_sell_debits_cash_not_position, test_none_fee_currency_preserves_oracle_behavior, test_base_fee_buy_scale_in_nets_each_leg, test_transaction_seam_properties_are_fee_currency_aware
+  status: green
+  failure_output: "TypeError: Unexpected keyword argument 'fee_currency' (5 failed) — the Transaction fee_currency field + settlement seam did not exist yet"
+  green_output: "5 passed — base-fee BUY nets position = amount - fee, cash = amount*price; quote-fee SELL + None-fee unchanged; Transaction seam properties locked"
+
+## Offline verification (all GREEN)
+
+- tests/unit/portfolio/test_spot_base_fee_settlement.py: 5 passed (RED→GREEN)
+- tests/integration/test_backtest_oracle.py: 3 passed — SMA_MACD oracle BYTE-EXACT (134 / 46189.87730727451 unchanged)
+- tests/unit/portfolio: 348 passed (343 prior + 5 new; zero regressions)
+- tests/unit/execution + tests/unit/events: 318 passed; the 5 execution failures are PRE-EXISTING on the clean tree (supervisor-catchall x3, venue-order-id-persist x1, submit-timeout-inflight x1 — timing/thread tests unrelated to fills, confirmed via git stash + isolated run)
+- OKX emit/fill/exchange tests: 83 passed — fee_currency propagates through _emit_fill
+- poetry run mypy (--strict): Success, no issues in 228 source files
+
+## Resolution
+
+root_cause: OkxExchange._emit_fill dropped the venue fee CURRENCY (read only fee.cost), so a base-denominated OKX spot BUY fee (charged in BTC) was recorded as a full-amount position + a quote cash debit. engine_qty = venue_qty + base_fee tripped the on-fill drift halt.
+
+fix: Fee-currency-aware spot settlement. FillEvent + Transaction carry fee_currency (defaulted None → oracle-dark). Transaction gains base_asset / is_base_fee / quote_commission / position_quantity; net_cash_delta uses quote_commission (0 for a base fee). Position.open_position / update_position settle transaction.position_quantity (amount - base_fee for a base BUY) with quote_commission. OkxExchange._emit_fill stamps fee_currency from trade['fee']['currency']. Result: engine position == venue base balance EXACTLY (drift 0, no band change needed).
+
+fix (extension — commit 2, after online proof showed test (i) still halted): the on-fill drift ABSORBER was inconsistent with the fee-aware settlement. PortfolioHandler.on_fill passed the RAW fill_event.quantity as just_applied_fill_qty, but settlement moves a base-fee BUY by (amount - base_fee); the absorber's pre-fill reconstruction (engine_qty - just_applied_fill_qty) was off by the fee, so when the async venue cache was still pre-fill at compare time it spuriously halted('drift'). Now just_applied_fill_qty = transaction.position_quantity signed by action (net-base delta; identity to raw quantity on the oracle/quote path). RED→GREEN offline regression: tests/unit/portfolio/test_spot_base_fee_drift_absorber.py (base-fee fill with pre-fill venue cache must NOT halt; genuine unexplained divergence still halts).
+
+verification: OFFLINE GREEN (above) + ONLINE CONFIRMED (make test-e2e-live, both commits in tree). The 'drift' HALT is GONE: test_demo_order_produces_real_fill_event passes ALL 4 hard settlement assertions (position delta, cash delta, status != HALTED, spot fetch_positions()==[]); test_venue_account_reconciles_post_fill_within_tolerance passes (engine==venue, drift 0); test_restart_rehydrate passes. The run's remaining 1 failure is OUT OF SCOPE — a test-side ARCH-3 diagnostic capture (_capture_arch3_finalization → fetch_my_trades with {"paginate": True}) that OKX rejects with code 51000 'Parameter limit error'; NOT an engine settlement bug (coordinator handling separately). Resolved 2026-07-05.
+
+files_changed: [itrader/events_handler/events/fill.py, itrader/execution_handler/exchanges/okx.py, itrader/portfolio_handler/transaction/transaction.py, itrader/portfolio_handler/position/position.py, itrader/portfolio_handler/portfolio_handler.py (settlement + absorber), itrader/portfolio_handler/portfolio.py, tests/unit/portfolio/test_spot_base_fee_settlement.py, tests/unit/portfolio/test_spot_base_fee_drift_absorber.py]
+
+online proof (partial, after commit 1 cdfd55a1): 2 passed / 1 failed — test_venue_account_reconciles_post_fill_within_tolerance PASSED (engine==venue, drift 0); test_demo_order_produces_real_fill_event STILL HALTED on 'drift' (absorber not yet fee-aware). Commit 2 addresses the remaining halt; awaiting re-run of make test-e2e-live (all 3 expected green).
+
+**Chosen seam (implementation):** Fee-awareness lives in Transaction properties: `fee_currency` field + `base_asset` / `is_base_fee` / `quote_commission` / `position_quantity`. `net_cash_delta` uses `quote_commission` (0 for a base fee → no cash leg). `Position.open_position` / `update_position` read `transaction.position_quantity` (= amount - fee for a base BUY) and `transaction.quote_commission`. Default path (fee_currency None or == quote) returns identity values → byte-exact oracle. FillEvent carries `fee_currency` (defaulted None); OkxExchange._emit_fill stamps it from `fee.get('currency')`.
+
+## Eliminated
+
+- hypothesis: reconcile tolerance too tight (widen the band) — REJECTED as the fix: the base-fee drift accumulates `N*fee` per buy and would trip any fixed band eventually, and it leaves the position overstated. The band (1e-8) is correct ONCE the base-fee is modeled into the position (engine==venue exactly); confirm no band change is needed rather than loosening it.
+
+## Constraints
+
+- ORACLE SAFETY: touches the SMA_MACD golden settlement path. Backtest/paper SimulatedExchange fills must stay BYTE-EXACT (oracle-dark) — they carry no venue fee-currency, so the new branch MUST default to current behavior when fee currency is absent/None or equals the quote currency. Verify with `tests/integration/test_backtest_oracle.py` (3) + the portfolio unit suite (343).
+- Money is Decimal end-to-end; enter Decimal via `to_money(str(x))`, never `Decimal(float)`. No second ID scheme.
+- Indentation: handler modules use TABS; events package / core / config use 4 spaces — match each file.
+- The online proof (`make test-e2e-live`) is human-gated and places one real demo BUY — propose as a checkpoint, do not run unprompted; assert `connector.sandbox is True` first. After the fix, `test_venue_account_reconciles` should pass (engine==venue) and `test_demo_order` should no longer halt on 'drift'.

--- a/.planning/quick/260705-fqe-adapt-e2e-okx-sandbox-recon-test-to-run-/260705-fqe-PLAN.md
+++ b/.planning/quick/260705-fqe-adapt-e2e-okx-sandbox-recon-test-to-run-/260705-fqe-PLAN.md
@@ -1,0 +1,223 @@
+---
+phase: quick-260705-fqe
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - tests/e2e/test_okx_sandbox_recon.py
+autonomous: true
+requirements: [RECON-01, RECON-03, D-20]
+must_haves:
+  truths:
+    - "The two online start()-driven tests (i test_demo_order_produces_real_fill_event, ii test_venue_account_reconciles_post_fill_within_tolerance) reach SystemStatus.RUNNING against the non-flat OKX demo account instead of halting with halt_reason='baseline-residual'"
+    - "The settlement proof asserts the BUY's position DELTA (pos.net_quantity - position_before) within _SETTLE_QTY_FEE_BAND, not the absolute post-fill net_quantity"
+    - "On a genuinely flat demo account (venue base total 0/absent) the seed is a no-op and the original flat-start behavior is unchanged"
+    - "The module still COLLECTS network-free and credential-free (no import errors); all connector imports in the new helper are lazy (inside the function body)"
+  artifacts:
+    - path: "tests/e2e/test_okx_sandbox_recon.py"
+      provides: "TEST-ONLY seed helper + delta-based settlement assertions"
+      contains: "_seed_believed_position_to_venue"
+  key_links:
+    - from: "tests/e2e/test_okx_sandbox_recon.py::_seed_believed_position_to_venue"
+      to: "portfolio.position_manager._storage.set_position"
+      via: "Position.open_position(Transaction(BUY, BTC/USDC, venue_qty)) then set_position"
+      pattern: "position_manager\\._storage\\.set_position"
+    - from: "tests/e2e/test_okx_sandbox_recon.py::_assert_settlement"
+      to: "pos.net_quantity - position_before"
+      via: "delta_qty assertion band"
+      pattern: "position_before"
+---
+
+<objective>
+Adapt `tests/e2e/test_okx_sandbox_recon.py` so the human-gated online settlement proof runs
+against a NON-FLAT OKX demo account (the only kind available — OKX seeds ~1 BTC and the EEA
+account cannot be sold flat). Two locked TEST-ONLY changes, no production edits:
+
+1. Seed the engine's believed BTC/USDC position to the LIVE venue BTC balance BEFORE `start()`,
+   so `_run_session_baseline_guard` (live_trading_system.py:579) reads `engine_qty == venue_qty`
+   and lets `start()` reach RUNNING instead of latching `halt('baseline-residual')`.
+2. Assert the BUY's DELTA `(pos.net_quantity - position_before)` in `_assert_settlement` instead
+   of the absolute position, so the proof holds on a pre-seeded (non-flat) portfolio.
+
+Purpose: unblock the online RECON-01/RECON-03 + D-20 CONF-B GREEN gate on the demo account that
+actually exists. The reconcile test (ii) still passes because engine and venue both move by the
+same fill delta from the seeded baseline.
+
+Output: modified `tests/e2e/test_okx_sandbox_recon.py` (the ONLY file touched).
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+</execution_context>
+
+<context>
+TEST-ONLY change. NO production source may be modified. If Task work reveals a production change
+is genuinely unavoidable, STOP and flag it as a blocker rather than editing `itrader/`.
+
+@tests/e2e/test_okx_sandbox_recon.py
+
+<interfaces>
+<!-- Real APIs discovered from the codebase — the executor uses these directly, no exploration. -->
+
+Baseline guard the seed must satisfy — itrader/trading_system/live_trading_system.py:579-627:
+- Runs INSIDE `start()` AFTER the connector connects (line ~1249) and AFTER
+  `_venue_account.snapshot()` (~1287) + reconcile; BEFORE the engine thread spawns (~1322).
+- `symbol = _OKX_STREAM_SYMBOL` == "BTC/USDC" == the test's `_OKX_SYMBOL`.
+- `venue_qty = self._venue_account.positions.get(symbol, Decimal('0'))`
+- `engine_qty = portfolio.get_open_position(symbol).net_quantity` (or Decimal('0'))
+- Halts `halt('baseline-residual')` unless `is_within_single_unit_tolerance(engine_qty, venue_qty, precision)`.
+- Consequence: the seed MUST run BEFORE `start()`, and the system connector is NOT yet connected
+  pre-start — so the live balance must be read via an independent connector.
+
+Venue spot position derivation — itrader/portfolio_handler/account/venue.py:190-211 (`_extract_spot_position`):
+- Reads `balance_payload["total"][BASE]` (BASE = "BTC"), keys it under the wired symbol "BTC/USDC",
+  crosses the Decimal edge via `to_money(str(base_raw))`. Zero/absent base total => `{}` (flat).
+- So seeding from `fetch_balance()["total"]["BTC"]` via `to_money(str(...))` matches the guard's
+  `venue_qty` byte-for-byte.
+
+Read-only balance connector — already in this file at line 280:
+- `_build_demo_connector()` -> constructs + `.connect()`s a sandbox `OkxConnector`, asserts
+  `connector.sandbox is True`. Reuse it; disconnect in a `finally`.
+- Balance read pattern (established at line 511): `connector.call(connector.client.fetch_balance())`
+  then `bal["total"]["BTC"]`.
+
+Position seed seam:
+- `Transaction` (itrader/portfolio_handler/transaction/transaction.py) is a `msgspec.Struct`;
+  required kwargs: `time, type, ticker, price, quantity, commission, portfolio_id, id, fill_id`.
+  `__post_init__` normalizes price/quantity/commission via `to_money` (never Decimal(float)).
+- `type=TransactionType.BUY` (from itrader.core.enums); `id=TransactionId(uc.uuid7())`,
+  `fill_id=uc.uuid7()` (import uuid_utils.compat as uc); `commission=Decimal("0")`.
+- `Position.open_position(transaction)` (position.py:242) -> Position; net_quantity == txn.quantity for a BUY.
+- `portfolio = system.portfolio_handler.get_portfolio(portfolio_id)` (portfolio_handler.py:234).
+- `portfolio.position_manager._storage.set_position(ticker, position)` (in_memory_storage.py:58) —
+  a PURE dict write: `self._positions[ticker] = position`. It does NOT mutate cash (PositionManager
+  is cash-agnostic, D-06). So `cash_before` (snapshotted after start()) is unaffected by the seed.
+- Read-back for assertions: `system.portfolio_handler.get_position(portfolio_id, ticker)` ->
+  PositionView with `.net_quantity` (portfolio_handler.py:302).
+
+Existing module constants to reuse: `_OKX_SYMBOL` ("BTC/USDC"), `_BASE_CCY` ("BTC"),
+`_PRICE_ESTIMATE` (Decimal("100000")), `_SETTLE_QTY_FEE_BAND` (Decimal("0.01")).
+
+Convention: 4-space indentation throughout this file. ALL connector/system imports stay LAZY
+(inside function bodies) so credential-free collection never touches ccxt.pro.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add the venue-position seed helper and wire it into both online start() tests</name>
+  <files>tests/e2e/test_okx_sandbox_recon.py</files>
+  <action>
+Add a new module-level helper `_seed_believed_position_to_venue(system, portfolio_id)` (place it
+alongside the other helpers, e.g. just after `_build_demo_connector` at line ~288). ALL imports go
+INSIDE the function body (lazy), matching this file's network-free-collection contract:
+`from datetime import datetime, timezone`; `import uuid_utils.compat as uc`;
+`from itrader.core.enums import TransactionType`; `from itrader.core.ids import TransactionId`;
+`from itrader.core.money import to_money`;
+`from itrader.portfolio_handler.position.position import Position`;
+`from itrader.portfolio_handler.transaction.transaction import Transaction`.
+
+Helper body:
+1. Build a throwaway read-only sandbox connector via the existing `_build_demo_connector()`.
+   In a try/finally, read `bal = connector.call(connector.client.fetch_balance())`, then
+   `base_raw = bal.get("total", {}).get(_BASE_CCY)` (guard non-dict), and in the `finally`
+   `connector.disconnect()` wrapped in its own try/except (clean teardown under
+   filterwarnings=["error"] — no leaked authenticated socket).
+2. If `base_raw is None`: `return Decimal("0")` (no venue balance key). If
+   `venue_qty = to_money(str(base_raw))` (Decimal edge — never Decimal(float)) equals 0:
+   `return Decimal("0")` — a genuinely FLAT account, seed is a no-op, original flat-start path intact.
+3. Construct `Transaction(time=datetime.now(timezone.utc), type=TransactionType.BUY,
+   ticker=_OKX_SYMBOL, price=_PRICE_ESTIMATE, quantity=venue_qty, commission=Decimal("0"),
+   portfolio_id=portfolio_id, id=TransactionId(uc.uuid7()), fill_id=uc.uuid7())`. Then
+   `position = Position.open_position(txn)`,
+   `portfolio = system.portfolio_handler.get_portfolio(portfolio_id)`,
+   `portfolio.position_manager._storage.set_position(_OKX_SYMBOL, position)`. Return `venue_qty`.
+   Docstring: explain the non-flat-demo constraint (OKX seeds ~1 BTC, EEA can't sell flat), that
+   the read is READ-ONLY (no order), and that set_position is position-only / cash-neutral.
+
+Wire the call into BOTH online start()-driven tests, immediately AFTER `_assert_sandbox_routed(system)`
+and BEFORE `system.start()`:
+- `test_demo_order_produces_real_fill_event` (line ~583-585)
+- `test_venue_account_reconciles_post_fill_within_tolerance` (line ~635-637)
+Call it as `_seed_believed_position_to_venue(system, portfolio_id)` (test (i) will also read
+position_before separately in Task 2; the return value is not required at the call site). Do NOT add
+a seed to `test_restart_rehydrate_then_venue_reconcile_no_spurious_halt` — that test never calls
+`system.start()` (it drives a standalone connector + reconciler) and does not hit the baseline guard.
+  </action>
+  <verify>
+  <automated>poetry run python -c "import ast; ast.parse(open('tests/e2e/test_okx_sandbox_recon.py').read())"</automated>
+  </verify>
+  <done>Helper exists with lazy imports; both start()-driven tests call it between the sandbox
+  guard and start(); test (iii) untouched; file parses cleanly.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Switch _assert_settlement to DELTA position assertions and thread position_before</name>
+  <files>tests/e2e/test_okx_sandbox_recon.py</files>
+  <action>
+Change `_assert_settlement` (line ~392) signature from
+`(system, portfolio_id, order, emitted, cash_before)` to
+`(system, portfolio_id, order, emitted, cash_before, position_before)`.
+
+Inside `_assert_settlement`, keep the `pos = system.portfolio_handler.get_position(...)` fetch and
+the `pos is not None` assertion. REPLACE the three absolute assertions (lines ~416-420):
+`assert pos.net_quantity > 0`;
+`assert pos.net_quantity <= filled_qty`;
+`assert pos.net_quantity >= filled_qty * (Decimal("1") - _SETTLE_QTY_FEE_BAND)`
+with DELTA assertions on `delta_qty = pos.net_quantity - position_before`:
+`assert delta_qty > 0` (the BUY grew the believed position);
+`assert delta_qty <= filled_qty` (an OKX spot BUY may take the fee from the base received);
+`assert delta_qty >= filled_qty * (Decimal("1") - _SETTLE_QTY_FEE_BAND)` (fee-band floor on the delta).
+Keep the exact failure-message style. Leave the CASH assertions (delta = cash_before - cash_after,
+band cost..cost*(1+band)) UNCHANGED — they already operate as a delta and cash_before is snapshotted
+after start()/after the (cash-neutral) seed. Keep assertions (3) not-HALTED and (4) spot
+fetch_positions()==[] unchanged. Add `"position_before": position_before` and
+`"position_delta": delta_qty` to the returned dict (so the ARCH-3 capture can record the delta).
+
+In `test_demo_order_produces_real_fill_event`, snapshot `position_before` right where `cash_before`
+is taken (line ~594, after start(), before submitting the order):
+`_pos_before = system.portfolio_handler.get_position(portfolio_id, _OKX_SYMBOL)`;
+`position_before = _pos_before.net_quantity if _pos_before is not None else Decimal("0")`.
+Update the call site (line ~611) to
+`_assert_settlement(system, portfolio_id, order, emitted, cash_before, position_before)`.
+
+Optionally (keep minimal, no new network calls) add two lines to `_capture_arch3_finalization`'s
+Wave-1 settlement section printing `settlement['position_before']` and `settlement['position_delta']`;
+if it complicates the diff, skip it — the capture already prints `position_qty` and `filled_qty`.
+  </action>
+  <verify>
+  <automated>poetry run python -c "import ast; ast.parse(open('tests/e2e/test_okx_sandbox_recon.py').read())" && poetry run pytest tests/e2e/test_okx_sandbox_recon.py --collect-only -q</automated>
+  </verify>
+  <done>`_assert_settlement` takes `position_before` and asserts the position DELTA within the
+  fee band; test (i) snapshots `position_before` after start() and passes it; cash + status + spot
+  assertions unchanged; module COLLECTS cleanly (credential-free skip path intact, no import errors).</done>
+</task>
+
+</tasks>
+
+<verification>
+Offline only (the suite is `-m live`, network+credential gated, and would place a real demo order —
+NEVER run the live test as verification here):
+1. `poetry run python -c "import ast; ast.parse(open('tests/e2e/test_okx_sandbox_recon.py').read())"` — parses.
+2. `poetry run pytest tests/e2e/test_okx_sandbox_recon.py --collect-only -q` — collects cleanly, no
+   import errors (lazy imports keep collection network-free).
+No mypy gate: this test module is outside `[tool.mypy] files = ["itrader"]` scope.
+</verification>
+
+<success_criteria>
+- `tests/e2e/test_okx_sandbox_recon.py` is the ONLY file changed; no `itrader/` edit.
+- New `_seed_believed_position_to_venue` helper reads the live venue BTC balance READ-ONLY and seeds
+  the believed BTC/USDC position via `Position.open_position` + `set_position` (cash-neutral); flat
+  account => no-op.
+- Both start()-driven online tests call the seed between the sandbox guard and `start()`; test (iii)
+  is untouched.
+- `_assert_settlement` asserts the position DELTA against `position_before` within `_SETTLE_QTY_FEE_BAND`;
+  cash/status/spot-venue assertions preserved.
+- Module parses and collects cleanly offline.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260705-fqe-adapt-e2e-okx-sandbox-recon-test-to-run-/260705-fqe-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260705-fqe-adapt-e2e-okx-sandbox-recon-test-to-run-/260705-fqe-SUMMARY.md
+++ b/.planning/quick/260705-fqe-adapt-e2e-okx-sandbox-recon-test-to-run-/260705-fqe-SUMMARY.md
@@ -1,0 +1,116 @@
+---
+phase: quick-260705-fqe
+plan: 01
+subsystem: tests/e2e (OKX sandbox reconciliation)
+tags: [test-only, okx, live-sandbox, recon, D-20, RECON-01, RECON-03]
+requires: [RECON-01, RECON-03, D-20]
+provides:
+  - "TEST-ONLY venue-position seed helper (_seed_believed_position_to_venue)"
+  - "delta-based settlement assertions in _assert_settlement"
+affects:
+  - tests/e2e/test_okx_sandbox_recon.py
+key-files:
+  created: []
+  modified:
+    - tests/e2e/test_okx_sandbox_recon.py
+decisions:
+  - "Position DELTA (pos.net_quantity - position_before) is the settlement assertion, not the absolute post-fill net_quantity — the online proof runs on a NON-FLAT OKX EEA demo account."
+  - "Seed reads the live venue BTC balance READ-ONLY via a throwaway sandbox connector (system connector not yet connected pre-start); set_position is cash-neutral (D-06), so cash_before is unaffected."
+metrics:
+  duration: ~4min
+  completed: 2026-07-05
+---
+
+# Quick Task 260705-fqe: Adapt e2e OKX sandbox recon test to run on a non-flat demo account
+
+## One-liner
+
+Made the two online start()-driven OKX-demo settlement tests reach `RUNNING` on the only demo
+account available (non-flat, EEA/MiCA can't sell flat) by seeding the engine's believed BTC/USDC
+position to the live venue balance before `start()`, and switched `_assert_settlement` to assert
+the BUY's position DELTA instead of the absolute post-fill quantity.
+
+## What changed
+
+**File touched (ONLY):** `tests/e2e/test_okx_sandbox_recon.py`
+
+### Task 1 — venue-position seed helper (commit 9b79681c)
+- Added module-level `_seed_believed_position_to_venue(system, portfolio_id)` after
+  `_build_demo_connector`. All imports LAZY (inside the body): `datetime`, `uuid_utils.compat`,
+  `TransactionType`, `TransactionId`, `to_money`, `Position`, `Transaction`.
+- Reads the live venue BTC balance READ-ONLY via a throwaway sandbox connector
+  (`_build_demo_connector()`), reading `bal["total"]["BTC"]`, disconnect in a `finally`
+  (clean teardown under `filterwarnings=["error"]`).
+- `base_raw is None` OR `to_money(str(base_raw)) == 0` → returns `Decimal("0")` (flat account,
+  seed is a no-op — original flat-start path intact).
+- Otherwise constructs a `Transaction(BUY, BTC/USDC, venue_qty)` (Decimal edge via `to_money`,
+  never `Decimal(float)`), `Position.open_position(txn)`, and
+  `portfolio.position_manager._storage.set_position(_OKX_SYMBOL, position)` (pure dict write,
+  cash-neutral per D-06). Returns `venue_qty`.
+- Wired the seed into BOTH start()-driven tests immediately AFTER `_assert_sandbox_routed(system)`
+  and BEFORE `system.start()`: `test_demo_order_produces_real_fill_event` and
+  `test_venue_account_reconciles_post_fill_within_tolerance`. Test (iii)
+  `test_restart_rehydrate_then_venue_reconcile_no_spurious_halt` UNTOUCHED (never calls `start()`).
+
+### Task 2 — delta-based settlement assertions (commit f2070431)
+- `_assert_settlement` signature gained `position_before` (now
+  `(system, portfolio_id, order, emitted, cash_before, position_before)`).
+- Replaced the three absolute position assertions with DELTA assertions on
+  `delta_qty = pos.net_quantity - position_before`: `delta_qty > 0`, `delta_qty <= filled_qty`,
+  `delta_qty >= filled_qty * (1 - _SETTLE_QTY_FEE_BAND)`. Failure-message style preserved.
+- CASH / STATUS-not-HALTED / spot `fetch_positions()==[]` assertions left UNCHANGED (cash is
+  already a delta and `cash_before` is snapshotted after the cash-neutral seed).
+- Returned dict gained `position_before` and `position_delta` (ARCH-3 capture records the delta).
+- `test_demo_order_produces_real_fill_event` snapshots `position_before` alongside `cash_before`
+  after `start()` and passes it to `_assert_settlement`.
+- ARCH-3 Wave-1 capture prints `position_before` (seeded baseline) and `position_delta`
+  (fill-induced).
+
+## Deviations from Plan
+
+None — plan executed exactly as written. No production (`itrader/`) source was modified.
+
+## Verification (OFFLINE only — the live `-m live` credential-gated test was NOT run)
+
+**1. AST parse:**
+```
+PARSE OK
+```
+
+**2. Credential-free collect-only:**
+```
+============================= test session starts ==============================
+platform darwin -- Python 3.13.1, pytest-9.0.3, pluggy-1.6.0
+rootdir: /Users/tizianoiacovelli/Desktop/projects/intelli-trader
+configfile: pyproject.toml
+plugins: cov-7.1.0, asyncio-1.4.0, metadata-3.1.1, html-4.2.0
+asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
+collected 3 items
+
+<Dir intelli-trader>
+  <Dir tests>
+    <Package e2e>
+      <Module test_okx_sandbox_recon.py>
+        <Function test_demo_order_produces_real_fill_event>
+        <Function test_venue_account_reconciles_post_fill_within_tolerance>
+        <Function test_restart_rehydrate_then_venue_reconcile_no_spurious_halt>
+
+========================== 3 tests collected in 0.03s ==========================
+```
+
+Module parses clean and COLLECTS credential-free (lazy imports keep collection network-free; the
+module-level `skipif` keeps it from running without demo creds). The online GREEN gate remains
+human-triggered (`-m live`).
+
+## Commits
+
+- `9b79681c` — test(quick-260705-fqe): seed believed venue position before start() in online recon tests
+- `f2070431` — test(quick-260705-fqe): assert BUY position DELTA in _assert_settlement for non-flat demo
+
+## Self-Check: PASSED
+- `tests/e2e/test_okx_sandbox_recon.py` modified (only file) — FOUND
+- Commit 9b79681c — FOUND
+- Commit f2070431 — FOUND
+- `_seed_believed_position_to_venue` helper present, lazy imports, cash-neutral seed — FOUND
+- `position_before` threaded through `_assert_settlement`, delta assertions in place — FOUND
+- Offline parse + collect-only both green — PASSED

--- a/itrader/events_handler/events/fill.py
+++ b/itrader/events_handler/events/fill.py
@@ -76,6 +76,13 @@ class FillEvent(Event, frozen=True, kw_only=True, gc=False):
     # at the settlement chokepoint — the SMA_MACD oracle stays byte-exact
     # (oracle-dark). Stamped live-only from the ccxt-unified ``trade['id']``.
     venue_trade_id: 'str | None' = None
+    # spot-base-fee-drift-halt: the venue's fee CURRENCY (ccxt-unified
+    # ``trade['fee']['currency']``). OKX charges the spot BUY taker fee in the
+    # pair's BASE asset (BTC) — carried so settlement can net a base-denominated
+    # fee out of the position quantity instead of the (unit-mismatched) cash leg.
+    # Default None so backtest/simulated fills take NO new settlement branch and
+    # the SMA_MACD oracle stays byte-exact (oracle-dark). Stamped live-only.
+    fee_currency: 'str | None' = None
 
     def __str__(self) -> str:
         return f'{self.type} ({self.ticker}, {self.action}, {round(self.quantity, 4)}, {round(self.price, 4)} $)'
@@ -88,7 +95,8 @@ class FillEvent(Event, frozen=True, kw_only=True, gc=False):
                  price: 'Decimal | float', quantity: 'Decimal | float',
                  commission: 'Decimal | float',
                  time: 'datetime | None' = None,
-                 venue_trade_id: 'str | None' = None) -> 'FillEvent':
+                 venue_trade_id: 'str | None' = None,
+                 fee_currency: 'str | None' = None) -> 'FillEvent':
         """
         Generate a complete FillEvent from the originating order.
 
@@ -135,6 +143,10 @@ class FillEvent(Event, frozen=True, kw_only=True, gc=False):
             key. Defaults to None: backtest/simulated fills carry no venue key
             and are unaffected (oracle-dark). Live emitters (OkxExchange stream,
             VenueReconciler) stamp it from the ccxt-unified ``trade['id']``.
+        fee_currency : `str`, optional (keyword-only)
+            The venue's fee currency (spot-base-fee-drift-halt) — the ccxt-unified
+            ``trade['fee']['currency']``. Defaults to None: backtest/simulated fills
+            carry no fee currency and take no new settlement branch (oracle-dark).
 
         Returns
         -------
@@ -161,4 +173,7 @@ class FillEvent(Event, frozen=True, kw_only=True, gc=False):
             leverage=getattr(order, "leverage", Decimal("1")),
             # CR-01: the venue trade id (None for backtest/simulated fills).
             venue_trade_id=venue_trade_id,
+            # spot-base-fee-drift-halt: the venue fee currency (None for
+            # backtest/simulated fills — oracle-dark).
+            fee_currency=fee_currency,
         )

--- a/itrader/execution_handler/exchanges/okx.py
+++ b/itrader/execution_handler/exchanges/okx.py
@@ -451,6 +451,14 @@ class OkxExchange(AbstractExchange):
 		fee = trade.get("fee") if isinstance(trade.get("fee"), dict) else {}
 		fee_cost = fee.get("cost")
 		commission = abs(to_money(str(fee_cost))) if fee_cost is not None else Decimal("0")
+		# spot-base-fee-drift-halt: carry the fee CURRENCY too. OKX charges the
+		# spot BUY taker fee in the pair's BASE asset (BTC), so the venue credits
+		# ``amount - base_fee`` BTC — dropping the currency (as this path used to)
+		# made the engine record the full ``amount`` and overstate the position by
+		# the fee, tripping the on-fill drift halt. The portfolio settlement branch
+		# reads this to net a base-denominated fee out of the position quantity.
+		fee_currency = fee.get("currency")
+		fee_currency = str(fee_currency) if fee_currency is not None else None
 
 		# CR-01: carry the venue trade id onto the FillEvent as the cross-emitter
 		# idempotency key. The exchange-local ``_seen_trade_ids`` dedups a stream
@@ -466,7 +474,8 @@ class OkxExchange(AbstractExchange):
 			quantity=to_money(str(amount)),
 			commission=commission,
 			time=self._ms_to_dt(timestamp),
-			venue_trade_id=venue_trade_id)
+			venue_trade_id=venue_trade_id,
+			fee_currency=fee_currency)
 		# D-07: the EXCHANGE emits the fill; MPSC-safe put from the connector loop thread (D-19).
 		self.global_queue.put(fill)
 		return True

--- a/itrader/portfolio_handler/account/venue.py
+++ b/itrader/portfolio_handler/account/venue.py
@@ -236,26 +236,45 @@ class VenueAccount(Account):
         Mirrors ``OkxExchange._stream_fills``: cache-write on the connector loop
         thread, NEVER a drift compare and NEVER a halt (the compare lives on the
         engine thread in 05-04). Each venue float crosses the Decimal edge in
-        ``_extract_balance``; a missing field leaves the prior cache value intact.
+        ``_write_balance_stream``; a missing field leaves the prior cache value intact.
         """
         while True:
             update = await self._connector.client.watch_balance()
-            balance = self._extract_balance(update)
-            # D-03: on spot the position truth rides the BALANCE stream (there is no
-            # positions channel), so derive it here from ``total[BASE]``. Derivative
-            # positions arrive via ``_stream_positions`` instead (unchanged). WR-02:
-            # ``_spot_positions_from_balance`` returns ``None`` for a base-absent
-            # partial frame so the guard below leaves the prior holding intact
-            # (never a spurious clobber-to-flat that would trip the drift halt).
-            spot_positions = (
-                self._spot_positions_from_balance(update)
-                if self._market_type == "spot" else None
-            )
-            with self._lock:
-                if balance is not None:
-                    self._venue_balance = balance
-                if spot_positions is not None:
-                    self._venue_positions = spot_positions
+            self._write_balance_stream(update)
+
+    def _write_balance_stream(self, update: Any) -> None:
+        """Apply a venue balance push to the cache — POSITIONS only, NEVER the cash baseline.
+
+        Root cause ``okx-venue-cash-double-count``: cash is the two-term surface
+        ``balance = _venue_balance + _ledger_delta`` where ``apply_fill_cash_flow``
+        (the shared Account-ABC settlement primitive, ``portfolio.py`` spot/margin
+        settle) moves ``_ledger_delta`` for EVERY fill. If the balance stream ALSO
+        refreshed ``_venue_balance`` to the fill-inclusive venue push, the same fill
+        would be counted TWICE — once in the stream-pushed venue balance, once in the
+        local ledger — a 2x cash debit (position, which has no ledger overlay, stayed
+        single-counted). Resetting the ledger on the stream write is NOT a fix: on the
+        live path the venue ``watch_balance`` push routinely LEADS the engine-thread
+        ``on_fill`` apply (queue latency), so a reset-then-apply double-counts in the
+        opposite order. Cash must be single-channel.
+
+        D-01 keeps ``snapshot()`` as the SOLE cash-reconcile point: it atomically
+        re-baselines ``_venue_balance`` AND resets ``_ledger_delta``. Between snapshots
+        the local ledger is the only channel that moves cash, so ordering can never
+        double-count. The stream's remaining live job is spot position liveness for the
+        drift compare (D-03): on spot the per-symbol holding rides the BALANCE stream
+        (there is no positions channel), derived from ``total[BASE]``. Derivative
+        positions arrive via ``_stream_positions`` instead (unchanged). WR-02:
+        ``_spot_positions_from_balance`` returns ``None`` for a base-absent partial
+        frame so the guard below leaves the prior holding intact (never a spurious
+        clobber-to-flat that would trip the drift halt).
+        """
+        spot_positions = (
+            self._spot_positions_from_balance(update)
+            if self._market_type == "spot" else None
+        )
+        with self._lock:
+            if spot_positions is not None:
+                self._venue_positions = spot_positions
 
     async def _stream_positions(self) -> None:
         """Consume the venue positions stream forever, writing the cache ONLY (D-15).

--- a/itrader/portfolio_handler/portfolio.py
+++ b/itrader/portfolio_handler/portfolio.py
@@ -397,7 +397,11 @@ class Portfolio(object):
 		#    fee field and event-derived timestamp (D-05/D-06, Pitfalls 1/5).
 		self.account.apply_fill_cash_flow(
 			amount=net_delta,
-			fee=transaction.commission,
+			# spot-base-fee-drift-halt: the QUOTE-cash commission portion included in
+			# ``net_delta`` (0 for a base-denominated fee, which is netted out of the
+			# position quantity instead). Identity to transaction.commission on the
+			# default / oracle path (byte-exact).
+			fee=transaction.quote_commission,
 			description=f"Transaction {transaction.type.name} {transaction.ticker}",
 			reference_id=str(transaction.id),
 			timestamp=transaction.time,

--- a/itrader/portfolio_handler/portfolio_handler.py
+++ b/itrader/portfolio_handler/portfolio_handler.py
@@ -919,6 +919,11 @@ class PortfolioHandler:
                     # CR-01: carry the venue trade id onto the durable settlement
                     # record (None for backtest/simulated fills — oracle-dark).
                     venue_trade_id=venue_trade_id,
+                    # spot-base-fee-drift-halt: carry the venue fee currency so the
+                    # spot settlement seam nets a base-denominated fee (OKX spot BUY)
+                    # out of the position quantity instead of the quote cash leg.
+                    # None for backtest/simulated fills (oracle-dark).
+                    fee_currency=getattr(fill_event, "fee_currency", None),
                 )
 
                 portfolio.transact_shares(transaction)

--- a/itrader/portfolio_handler/portfolio_handler.py
+++ b/itrader/portfolio_handler/portfolio_handler.py
@@ -950,9 +950,20 @@ class PortfolioHandler:
                 # SELL) so the spurious-halt band can absorb the "fill applied to the
                 # engine but not yet in the venue snapshot" transient (V17-04) — a
                 # first spot position-opening fill must not spuriously halt.
+                # spot-base-fee-drift-halt: this MUST be the ACTUAL signed position
+                # delta the settlement applied — NET of a base-denominated fee. The
+                # settlement moves a base-fee BUY by (amount - base_fee), so passing
+                # the RAW fill_event.quantity here left the absorber's pre-fill
+                # reconstruction (engine_qty - just_applied_fill_qty) off by the fee,
+                # spuriously tripping halt('drift') when the venue cache was still
+                # pre-fill. transaction.position_quantity is (amount - base_fee) for a
+                # base BUY and the raw amount otherwise (fee_currency None / quote fee
+                # -> identity, so simulated fills yield +/- fill_event.quantity as
+                # before — oracle-dark).
+                settled_base_delta = transaction.position_quantity
                 just_applied_fill_qty = (
-                    to_money(fill_event.quantity) if fill_event.action is Side.BUY
-                    else -to_money(fill_event.quantity)
+                    settled_base_delta if fill_event.action is Side.BUY
+                    else -settled_base_delta
                 )
                 self._compare_symbol_drift(
                     portfolio, fill_event.ticker, correlation_id,

--- a/itrader/portfolio_handler/position/position.py
+++ b/itrader/portfolio_handler/position/position.py
@@ -250,17 +250,27 @@ class Position(object):
 		"""
 		position_side = PositionSide.LONG if transaction.type == TransactionType.BUY else PositionSide.SHORT
 
+		# spot-base-fee-drift-halt: the base quantity that actually settles into the
+		# position and the commission that is a QUOTE cash flow. For a base-denominated
+		# fee (OKX spot BUY) position_quantity == amount - base_fee (the venue-credited
+		# net base) and quote_commission == 0 (the fee is netted out of the base, not a
+		# quote cost). getattr fallbacks keep hand-built transaction stubs (predating the
+		# properties) working; on the default/oracle path they resolve to
+		# quantity/commission verbatim (byte-exact).
+		settle_quantity = getattr(transaction, "position_quantity", transaction.quantity)
+		quote_commission = getattr(transaction, "quote_commission", transaction.commission)
+
 		return cls(
 			entry_date = transaction.time,
 			ticker = transaction.ticker,
 			side = position_side,
 			price = transaction.price,
-			buy_quantity = transaction.quantity if position_side == PositionSide.LONG else 0,
-			sell_quantity = transaction.quantity if position_side == PositionSide.SHORT else 0,
+			buy_quantity = settle_quantity if position_side == PositionSide.LONG else 0,
+			sell_quantity = settle_quantity if position_side == PositionSide.SHORT else 0,
 			avg_bought = transaction.price if position_side == PositionSide.LONG else 0,
 			avg_sold = transaction.price if position_side == PositionSide.SHORT else 0,
-			buy_commission = transaction.commission if position_side == PositionSide.LONG else 0,
-			sell_commission = transaction.commission if position_side == PositionSide.SHORT else 0,
+			buy_commission = quote_commission if position_side == PositionSide.LONG else 0,
+			sell_commission = quote_commission if position_side == PositionSide.SHORT else 0,
 			is_open = True,
 			portfolio_id = transaction.portfolio_id,
 			# D-06: the one effective leverage, taken from the opening fill's
@@ -274,14 +284,20 @@ class Position(object):
 		Updates the average bought/sold price, quantity, and commission
 		of the Position based on the transaction details.
 		"""
+		# spot-base-fee-drift-halt: net-base settle quantity + quote-cash commission
+		# (see open_position). Default/oracle path resolves to quantity/commission
+		# verbatim (byte-exact); a base-denominated fee scales the position in by the
+		# venue-credited net base (amount - base_fee) and folds NO quote commission.
+		settle_quantity = getattr(transaction, "position_quantity", transaction.quantity)
+		quote_commission = getattr(transaction, "quote_commission", transaction.commission)
 		if transaction.type == TransactionType.BUY:
-			self.avg_bought = ((self.avg_bought * self.buy_quantity) + (transaction.quantity * transaction.price)) / (self.buy_quantity + transaction.quantity)
-			self.buy_quantity += transaction.quantity
-			self.buy_commission += transaction.commission
+			self.avg_bought = ((self.avg_bought * self.buy_quantity) + (settle_quantity * transaction.price)) / (self.buy_quantity + settle_quantity)
+			self.buy_quantity += settle_quantity
+			self.buy_commission += quote_commission
 		elif transaction.type == TransactionType.SELL:
-			self.avg_sold = ((self.avg_sold * self.sell_quantity) + (transaction.quantity * transaction.price)) / (self.sell_quantity + (transaction.quantity))
-			self.sell_quantity += transaction.quantity
-			self.sell_commission += transaction.commission
+			self.avg_sold = ((self.avg_sold * self.sell_quantity) + (settle_quantity * transaction.price)) / (self.sell_quantity + (settle_quantity))
+			self.sell_quantity += settle_quantity
+			self.sell_commission += quote_commission
 		# D-05 (PERF-08): this is the ONLY site that mutates the six fill-derived
 		# inputs (buy/sell_quantity, buy/sell_commission, avg_bought/avg_sold), so
 		# both caches are invalidated here. A grep audit confirms no other mutator

--- a/itrader/portfolio_handler/transaction/transaction.py
+++ b/itrader/portfolio_handler/transaction/transaction.py
@@ -52,6 +52,13 @@ class Transaction(msgspec.Struct, gc=False):
 	# position-life locked margin (aggregate_notional / leverage) EQUALS the
 	# admission reservation (notional / effective_leverage).
 	leverage: Decimal = msgspec.field(default_factory=lambda: Decimal("1"))
+	# spot-base-fee-drift-halt: the venue's fee CURRENCY carried from the FillEvent.
+	# OKX charges the spot BUY taker fee in the pair's BASE asset (BTC); when this
+	# equals the pair base the settlement seam nets the fee out of the position
+	# quantity instead of debiting it from quote cash. None for backtest/simulated
+	# fills (oracle-dark) — the defaulted field keeps the positional construction +
+	# spot byte-exact path unchanged.
+	fee_currency: Optional[str] = None
 
 	def __post_init__(self) -> None:
 		"""Enter the Decimal money domain at the construction boundary (D-04).
@@ -99,6 +106,59 @@ class Transaction(msgspec.Struct, gc=False):
 			return self.cost + self.commission
 
 	@property
+	def base_asset(self) -> Optional[str]:
+		"""The pair's BASE asset parsed from the ticker (spot-base-fee-drift-halt).
+
+		Venue tickers on the live path are ccxt-unified ``BASE/QUOTE`` (e.g.
+		``BTC/USDC`` → ``BTC``). Returns None for a ticker without a ``/`` separator
+		(e.g. the backtest ``BTCUSDT`` idiom) so the base-fee branch never engages on
+		the oracle path.
+		"""
+		if "/" in self.ticker:
+			return self.ticker.split("/")[0]
+		return None
+
+	@property
+	def is_base_fee(self) -> bool:
+		"""True when the venue charged the fee in the pair's BASE asset (OKX spot BUY).
+
+		Requires a non-None ``fee_currency`` that equals the parsed base asset AND a
+		non-zero commission. False for a quote-denominated fee, a fee currency absent
+		(None — every backtest/simulated fill), or a zero commission → the CURRENT
+		settlement path (oracle-dark, byte-exact).
+		"""
+		if self.fee_currency is None or self.commission == 0:
+			return False
+		return self.fee_currency == self.base_asset
+
+	@property
+	def quote_commission(self) -> Decimal:
+		"""Commission that settles as a QUOTE cash flow (spot-base-fee-drift-halt).
+
+		A base-denominated fee is taken in the base asset and nets out of the position
+		quantity, so it is NOT a quote cash outflow → ``Decimal("0")``. Otherwise the
+		full commission is a quote cash flow (default / oracle path → identity, so the
+		cash math is byte-exact when there is no venue base fee).
+		"""
+		if self.is_base_fee:
+			return Decimal("0")
+		return self.commission
+
+	@property
+	def position_quantity(self) -> Decimal:
+		"""Base quantity that actually settles into the position (spot-base-fee-drift-halt).
+
+		For a base-denominated fee on a BUY the venue credits ``amount - base_fee`` base
+		(the fee is netted out of what is received), so the position must hold the NET
+		amount to equal the venue base balance (drift eliminated at the source). Every
+		other path — quote-fee, None fee currency, SELL — returns the full traded
+		``quantity`` (oracle-dark, byte-exact).
+		"""
+		if self.is_base_fee and self.type == TransactionType.BUY:
+			return self.quantity - self.commission
+		return self.quantity
+
+	@property
 	def net_cash_delta(self) -> Decimal:
 		"""
 		Signed, full-precision net cash delta this transaction settles for.
@@ -118,10 +178,15 @@ class Transaction(msgspec.Struct, gc=False):
 			Negative for a BUY (cash outflow: -(cost + commission)),
 			positive for a SELL (cash inflow: cost - commission).
 		"""
+		# spot-base-fee-drift-halt: a base-denominated fee has NO quote cash leg
+		# (``quote_commission`` == 0) — it is netted out of the position quantity
+		# instead. ``quote_commission`` is the full commission on the default /
+		# quote-fee path, so this expression is byte-exact when there is no venue
+		# base fee (the SMA_MACD oracle path).
 		if self.type == TransactionType.BUY:
-			return -(self.price * self.quantity + self.commission)
+			return -(self.price * self.quantity + self.quote_commission)
 		else:  # SELL
-			return self.price * self.quantity - self.commission
+			return self.price * self.quantity - self.quote_commission
 
 	@classmethod
 	def new_transaction(cls, filled_order: FillEvent) -> "Transaction":
@@ -158,6 +223,9 @@ class Transaction(msgspec.Struct, gc=False):
 			leverage=getattr(filled_order, "leverage", Decimal("1")),
 			# CR-01: carry the venue trade id (None for backtest/simulated fills).
 			venue_trade_id=getattr(filled_order, "venue_trade_id", None),
+			# spot-base-fee-drift-halt: carry the venue fee currency (None for
+			# backtest/simulated fills — oracle-dark).
+			fee_currency=getattr(filled_order, "fee_currency", None),
 		)
 
 	def to_dict(self) -> dict[str, object]:

--- a/tests/e2e/test_okx_sandbox_recon.py
+++ b/tests/e2e/test_okx_sandbox_recon.py
@@ -457,7 +457,7 @@ def _sum_fill_cost(order_trades):
     )
 
 
-def _assert_settlement(system, portfolio_id, order, emitted, cash_before):
+def _assert_settlement(system, portfolio_id, order, emitted, cash_before, position_before):
     """D-20 CONF-B: the four Wave-1 settlement assertions the pre-05.1 suite lacked.
 
     The prior suite asserted only the order mirror + emitted fills, NEVER the portfolio
@@ -466,6 +466,11 @@ def _assert_settlement(system, portfolio_id, order, emitted, cash_before):
     equality): an OKX spot BUY may deduct the fee from the base asset received, so the
     settled qty / cash-delta straddle a cost..cost*(1+fee) band. Returns the measured
     values so the ARCH-3 capture can record them without a second network round-trip.
+
+    The POSITION check asserts the BUY's DELTA (``pos.net_quantity - position_before``),
+    not the absolute post-fill net_quantity — the online proof runs against a NON-FLAT
+    demo account pre-seeded to the venue baseline (see ``_seed_believed_position_to_venue``),
+    so only the fill-induced delta is meaningful.
     """
     from itrader.core.enums import SystemStatus
 
@@ -475,16 +480,18 @@ def _assert_settlement(system, portfolio_id, order, emitted, cash_before):
     filled_qty = _sum_filled_qty(order_trades)
     fill_cost = _sum_fill_cost(order_trades)
 
-    # (1) POSITION settled: non-None with qty ≈ the venue-filled qty (within a base-fee
-    #     band — a spot BUY fee is frequently taken from the BTC received).
+    # (1) POSITION settled: non-None with the fill DELTA ≈ the venue-filled qty (within a
+    #     base-fee band — a spot BUY fee is frequently taken from the BTC received). The
+    #     delta is relative to the pre-seeded non-flat baseline, not the absolute qty.
     pos = system.portfolio_handler.get_position(portfolio_id, _OKX_SYMBOL)
     assert pos is not None, (
         f"portfolio has no {_OKX_SYMBOL} position after a real demo fill — settlement "
         f"never reached the portfolio (V17-01 blind spot)")
-    assert pos.net_quantity > 0
-    assert pos.net_quantity <= filled_qty
-    assert pos.net_quantity >= filled_qty * (Decimal("1") - _SETTLE_QTY_FEE_BAND), (
-        f"settled qty {pos.net_quantity} below the fee-band floor of venue-filled "
+    delta_qty = pos.net_quantity - position_before
+    assert delta_qty > 0
+    assert delta_qty <= filled_qty
+    assert delta_qty >= filled_qty * (Decimal("1") - _SETTLE_QTY_FEE_BAND), (
+        f"settled qty delta {delta_qty} below the fee-band floor of venue-filled "
         f"{filled_qty}")
 
     # (2) CASH decreased by ≈ cost+fee — settlement debited the ledger.
@@ -515,6 +522,8 @@ def _assert_settlement(system, portfolio_id, order, emitted, cash_before):
         "filled_qty": filled_qty,
         "fill_cost": fill_cost,
         "position_qty": pos.net_quantity,
+        "position_before": position_before,
+        "position_delta": delta_qty,
         "cash_before": cash_before,
         "cash_after": cash_after,
         "cash_delta": delta,
@@ -596,6 +605,8 @@ def _capture_arch3_finalization(system, order, settlement, venue_id_check):
         "## Wave-1 settlement assertions (GREEN gate)",
         "",
         f"- position qty (settled): `{settlement['position_qty']}`",
+        f"- position before (seeded baseline): `{settlement['position_before']}`",
+        f"- position delta (fill-induced): `{settlement['position_delta']}`",
         f"- venue-filled qty: `{settlement['filled_qty']}`",
         f"- fill cost (quote notional): `{settlement['fill_cost']}`",
         f"- cash before / after: `{settlement['cash_before']}` -> `{settlement['cash_after']}`",
@@ -664,6 +675,10 @@ def test_demo_order_produces_real_fill_event() -> None:
         # D-20: snapshot buying power BEFORE the order so the settlement assertion can
         # prove a real fill DEBITED the ledger (not merely produced a FillEvent).
         cash_before = system.portfolio_handler.available_cash(portfolio_id)
+        # Snapshot the pre-order believed position (non-flat after the venue seed) so the
+        # settlement proof asserts the BUY's DELTA, not the absolute post-fill net_quantity.
+        _pos_before = system.portfolio_handler.get_position(portfolio_id, _OKX_SYMBOL)
+        position_before = _pos_before.net_quantity if _pos_before is not None else Decimal("0")
 
         order = _submit_min_demo_order(system, portfolio_id)
         filled = _wait_for_fill(system, order)
@@ -681,7 +696,7 @@ def test_demo_order_produces_real_fill_event() -> None:
         #     fill lands in the portfolio (position + cash), does not HALT, and the spot
         #     venue-truth channel is []. These four are the Wave-1 GREEN exit gate.
         settlement = _assert_settlement(
-            system, portfolio_id, order, emitted, cash_before)
+            system, portfolio_id, order, emitted, cash_before, position_before)
         # (e) RECORDED soft-check (pending D-06 / Phase 05.2) — records the post-fill
         #     venue_order_id result without hard-failing the Wave-1 gate.
         venue_id_check = _venue_order_id_softcheck(system, order, emitted)

--- a/tests/e2e/test_okx_sandbox_recon.py
+++ b/tests/e2e/test_okx_sandbox_recon.py
@@ -577,8 +577,11 @@ def _capture_arch3_finalization(system, order, settlement, venue_id_check):
 
     # --- Point 1: fetch_my_trades window / pagination / id presence ------------
     since_ms = int(order.time.timestamp() * 1000)
+    # Explicit limit=100 (the OKX fills endpoint cap), no pagination: the
+    # `{"paginate": True}` / limit=None form is rejected by OKX with sCode 51000
+    # "Parameter limit error". A single 100-row page is ample for a one-fill run.
     trades = connector.call(
-        connector.client.fetch_my_trades(_OKX_SYMBOL, since_ms, None, {"paginate": True}))
+        connector.client.fetch_my_trades(_OKX_SYMBOL, since_ms, 100))
     trades = trades or []
     all_have_id = all(t.get("id") for t in trades)
     all_have_order = all(t.get("order") for t in trades)
@@ -617,7 +620,8 @@ def _capture_arch3_finalization(system, order, settlement, venue_id_check):
         "## ARCH-3 finalization point 1 — fetch_my_trades (window / pagination / ids)",
         "",
         f"- since (ms, oldest = order submit): `{since_ms}`",
-        "- pagination: `params={'paginate': True}` (since disables `limit` — ccxt quirk)",
+        "- pagination: explicit `limit=100`, no `paginate` (the paginated/None-limit "
+        "form is rejected by OKX with sCode 51000 'Parameter limit error')",
         f"- trades returned: `{len(trades)}`",
         f"- all have unified `id` (tradeId): `{all_have_id}`",
         f"- all have unified `order` (ordId): `{all_have_order}`",
@@ -701,8 +705,15 @@ def test_demo_order_produces_real_fill_event() -> None:
         #     venue_order_id result without hard-failing the Wave-1 gate.
         venue_id_check = _venue_order_id_softcheck(system, order, emitted)
         # (f) Record the four ARCH-3 finalization points to .planning/debug/ — the input
-        #     that finalizes the provisional ARCH-3 posture for Phase 05.2.
-        _capture_arch3_finalization(system, order, settlement, venue_id_check)
+        #     that finalizes the provisional ARCH-3 posture for Phase 05.2. BEST-EFFORT:
+        #     this is a diagnostic artifact-writing step, NOT a settlement assertion — the
+        #     four Wave-1 GREEN-gate asserts (a-d) already ran and passed above. A venue-API
+        #     quirk in the capture (e.g. an OKX param rejection on fetch_my_trades) must
+        #     NOT fail the settlement gate, so record the failure and continue.
+        try:
+            _capture_arch3_finalization(system, order, settlement, venue_id_check)
+        except Exception as capture_exc:  # noqa: BLE001 — diagnostic step, never gating
+            print(f"ARCH-3 capture skipped (diagnostic, non-gating): {capture_exc!r}")
     finally:
         _cleanup_and_stop(system)
 

--- a/tests/e2e/test_okx_sandbox_recon.py
+++ b/tests/e2e/test_okx_sandbox_recon.py
@@ -287,6 +287,74 @@ def _build_demo_connector():
     return connector
 
 
+def _seed_believed_position_to_venue(system, portfolio_id):
+    """TEST-ONLY: seed the engine's believed BTC/USDC position to the LIVE venue balance.
+
+    The only OKX demo account available is NON-FLAT: OKX pre-seeds ~1 BTC and the EEA/MiCA
+    account cannot be sold flat (sells blocked by a price-floor > best-bid). On such an
+    account ``_run_session_baseline_guard`` (live_trading_system.py:579) reads a base-asset
+    residual and latches ``halt('baseline-residual')`` inside ``start()`` — the two online
+    start()-driven tests never reach RUNNING.
+
+    This helper reads the live venue BTC balance READ-ONLY (via an independent sandbox
+    connector — the system connector is not yet connected pre-``start()``) and seeds the
+    believed BTC/USDC position to match it BEFORE ``start()``, so the guard reads
+    ``engine_qty == venue_qty`` and lets the session reach RUNNING. The read places NO order.
+    ``set_position`` is a pure position-only dict write (``PositionManager`` is cash-agnostic,
+    D-06), so ``cash_before`` — snapshotted after ``start()`` — is unaffected by the seed.
+
+    On a genuinely FLAT account (venue base total 0 or absent) the seed is a no-op and the
+    original flat-start behavior is unchanged. Returns the seeded ``venue_qty`` (Decimal).
+    All imports are LAZY (inside this body) so credential-free collection never touches
+    connector code.
+    """
+    from datetime import datetime, timezone
+
+    import uuid_utils.compat as uc
+
+    from itrader.core.enums import TransactionType
+    from itrader.core.ids import TransactionId
+    from itrader.core.money import to_money
+    from itrader.portfolio_handler.position.position import Position
+    from itrader.portfolio_handler.transaction.transaction import Transaction
+
+    # READ-ONLY: read the live venue BTC balance via a throwaway sandbox connector.
+    connector = _build_demo_connector()
+    try:
+        bal = connector.call(connector.client.fetch_balance())
+        total = bal.get("total", {}) if isinstance(bal, dict) else {}
+        base_raw = total.get(_BASE_CCY) if isinstance(total, dict) else None
+    finally:
+        try:
+            connector.disconnect()
+        except Exception:
+            pass
+
+    if base_raw is None:
+        return Decimal("0")   # no venue balance key — genuinely flat, seed is a no-op.
+
+    # Decimal edge — never Decimal(float); matches the guard's venue_qty byte-for-byte.
+    venue_qty = to_money(str(base_raw))
+    if venue_qty == 0:
+        return Decimal("0")   # flat account — original flat-start path intact.
+
+    txn = Transaction(
+        time=datetime.now(timezone.utc),
+        type=TransactionType.BUY,
+        ticker=_OKX_SYMBOL,
+        price=_PRICE_ESTIMATE,
+        quantity=venue_qty,
+        commission=Decimal("0"),
+        portfolio_id=portfolio_id,
+        id=TransactionId(uc.uuid7()),
+        fill_id=uc.uuid7(),
+    )
+    position = Position.open_position(txn)
+    portfolio = system.portfolio_handler.get_portfolio(portfolio_id)
+    portfolio.position_manager._storage.set_position(_OKX_SYMBOL, position)
+    return venue_qty
+
+
 def _start_pg_container():
     """Start a testcontainers Postgres (rehydrate substrate); skip if Docker is absent (D-11)."""
     from testcontainers.postgres import PostgresContainer
@@ -582,6 +650,10 @@ def test_demo_order_produces_real_fill_event() -> None:
 
     system, portfolio_id = _build_live_okx_stack()
     _assert_sandbox_routed(system)
+    # Seed the believed BTC/USDC position to the live (non-flat) venue balance BEFORE
+    # start() so the baseline guard reads engine_qty == venue_qty and reaches RUNNING
+    # instead of latching halt('baseline-residual'). No-op on a genuinely flat account.
+    _seed_believed_position_to_venue(system, portfolio_id)
     emitted = _install_emit_spy(system)
     try:
         # T-05-04: final routing guard — the connector MUST be sandbox is True before we submit.
@@ -634,6 +706,11 @@ def test_venue_account_reconciles_post_fill_within_tolerance() -> None:
 
     system, portfolio_id = _build_live_okx_stack()
     _assert_sandbox_routed(system)
+    # Seed the believed BTC/USDC position to the live (non-flat) venue balance BEFORE
+    # start() so the baseline guard reaches RUNNING (see test (i)); the reconcile below
+    # still holds because engine and venue both move by the same fill delta from this
+    # seeded baseline. No-op on a genuinely flat account.
+    _seed_believed_position_to_venue(system, portfolio_id)
     try:
         # T-05-04: final routing guard — the connector MUST be sandbox is True before we submit.
         assert system._okx_connector.sandbox is True

--- a/tests/unit/execution/test_supervisor_catchall.py
+++ b/tests/unit/execution/test_supervisor_catchall.py
@@ -258,6 +258,16 @@ def test_supervisor_catchall_venue_stream_survives_networkerror() -> None:
     ``NetworkError`` kills the balance-cache writer outright, so the post-blip balance is
     never written and the cache freezes at ``None``. GREEN after D-11 wraps it in the same
     bounded-retry supervisor: the transient drop is survived and the recovered balance lands.
+
+    NOTE (Phase 05.3 implementer — assertion premise invalidated by commit 30cfb73):
+    the ``_venue_balance == 123.45`` assertion below no longer expresses stream survival.
+    The cash-double-count fix made the balance stream (``_write_balance_stream``) write
+    POSITIONS ONLY — ``_venue_balance`` is now written SOLELY by ``snapshot()`` (single-
+    channel cash, D-01). So even AFTER D-11 adds the reconnect supervisor, this test will
+    STILL fail on the ``_venue_balance`` check, because the stream deliberately never writes
+    the cash baseline anymore. When you implement D-11, RE-EXPRESS the survival assertion
+    another way (e.g. assert a positions write after recovery, or spy the recovery
+    iteration) — do NOT resurrect a stream-side ``_venue_balance`` write to satisfy it.
     """
     client = MagicMock(name="ccxt_pro_client")
     good_balance = {"total": {"USDT": 123.45}, "free": {"USDT": 100.0}}
@@ -278,6 +288,8 @@ def test_supervisor_catchall_venue_stream_survives_networkerror() -> None:
         # GREEN: the supervisor breaks on the _StopLoop sentinel after the recovery write.
         pass
 
+    # NOTE (30cfb73): the balance stream now writes positions only; _venue_balance is
+    # snapshot()-only. This assertion must be re-expressed when D-11 lands — see docstring.
     assert venue._venue_balance == to_money("123.45"), (
         "A6/V17-07: VenueAccount._stream_account is a bare `while True` with no reconnect "
         "supervisor — a single NetworkError killed the balance-cache writer silently and the "

--- a/tests/unit/portfolio/test_spot_base_fee_drift_absorber.py
+++ b/tests/unit/portfolio/test_spot_base_fee_drift_absorber.py
@@ -1,0 +1,170 @@
+"""Regression: the on-fill drift ABSORBER must be fee-aware (spot-base-fee-drift-halt).
+
+Follow-on to the fee-currency-aware settlement fix. The settlement now moves a spot
+position by ``amount - base_fee`` for a base-denominated fee (OKX spot BUY), so the
+engine position == venue base balance EXACTLY. But the on-fill drift-halt ABSORBER
+(``PortfolioHandler._compare_symbol_drift`` spurious-halt band, D-04/V17-04) forgives
+the "fill applied to the engine but not yet in the venue snapshot" transient by checking
+``venue_qty ≈ engine_qty - just_applied_fill_qty``. ``on_fill`` USED TO pass the RAW
+``fill_event.quantity`` as ``just_applied_fill_qty`` — but the settlement only moved the
+position by ``amount - base_fee``, so ``engine_qty - amount == pre - base_fee`` (off by the
+fee from the true pre-fill holding). When the async venue cache is still pre-fill at compare
+time (stream-vs-engine-thread race), the absorber fails and falls through to ``halt('drift')``.
+
+This is the exact race the online ``test_demo_order_produces_real_fill_event`` hits. The fix
+derives ``just_applied_fill_qty`` from the SAME fee-aware net-base delta the settlement
+applied (``transaction.position_quantity``, signed by action) so the absorber reconstructs the
+true pre-fill holding and forgives the transient.
+
+Fully offline (``FakeLiveConnector`` spot fixture — no OKX creds, no network); ``disconnect()``
+teardown keeps the strict suite clean (``filterwarnings=["error"]``). 4-space indent.
+"""
+
+import json
+import queue
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+import uuid_utils.compat as uuid_compat
+
+from itrader import idgen
+from itrader.core.enums import FillStatus, Side, TransactionType
+from itrader.core.ids import CorrelationId, OrderId, StrategyId
+from itrader.events_handler.events import FillEvent
+from itrader.portfolio_handler.account.venue import VenueAccount
+from itrader.portfolio_handler.portfolio import Portfolio
+from itrader.portfolio_handler.portfolio_handler import PortfolioHandler
+from itrader.portfolio_handler.transaction import Transaction
+
+_TICKER = "BTC/USDC"
+_SPOT_FIXTURE = Path(__file__).parent / "okx_recon_payloads_spot.json"
+
+
+def _spot_payloads_with_btc(btc_total: str) -> dict:
+    """Load the SPOT recon fixture with the base (BTC) balance total set (float edge)."""
+    payloads = json.loads(_SPOT_FIXTURE.read_text())
+    balance = payloads["fetch_balance"]
+    balance["total"]["BTC"] = float(btc_total)
+    balance["free"]["BTC"] = float(btc_total)
+    return payloads
+
+
+def _seed_buy(qty: str, price: str = "100") -> Transaction:
+    """A zero-fee BUY used only to seed the engine position belief to the venue baseline."""
+    return Transaction(
+        datetime.now(), TransactionType.BUY, _TICKER, Decimal(price), Decimal(qty),
+        Decimal("0"), None, idgen.generate_transaction_id(),
+        fill_id=uuid_compat.uuid7(),
+    )
+
+
+def _base_fee_buy_fill(portfolio_id, *, amount: str, fee: str, price: str = "100") -> FillEvent:
+    """An EXECUTED base-denominated-fee BUY FillEvent (fee_currency == pair base 'BTC')."""
+    return FillEvent(
+        time=datetime.now(),
+        status=FillStatus.EXECUTED,
+        ticker=_TICKER,
+        action=Side.BUY,
+        price=Decimal(price),
+        quantity=Decimal(amount),
+        commission=Decimal(fee),
+        portfolio_id=portfolio_id,
+        fill_id=uuid_compat.uuid7(),
+        order_id=OrderId(uuid_compat.uuid7()),
+        strategy_id=StrategyId(uuid_compat.uuid7()),
+        fee_currency="BTC",
+    )
+
+
+@pytest.fixture
+def venue_connectors():
+    """Factory yielding CONNECTED FakeLiveConnectors with guaranteed teardown."""
+    from tests.support.fake_venue_connector import make_fake_venue_connector
+
+    created = []
+
+    def _make(payloads):
+        connector = make_fake_venue_connector(sandbox=True, payloads=payloads)
+        connector.connect()
+        created.append(connector)
+        return connector
+
+    try:
+        yield _make
+    finally:
+        for connector in created:
+            connector.disconnect()
+
+
+@pytest.fixture
+def handler() -> PortfolioHandler:
+    return PortfolioHandler(queue.Queue())
+
+
+@pytest.fixture
+def halt_calls(handler: PortfolioHandler) -> list:
+    calls: list = []
+    handler.set_halt_signal(lambda reason: calls.append(reason))
+    return calls
+
+
+def _spot_venue_portfolio(venue_connectors, handler, btc_total: str) -> Portfolio:
+    """A registered Portfolio whose account is a VenueAccount snapshotted from spot truth."""
+    connector = venue_connectors(_spot_payloads_with_btc(btc_total))
+    portfolio = Portfolio("spot_venue_pf", "okx", Decimal("150000"), datetime.now())
+    account = VenueAccount(
+        connector, quote_currency="USDC", market_type="spot", symbol=_TICKER
+    )
+    account.snapshot()
+    portfolio.account = account
+    handler._portfolios[portfolio.portfolio_id] = portfolio
+    return portfolio
+
+
+def test_base_fee_fill_with_prefill_venue_cache_does_not_halt(venue_connectors, handler, halt_calls):
+    """A base-fee BUY whose venue cache is still PRE-fill must NOT spuriously halt.
+
+    Venue base balance == engine belief == 1.0 BTC pre-fill (the snapshot is taken then).
+    A base-fee BUY of 0.001 BTC (fee 0.000001 BTC) settles the engine to 1.000999, while the
+    async venue cache still reads the pre-fill 1.0 (the stream-vs-engine-thread race). The
+    on-fill absorber must reconstruct the pre-fill holding from the NET base delta
+    (1.000999 - 0.000999 == 1.0 == venue) and forgive the transient.
+
+    RED before the absorber fix: on_fill passed the RAW 0.001 as just_applied_fill_qty, so
+    1.000999 - 0.001 == 0.999999 != 1.0 (off by the 1e-6 base fee, beyond the 1e-8 band) ->
+    the absorber falls through to halt('drift'). GREEN after: net-base delta reconstructs 1.0.
+    """
+    portfolio = _spot_venue_portfolio(venue_connectors, handler, btc_total="1.0")
+    # Engine believes 1.0 BTC — equal to the snapshotted venue base balance (pre-fill parity).
+    portfolio.position_manager.process_position_update(_seed_buy(qty="1.0"))
+    assert portfolio.get_open_position(_TICKER).net_quantity == Decimal("1.0")
+
+    # A base-fee BUY streams in; settlement nets the fee out (engine -> 1.000999) while the
+    # venue cache is NOT refreshed (still 1.0) — the exact on-fill race.
+    fill = _base_fee_buy_fill(portfolio.portfolio_id, amount="0.001", fee="0.000001")
+    handler.on_fill(fill)
+
+    # Engine moved by the NET base (amount - base_fee); venue cache still pre-fill.
+    assert portfolio.get_open_position(_TICKER).net_quantity == Decimal("1.000999")
+    assert portfolio.account.positions.get(_TICKER) == Decimal("1.0")
+    # The absorber forgave the transient — NO spurious halt.
+    assert halt_calls == []
+
+
+def test_genuine_unexplained_base_drift_still_halts(venue_connectors, handler, halt_calls):
+    """The fee-aware absorber must NOT hide a genuine unexplained divergence.
+
+    Engine believes 1.0 BTC but the venue base balance is 2.0 (a real, unexplained 1.0 BTC
+    holding) with NO just-applied fill in flight. The per-symbol compare must still surface
+    it as ``halt('drift')`` — the fee-awareness only forgives the pre-fill on-fill transient,
+    never a persistent beyond-band divergence.
+    """
+    portfolio = _spot_venue_portfolio(venue_connectors, handler, btc_total="2.0")
+    portfolio.position_manager.process_position_update(_seed_buy(qty="1.0"))
+
+    handler._compare_symbol_drift(
+        portfolio, _TICKER, CorrelationId(idgen.generate_correlation_id()))
+
+    assert halt_calls == ["drift"]

--- a/tests/unit/portfolio/test_spot_base_fee_settlement.py
+++ b/tests/unit/portfolio/test_spot_base_fee_settlement.py
@@ -1,0 +1,155 @@
+"""Regression: fee-currency-aware spot settlement (spot-base-fee-drift-halt).
+
+Root cause (`.planning/debug/spot-base-fee-drift-halt.md`): OKX charges the spot
+**BUY** taker fee in the **BASE** asset (BTC). The venue credits ``amount - base_fee``
+BTC, but the engine used to record the FULL fill ``amount`` as the position and debit
+the base-fee as a (unit-mismatched) quote cash outflow. Result: ``engine_qty ==
+venue_qty + base_fee`` — the on-fill drift compare tripped ``halt('drift')`` on every
+clean demo BUY, and the position was overstated by the fee.
+
+The fix carries the fee **currency** onto the FillEvent / Transaction and branches
+settlement on it:
+
+* fee in the pair's **BASE** asset (OKX spot BUY) → deduct it from the **position**
+  quantity (net base received = ``amount - base_fee``); NO quote cash debit for it.
+* fee in the **QUOTE** asset (OKX spot SELL) → debit **cash** (unchanged behavior).
+
+ORACLE SAFETY: a fill with ``fee_currency=None`` (every backtest/simulated fill) or a
+quote-denominated fee takes the CURRENT path byte-for-byte — the SMA_MACD golden oracle
+stays byte-exact. These are OFFLINE unit regressions (no network, no demo order) driving
+``Portfolio.process_transaction`` directly. Folder-derived ``unit`` marker; 4-space indent.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+
+import uuid_utils.compat as uuid_compat
+
+from itrader.portfolio_handler.portfolio import Portfolio
+from itrader.portfolio_handler.transaction import Transaction, TransactionType
+from itrader import idgen
+
+
+_INITIAL_CASH = 150000
+
+
+def _txn(txn_type, ticker, price, qty, commission=0, fee_currency=None):
+    """Build a spot transaction, optionally carrying the venue fee currency."""
+    return Transaction(
+        datetime.now(), txn_type, ticker, price, qty, commission, None,
+        idgen.generate_transaction_id(), fill_id=uuid_compat.uuid7(),
+        fee_currency=fee_currency,
+    )
+
+
+def _spot_portfolio():
+    """A fresh SPOT simulated portfolio (enable_margin defaults False)."""
+    return Portfolio("spot_pf", "simulated", _INITIAL_CASH, datetime.now())
+
+
+def test_base_fee_buy_reduces_position_not_cash():
+    """A BASE-denominated fee (OKX spot BUY) nets out of the POSITION, not cash.
+
+    BUY 0.001 BTC/USDC @ 100000 with a 0.000001 BTC base fee:
+      * position.net_quantity == 0.001 - 0.000001 == 0.000999 (venue-credited net base)
+      * cash == 150000 - (100000 * 0.001) == 149900   (notional only — NO fee cash debit)
+
+    RED before the fix: the base-fee was ignored (position == 0.001) and debited from
+    cash (149899.999999), reproducing the engine-overstates-by-base-fee drift.
+    """
+    pf = _spot_portfolio()
+    pf.process_transaction(
+        _txn(TransactionType.BUY, "BTC/USDC", Decimal("100000"), Decimal("0.001"),
+             commission=Decimal("0.000001"), fee_currency="BTC"))
+
+    position = pf.positions["BTC/USDC"]
+    assert position.net_quantity == Decimal("0.000999")
+    assert pf.cash == Decimal("149900")
+
+
+def test_quote_fee_sell_debits_cash_not_position():
+    """A QUOTE-denominated fee (OKX spot SELL) debits CASH — unchanged behavior.
+
+    Open 0.001 @ 100000 (no fee), then SELL 0.0005 @ 110000 with a 0.055 USDC quote fee:
+      * position.net_quantity == 0.001 - 0.0005 == 0.0005 (full sold qty leaves the base)
+      * cash inflow == 0.0005 * 110000 - 0.055 == 54.945 (proceeds minus the quote fee)
+    """
+    pf = _spot_portfolio()
+    pf.process_transaction(
+        _txn(TransactionType.BUY, "BTC/USDC", Decimal("100000"), Decimal("0.001")))
+    assert pf.cash == Decimal("149900")
+
+    pf.process_transaction(
+        _txn(TransactionType.SELL, "BTC/USDC", Decimal("110000"), Decimal("0.0005"),
+             commission=Decimal("0.055"), fee_currency="USDC"))
+
+    position = pf.positions["BTC/USDC"]
+    assert position.net_quantity == Decimal("0.0005")
+    assert pf.cash == Decimal("149954.945")
+
+
+def test_none_fee_currency_preserves_oracle_behavior():
+    """fee_currency=None (every backtest/simulated fill) takes the CURRENT path.
+
+    A quote-side commission debits cash AND the position holds the FULL amount — the
+    byte-exact behavior the SMA_MACD oracle regression-locks. BUY 0.001 @ 100000 with a
+    0.1 quote commission and NO fee currency:
+      * position.net_quantity == 0.001 (full amount, no base reduction)
+      * cash == 150000 - (100 + 0.1) == 149899.9
+    """
+    pf = _spot_portfolio()
+    pf.process_transaction(
+        _txn(TransactionType.BUY, "BTC/USDC", Decimal("100000"), Decimal("0.001"),
+             commission=Decimal("0.1"), fee_currency=None))
+
+    position = pf.positions["BTC/USDC"]
+    assert position.net_quantity == Decimal("0.001")
+    assert pf.cash == Decimal("149899.9")
+
+
+def test_base_fee_buy_scale_in_nets_each_leg():
+    """Two base-fee BUYs each net their own fee out of the position (scale-in).
+
+    BUY 0.001 (fee 0.000001 BTC) then BUY 0.002 (fee 0.000002 BTC), both @ 100000:
+      * net_quantity == (0.001 - 0.000001) + (0.002 - 0.000002) == 0.002997
+      * cash == 150000 - (100 + 200) == 149700 (notional only across both legs)
+    """
+    pf = _spot_portfolio()
+    pf.process_transaction(
+        _txn(TransactionType.BUY, "BTC/USDC", Decimal("100000"), Decimal("0.001"),
+             commission=Decimal("0.000001"), fee_currency="BTC"))
+    pf.process_transaction(
+        _txn(TransactionType.BUY, "BTC/USDC", Decimal("100000"), Decimal("0.002"),
+             commission=Decimal("0.000002"), fee_currency="BTC"))
+
+    position = pf.positions["BTC/USDC"]
+    assert position.net_quantity == Decimal("0.002997")
+    assert pf.cash == Decimal("149700")
+
+
+def test_transaction_seam_properties_are_fee_currency_aware():
+    """Direct lock on the Transaction settlement seam (net_cash_delta / position_quantity).
+
+    Base-fee BUY: quote_commission == 0, position_quantity == amount - fee,
+    net_cash_delta == -(price*amount). Quote-fee / None: unchanged (commission in cash,
+    position_quantity == amount)."""
+    base = _txn(TransactionType.BUY, "BTC/USDC", Decimal("100000"), Decimal("0.001"),
+                commission=Decimal("0.000001"), fee_currency="BTC")
+    assert base.is_base_fee is True
+    assert base.quote_commission == Decimal("0")
+    assert base.position_quantity == Decimal("0.000999")
+    assert base.net_cash_delta == Decimal("-100")
+
+    quote = _txn(TransactionType.SELL, "BTC/USDC", Decimal("110000"), Decimal("0.0005"),
+                 commission=Decimal("0.055"), fee_currency="USDC")
+    assert quote.is_base_fee is False
+    assert quote.quote_commission == Decimal("0.055")
+    assert quote.position_quantity == Decimal("0.0005")
+    assert quote.net_cash_delta == Decimal("54.945")
+
+    default = _txn(TransactionType.BUY, "BTC/USDC", Decimal("100000"), Decimal("0.001"),
+                   commission=Decimal("0.1"), fee_currency=None)
+    assert default.is_base_fee is False
+    assert default.quote_commission == Decimal("0.1")
+    assert default.position_quantity == Decimal("0.001")
+    assert default.net_cash_delta == Decimal("-100.1")

--- a/tests/unit/portfolio/test_venue_account_cache.py
+++ b/tests/unit/portfolio/test_venue_account_cache.py
@@ -48,21 +48,32 @@ def test_snapshot_populates_cache_from_rest(
     assert account.positions == {"BTC/USDT": Decimal("0.5")}
 
 
-def test_push_stream_mutates_cache(
+def test_push_stream_mutates_positions_cache(
     fake_venue_connector: FakeLiveConnector,
 ) -> None:
-    """A ``watch_balance`` push writes the cache on the connector loop thread (D-15)."""
+    """A ``watch_positions`` push writes the POSITIONS cache on the connector loop thread (D-15).
+
+    Post ``okx-venue-cash-double-count``: the balance stream no longer overwrites the
+    cash baseline ``_venue_balance`` — that second cash channel double-counted every
+    fill against the local ``_ledger_delta`` (``balance = _venue_balance + _ledger_delta``).
+    Cash is now single-channel: ``snapshot()`` owns the baseline (D-01) and
+    ``apply_fill_cash_flow`` moves the ledger. The push streams keep the POSITIONS cache
+    live for the drift compare, which is what this test now pins. An engine-thread cash
+    read before any ``snapshot()`` therefore still surfaces ``StateError`` (never a silent
+    stream-populated 0).
+    """
     account = VenueAccount(fake_venue_connector)
     account.start_streaming()
 
-    # The canned watch_balance stream yields 100000 -> 91599.916 -> 78999.79 (total USDT);
-    # watch_positions yields long 0.2 -> long 0.5. Drain to the final values.
-    _wait_for(lambda: account._venue_balance == Decimal("78999.79"))
+    # watch_positions yields long 0.2 -> long 0.5. Drain to the final value.
     _wait_for(lambda: account._venue_positions == {"BTC/USDT": Decimal("0.5")})
-
-    assert account.balance == Decimal("78999.79")
-    assert account.available_balance == Decimal("78999.79")
     assert account.positions == {"BTC/USDT": Decimal("0.5")}
+
+    # The balance stream did NOT move the cash baseline — cash stays snapshot-owned, so
+    # an unsnapshotted cash read is still loud (never a silent stream-populated value).
+    assert account._venue_balance is None
+    with pytest.raises(StateError):
+        _ = account.balance
 
 
 def test_read_before_snapshot_raises_state_error(

--- a/tests/unit/portfolio/test_venue_cash_no_double_count.py
+++ b/tests/unit/portfolio/test_venue_cash_no_double_count.py
@@ -1,0 +1,96 @@
+"""Regression: a venue balance push must not double-count a locally-applied fill.
+
+Root cause ``okx-venue-cash-double-count`` (.planning/debug/): the live cash surface
+is ``VenueAccount.balance = _venue_balance + _ledger_delta``. Every fill settles into
+the account via ``apply_fill_cash_flow`` (the shared Account-ABC settlement primitive),
+which moves ``_ledger_delta``. The async balance stream (``_stream_account`` ->
+``_write_balance_stream``) USED TO ALSO refresh ``_venue_balance`` to the venue's
+post-fill ``watch_balance`` push — so the SAME fill was counted twice (once in the
+stream-pushed venue balance, once in the ledger): a 2x cash debit, while the position
+(single-sourced from ``_venue_positions``, no ledger overlay) stayed single-counted.
+
+The exact online symptom (tests/e2e/test_okx_sandbox_recon.py): a single 0.0001 BTC @
+59513 demo BUY (notional 5.9513 USDC) debited cash by 11.9026001 (exactly 2x) instead
+of ~5.9513.
+
+The fix: the balance stream writes POSITIONS only, never the cash baseline. ``snapshot()``
+remains the SOLE cash-reconcile point (D-01) — it re-baselines ``_venue_balance`` AND
+resets ``_ledger_delta`` atomically. This is deterministic and OFFLINE (no network, no
+demo order): it drives the cache-write helper directly. Folder-derived ``unit`` marker.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from itrader.portfolio_handler.account.venue import VenueAccount
+
+
+def _spot_account_snapshotted(pre_fill_quote: str) -> VenueAccount:
+    """A spot BTC/USDC ``VenueAccount`` snapshotted to a pre-fill quote balance.
+
+    Uses a ``MagicMock`` connector whose ``call(...)`` returns the canned REST balance
+    payload ``snapshot()`` reads (``{"total": {"USDC": <pre_fill_quote>}}``). No BTC key
+    yet -> a flat pre-fill holding. After ``snapshot()`` the cache baseline is set and
+    ``_ledger_delta`` is zero.
+    """
+    connector = MagicMock(name="connector")
+    connector.call.return_value = {"total": {"USDC": float(pre_fill_quote)}}
+    account = VenueAccount(
+        connector,
+        quote_currency="USDC",
+        market_type="spot",
+        symbol="BTC/USDC",
+    )
+    account.snapshot()
+    return account
+
+
+def test_balance_push_after_fill_does_not_double_count_cash() -> None:
+    """A post-fill balance push must leave cash single-counted (the online 2x bug)."""
+    account = _spot_account_snapshotted("100.0")
+    assert account.balance == Decimal("100.0")  # baseline, ledger == 0
+
+    # A 0.0001 @ 59513 BUY settles locally exactly as Portfolio.transact_shares does:
+    # one signed net-cash delta of -5.9513 through the ABC settlement primitive.
+    account.apply_fill_cash_flow(
+        amount=Decimal("-5.9513"),
+        fee=Decimal("0"),
+        description="BUY BTC/USDC",
+        reference_id="txn-1",
+        timestamp=datetime(2026, 7, 5),
+    )
+    # Single-counted so far — the ledger holds the one fill.
+    assert account.balance == Decimal("94.0487")
+
+    # The venue balance stream now pushes the POST-fill balance: quote already reflects
+    # the -5.9513 (94.0487) and the base holding is now 0.0001 BTC. Before the fix this
+    # refreshed _venue_balance to 94.0487 while _ledger_delta STILL held -5.9513 ->
+    # balance == 88.0974 (the online 11.9026001 == 2x symptom).
+    post_fill_push = {"total": {"USDC": 94.0487, "BTC": 0.0001}}
+    account._write_balance_stream(post_fill_push)
+
+    # Cash single-counted: the stream did NOT re-debit the fill.
+    assert account.balance == Decimal("94.0487"), (
+        "venue balance stream double-counted the locally-applied fill "
+        f"(got {account.balance}, expected 94.0487) — okx-venue-cash-double-count")
+
+
+def test_balance_push_still_keeps_spot_position_live() -> None:
+    """The stream must still derive spot position liveness from the balance push (D-03)."""
+    account = _spot_account_snapshotted("100.0")
+    assert account.positions == {}  # flat pre-fill
+
+    # A balance push carrying the base key is authoritative — derives the holding.
+    account._write_balance_stream({"total": {"USDC": 94.0487, "BTC": 0.0001}})
+    assert account.positions == {"BTC/USDC": Decimal("0.0001")}
+
+
+def test_balance_push_does_not_touch_cash_baseline() -> None:
+    """The stream leaves the cash baseline (``_venue_balance``) to ``snapshot()`` (D-01)."""
+    account = _spot_account_snapshotted("100.0")
+    baseline = account._venue_balance
+    account._write_balance_stream({"total": {"USDC": 777.0, "BTC": 0.5}})
+    # The stream pushed a wildly different quote total; the cash baseline is UNCHANGED.
+    assert account._venue_balance == baseline
+    assert account.balance == Decimal("100.0")


### PR DESCRIPTION
This pull request documents and resolves a critical bug in the OKX venue-backed cash accounting, where spot BUY fills were debiting portfolio cash twice (double-counting) while positions were correctly single-counted. The changes include a detailed debug session, root cause analysis, and the implemented fix, along with regression tests to prevent recurrence. Additional planning and state tracking entries have been updated to reflect this work.

The most important changes are:

**Bug Resolution and Root Cause Analysis**
* Added a detailed debug session and resolution summary in `okx-venue-cash-double-count.md`, documenting the symptoms, evidence, hypothesis, and fix for the cash double-counting issue in the OKX venue-backed account. The fix ensures cash is now single-channel, with only `snapshot()` updating the cash baseline, and the async balance stream updating positions only.

**Testing and Verification**
* Described the addition of an offline regression test (`test_venue_cash_no_double_count.py`) that deterministically verifies the bug and its fix without requiring network access or live demo orders.
* Updated the positions cache test (`test_venue_account_cache.py`) to match the new contract (stream updates positions only, not cash baseline).

**Planning and State Tracking**
* Updated `.planning/STATE.md` to log completion of the quick task adapting the e2e OKX sandbox recon test for a non-flat demo account, and to record the double-count bug and its fix. [[1]](diffhunk://#diff-10c47d0e33270cc4a979d56198376cf3a9df6cc3a3c397ef7d5131afda869b40L34-R34) [[2]](diffhunk://#diff-10c47d0e33270cc4a979d56198376cf3a9df6cc3a3c397ef7d5131afda869b40R226-R227)
* Added a new debug log for the 2026-07-05 online settlement and ARCH-3 finalization, capturing the successful assertions and payload shapes after the fix.

These changes collectively resolve a critical settlement bug, improve test coverage, and update project planning to reflect the work.