### PR TITLE
V1.8/initialise milestone

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -27,6 +27,60 @@ A single backtest run of `SMA_MACD` on `data/BTCUSD_1d_ohlcv_2018_2026.csv` prod
 **correct, deterministic, cross-validated numbers** — if nothing else works, the backtest path
 must import, run, and yield trustworthy results.
 
+## Current Milestone: v1.8 — Live System Refactor & Live-Readiness Hardening
+
+**Goal:** Decompose the 2,171-line `LiveTradingSystem` God object (~17 concerns) into a thin facade
+(~200 lines) over focused, independently-testable collaborators — venue-parametrized (zero
+`if self.exchange == …`), config-centralized, and FastAPI-ready — **without disturbing the byte-exact
+backtest oracle (`134 / 46189.87730727451`) or the OKX import-inertness gate**
+(`tests/integration/test_okx_inertness.py`). Full scope: the core refactor **plus** the three ★
+feature-adds (LR-03/LR-04). FastAPI itself is out of scope (LR-01) — this milestone makes the engine
+*interfacable*, shipping no ASGI code.
+
+**Target features (13 phases — P1..P13):**
+- **Config centralization (P1)** — `SystemConfig` aggregation (eager/lazy/templates), module-constant
+  migration, dead-config audit, `extra` normalization (concerns 17/21/24; CF-6/CF-8-enum).
+- **Event bus (P2)** — `EventBus` Protocol + `FifoEventBus`/`PriorityEventBus` (two-tier CONTROL >
+  BUSINESS), injected into `compose_engine` (backtest → Fifo, zero oracle risk) (LR-11).
+- **`EngineContext` + storage-in-handler (P3)** — handler-owns storage init (Order/Strategies), new
+  `compose_engine(ctx, spec)` signature (concern 20; LR-13/LR-14).
+- **`SqlEngine` rename + migrations relocation (P4)** — `SqlBackend→SqlEngine`; `migrations/` → project
+  root (LR-18).
+- **New durable stores (P5)** — `SystemStore`, `VenueStore`, `StrategyRegistryStore` (tables +
+  registrars + Alembic chain + rehydrate) (LR-22).
+- **Venue registry + 4-collaborator bundle (P6)** — two registries (`ExecutionVenueRegistry` +
+  `DataProviderRegistry`), `VenuePlugin`/`VenueBundle`, `LiveDataProvider` Protocol, connector
+  memoization by `(venue, account_id)`, precision/validate on the exchange, per-portfolio account
+  factory, shared `StreamSupervisor` — kills every `if exchange==` (concerns 1/6/13/14/15; CF-3/4/9;
+  LR-17).
+- **`LiveRunner` + factory + facade shrink (P7)** — `build_live_system`, `LiveRunner`,
+  `SessionInitializer` + shared `UniverseWiring` *(oracle-sensitive)*, `LiveRouteRegistrar`,
+  `UniverseHandler` proper init, `StrategyWarmupConsumer` rehome, drop legacy
+  `print_status`/`get_statistics`/`__init__` params (concerns 4/5/7/8/10/25/26; CF-10; LR-10/LR-16).
+- **Safety + reconciliation + stream recovery (P8)** — `SafetyController`, `ReconciliationCoordinator`,
+  `StreamRecoveryHandler`, CONTROL routes — flag machinery deleted (concerns 11/12; CF-2/7/8; LR-12).
+- **Error subsystem (P9)** — `ErrorPolicy` injected (no monkeypatch), `ErrorHandler` formalized, two-guard
+  terminal safety, **CF-1 aggregate circuit breaker** (the one HIGH-priority safety add) (concern 19;
+  CF-1/5).
+- **★ Runtime-config platform (P10)** — SystemStore-backed overrides, scoped `ConfigUpdateEvent`,
+  allowlist, restart layering, `RuntimeConfig` overlay, stats snapshot (concerns 22/23; LR-04).
+- **★ Strategies registry (P11)** — durable `StrategyRegistryStore` rehydrate, enable/disable via
+  `STRATEGY_COMMAND`, survives restart (concern 18).
+- **★ Multi-portfolio-live (P12)** — per-`account_id` account factory, drop single-portfolio guard +
+  distinct-`account_id` invariant, per-portfolio reconcile, connector keyed `(venue, account_id)`,
+  `PortfolioSpec.account_id`, `clOrdId→client_order_id` (LR-03/LR-19/LR-20).
+- **Test migration (P13)** — `run_paper_replay`→`ReplayRunner` in `tests/`, `replay` plugin
+  fixture-registered, production replay-free; live-smoke / config-restart / multi-portfolio gates
+  (concern 9).
+
+**Key context:** Backtest byte-exactness (LR-02) is the **blocking gate** for the foundational +
+universe-wiring phases (P1–P4, P7's `UniverseWiring`) — any re-baseline is explicit + cross-validated
+(backtesting.py + backtrader), never silent. The inertness gate must stay green (registering venues
+imports no `ccxt.pro` until built; `SystemConfig` never constructs Postgres `SqlSettings` at import).
+Ten pending `.planning/todos/` items fold in as **CF-1..CF-10** across P1/P6/P7/P8/P9 (all live-only /
+backtest-dark). Trim boundary noted but **not taken**: P10–P12 (★) are in scope this milestone. Design
+source: `docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md` (LR-00..LR-22, CF-1..CF-10).
+
 ## Shipped Milestone: v1.7 — Live Trading Readiness (2026-07-07)
 
 **Delivered:** Deployed and ran the package **live on one crypto venue (OKX), paper-first**, with a real
@@ -726,4 +780,14 @@ the oracle** (drops `ta` on the runtime path); its lock is cross-validation + a 
 v1.0/v1.1/v1.2/v1.3/v1.4 SHIPPED — archived under `milestones/`.*
 
 ---
-*Last updated: 2026-07-07 after v1.7 (Live Trading Readiness) milestone close.*
+*Last updated: 2026-07-09 — **v1.8 — Live System Refactor & Live-Readiness Hardening STARTED.**
+Decomposes the 2,171-line `LiveTradingSystem` God object into a thin facade over focused collaborators
+(factory + shared `compose_engine` + `LiveRunner` + controllers), venue-parametrized and
+config-centralized, FastAPI-ready — without disturbing the byte-exact backtest oracle
+(`134 / 46189.87730727451`) or the OKX inertness gate. Full scope (13 phases, P1–P13, incl. the three ★
+feature-adds LR-03/LR-04). Design source:
+`docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md` (LR-00..LR-22, CF-1..CF-10).
+Defining requirements → roadmap via `/gsd:new-milestone`. v1.0–v1.7 SHIPPED — archived under
+`milestones/`.*
+
+*Earlier: 2026-07-07 after v1.7 (Live Trading Readiness) milestone close.*

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -37,49 +37,54 @@ backtest oracle (`134 / 46189.87730727451`) or the OKX import-inertness gate**
 feature-adds (LR-03/LR-04). FastAPI itself is out of scope (LR-01) — this milestone makes the engine
 *interfacable*, shipping no ASGI code.
 
-**Target features (13 phases — P1..P13):**
+**Target features (12 phases — P1..P12):**
 - **Config centralization (P1)** — `SystemConfig` aggregation (eager/lazy/templates), module-constant
-  migration, dead-config audit, `extra` normalization (concerns 17/21/24; CF-6/CF-8-enum).
+  migration, dead-config audit, `extra` normalization, `HaltReason` enum (concerns 17/21/24; CF-6/CF-8).
 - **Event bus (P2)** — `EventBus` Protocol + `FifoEventBus`/`PriorityEventBus` (two-tier CONTROL >
-  BUSINESS), injected into `compose_engine` (backtest → Fifo, zero oracle risk) (LR-11).
+  BUSINESS), CONTROL EventTypes + minimal `EngineContext` skeleton; injected into `compose_engine`
+  (backtest → Fifo, zero oracle risk) (LR-11).
 - **`EngineContext` + storage-in-handler (P3)** — handler-owns storage init (Order/Strategies), new
-  `compose_engine(ctx, spec)` signature (concern 20; LR-13/LR-14).
-- **`SqlEngine` rename + migrations relocation (P4)** — `SqlBackend→SqlEngine`; `migrations/` → project
-  root (LR-18).
-- **New durable stores (P5)** — `SystemStore`, `VenueStore`, `StrategyRegistryStore` (tables +
-  registrars + Alembic chain + rehydrate) (LR-22).
-- **Venue registry + 4-collaborator bundle (P6)** — two registries (`ExecutionVenueRegistry` +
+  `compose_engine(ctx, spec)` signature, and the `SqlBackend→SqlEngine` rename folded in (concern 20;
+  LR-13/LR-14/LR-18).
+- **Storage schema: migrations relocation + new durable stores (P4)** — `migrations/` → project root;
+  `SystemStore`, `VenueStore`, `StrategyRegistryStore` (registrars + chained Alembic migrations +
+  rehydrate); single-head + parity gate (LR-18/LR-22).
+- **Venue registry + 4-collaborator bundle (P5)** — two registries (`ExecutionVenueRegistry` +
   `DataProviderRegistry`), `VenuePlugin`/`VenueBundle`, `LiveDataProvider` Protocol, connector
   memoization by `(venue, account_id)`, precision/validate on the exchange, per-portfolio account
   factory, shared `StreamSupervisor` — kills every `if exchange==` (concerns 1/6/13/14/15; CF-3/4/9;
   LR-17).
-- **`LiveRunner` + factory + facade shrink (P7)** — `build_live_system`, `LiveRunner`,
+- **`LiveRunner` + factory + facade shrink (P6)** — `build_live_system`, `LiveRunner`,
   `SessionInitializer` + shared `UniverseWiring` *(oracle-sensitive)*, `LiveRouteRegistrar`,
   `UniverseHandler` proper init, `StrategyWarmupConsumer` rehome, drop legacy
   `print_status`/`get_statistics`/`__init__` params (concerns 4/5/7/8/10/25/26; CF-10; LR-10/LR-16).
-- **Safety + reconciliation + stream recovery (P8)** — `SafetyController`, `ReconciliationCoordinator`,
-  `StreamRecoveryHandler`, CONTROL routes — flag machinery deleted (concerns 11/12; CF-2/7/8; LR-12).
-- **Error subsystem (P9)** — `ErrorPolicy` injected (no monkeypatch), `ErrorHandler` formalized, two-guard
+- **Safety + reconciliation + stream recovery (P7)** — `SafetyController`, `ReconciliationCoordinator`,
+  `StreamRecoveryHandler`, CONTROL routes, flag machinery deleted, **pre-trade submit-rate/max-notional
+  throttle** (concerns 11/12; CF-2/7/8; LR-12).
+- **Error subsystem (P8)** — `ErrorPolicy` injected (no monkeypatch), `ErrorHandler` formalized, two-guard
   terminal safety, **CF-1 aggregate circuit breaker** (the one HIGH-priority safety add) (concern 19;
   CF-1/5).
-- **★ Runtime-config platform (P10)** — SystemStore-backed overrides, scoped `ConfigUpdateEvent`,
-  allowlist, restart layering, `RuntimeConfig` overlay, stats snapshot (concerns 22/23; LR-04).
-- **★ Strategies registry (P11)** — durable `StrategyRegistryStore` rehydrate, enable/disable via
-  `STRATEGY_COMMAND`, survives restart (concern 18).
-- **★ Multi-portfolio-live (P12)** — per-`account_id` account factory, drop single-portfolio guard +
+- **★ Runtime-config platform (P9)** — SystemStore-backed overrides, scoped `ConfigUpdateEvent`,
+  allowlist (fee/slippage mutable simulated-venues-only), restart layering, `RuntimeConfig` overlay,
+  stats snapshot (concerns 22/23; LR-04).
+- **★ Strategies registry (P10)** — durable `StrategyRegistryStore` rehydrate, enable/disable via
+  `STRATEGY_COMMAND`, atomic runtime param reconfiguration, survives restart (concern 18).
+- **★ Multi-portfolio-live (P11)** — per-`account_id` account factory, drop single-portfolio guard +
   distinct-`account_id` invariant, per-portfolio reconcile, connector keyed `(venue, account_id)`,
   `PortfolioSpec.account_id`, `clOrdId→client_order_id` (LR-03/LR-19/LR-20).
-- **Test migration (P13)** — `run_paper_replay`→`ReplayRunner` in `tests/`, `replay` plugin
+- **Test migration (P12)** — `run_paper_replay`→`ReplayRunner` in `tests/`, `replay` plugin
   fixture-registered, production replay-free; live-smoke / config-restart / multi-portfolio gates
   (concern 9).
 
 **Key context:** Backtest byte-exactness (LR-02) is the **blocking gate** for the foundational +
-universe-wiring phases (P1–P4, P7's `UniverseWiring`) — any re-baseline is explicit + cross-validated
+universe-wiring phases (P1–P4, P5, P6's `UniverseWiring`) — any re-baseline is explicit + cross-validated
 (backtesting.py + backtrader), never silent. The inertness gate must stay green (registering venues
 imports no `ccxt.pro` until built; `SystemConfig` never constructs Postgres `SqlSettings` at import).
-Ten pending `.planning/todos/` items fold in as **CF-1..CF-10** across P1/P6/P7/P8/P9 (all live-only /
-backtest-dark). Trim boundary noted but **not taken**: P10–P12 (★) are in scope this milestone. Design
-source: `docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md` (LR-00..LR-22, CF-1..CF-10).
+Ten pending `.planning/todos/` items fold in as **CF-1..CF-10** across P1/P5/P6/P7/P8 (all live-only /
+backtest-dark). Trim boundary noted but **not taken**: P9–P11 (★) are in scope this milestone. Research
+added three owner refinements: a pre-trade throttle (P7), venue-kind-gated fee/slippage mutation (P9),
+and atomic strategy-param reconfiguration (P10). Design source:
+`docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md` (LR-00..LR-22, CF-1..CF-10).
 
 ## Shipped Milestone: v1.7 — Live Trading Readiness (2026-07-07)
 

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -15,13 +15,13 @@ pre-trade throttle folded in (SAFE-06); fee/slippage runtime-mutation gated to s
 ## Milestone-wide gates (apply to EVERY phase — not numbered requirements)
 
 1. **Oracle byte-exact** — `SMA_MACD` stays `134 / 46189.87730727451` (`check_exact=True`), determinism
-   double-run identical. **Per-PLAN gate** on the foundational + universe-wiring phases (P1–P4, P6, and
-   P7's `UniverseWiring` extraction — the highest oracle-risk seam). Any re-baseline (LR-02) is explicit
+   double-run identical. **Per-PLAN gate** on the foundational + universe-wiring phases (P1–P4, P5, and
+   P6's `UniverseWiring` extraction — the highest oracle-risk seam). Any re-baseline (LR-02) is explicit
    + externally cross-validated (backtesting.py + backtrader), never silent.
 2. **OKX import-inertness** — `tests/integration/test_okx_inertness.py` stays green; extended to assert
-   register-vs-build on P1/P2/P5/P6. Registering a venue imports no `ccxt.pro` until built; `SystemConfig`
+   register-vs-build on P1/P2/P4/P5. Registering a venue imports no `ccxt.pro` until built; `SystemConfig`
    never constructs Postgres `SqlSettings` at import; `FifoEventBus`/`EngineContext(sql_engine=None)` pull
-   nothing heavy. **Zero new third-party dependency, no poetry change** anywhere in P1–P13 (research STACK).
+   nothing heavy. **Zero new third-party dependency, no poetry change** anywhere in P1–P12 (research STACK).
 3. **Held throughout** — Decimal money end-to-end; single UUIDv7; determinism (business `time`, seeded RNG,
    injected clock); `mypy --strict` clean on new code; `filterwarnings=["error"]` green; tabs/spaces
    indentation matched to the file (never normalized).
@@ -79,9 +79,10 @@ pre-trade throttle folded in (SAFE-06); fee/slippage runtime-mutation gated to s
   `script_location` updated; `env.py` keeps importing the `build_*_table` registrars + `NAMING_CONVENTION`
   from `itrader.storage`; migrations stay out of the shipped wheel (LR-18/§7e).
 - [ ] **SQL-02**: An Alembic gate confirms `alembic upgrade head` on a clean DB, `alembic heads == 1`
-  (single head), and a `create_all`/migration parity test (research PITFALLS).
+  (single head) over the full relocated chain incl. the three new stores, and a `create_all`/migration
+  parity test (research PITFALLS).
 
-### New Durable Stores (P5)
+### New Durable Stores (P4)
 
 - [ ] **STORE-01**: `SystemStore` (cardinality 1, key-value `(key, value_json, updated_at)`, namespaced
   upsert) holds system-wide config overrides + operational state + the latest stats snapshot (LR-22/§6d).
@@ -91,17 +92,17 @@ pre-trade throttle folded in (SAFE-06); fee/slippage runtime-mutation gated to s
   config + subscriptions (LR-22/§7d).
 - [ ] **STORE-04**: Each store follows the `HaltRecordStore` template (composes `sql_engine`, own
   `build_*_table` registrar, chained Alembic migration `d10_halt_records → system_store → venue_config →
-  strategy_registry`) and rehydrates on restart (§7d).
+  strategy_registry` in the relocated `migrations/` tree) and rehydrates on restart (§7d).
 - [ ] **STORE-05**: An in-memory fallback keeps the backtest path untouched — the new stores are live-only
   composition-root infrastructure (§7c).
 
-### Venue Registry + Bundle (P6)
+### Venue Registry + Bundle (P5)
 
 - [ ] **VENUE-01**: Two registries — `ExecutionVenueRegistry` + `DataProviderRegistry` — select execution
   venue + data provider independently via `SystemSpec` (`execution_venue` + `data_provider`) (LR-17/§8a-b).
 - [ ] **VENUE-02**: A `VenuePlugin` Protocol builds a `VenueBundle` (optional connector, exchange,
   mandatory per-portfolio account factory) with concretions lazy-imported inside `build_bundle` —
-  registering `'okx'` pulls no `ccxt.pro` until built; `test_okx_inertness.py` is the P6 acceptance gate
+  registering `'okx'` pulls no `ccxt.pro` until built; `test_okx_inertness.py` is the P5 acceptance gate
   (§8a, concerns 2/3).
 - [ ] **VENUE-03**: Connectors are memoized by `(venue, account_id)` at the composition root; credentials
   are per-`account_id`, env-sourced, never persisted (LR-17/LR-20/§8c).
@@ -119,7 +120,7 @@ pre-trade throttle folded in (SAFE-06); fee/slippage runtime-mutation gated to s
   markets-map freshness closes the fail-open-before-load window via the existing `validate_symbol` →
   removal path (CF-9) (§8f).
 
-### LiveRunner + Factory + Facade Shrink (P7)
+### LiveRunner + Factory + Facade Shrink (P6)
 
 - [ ] **RUN-01**: `build_live_system(spec)` is the live factory / composition root — reads centralized
   config, builds the one `sql_engine`, resolves venue plugin(s), assembles `EngineContext`, calls
@@ -144,7 +145,7 @@ pre-trade throttle folded in (SAFE-06); fee/slippage runtime-mutation gated to s
   reusable `StrategyWarmupConsumer` sized to `max(strategy.warmup)`; the depth-hint seam is shaped for
   CF-10 (the K-computation change itself stays deferred) (concern 26/§13d).
 
-### Safety + Reconciliation + Stream Recovery (P8)
+### Safety + Reconciliation + Stream Recovery (P7)
 
 - [ ] **SAFE-01**: A `SafetyController` (pure state machine, no venue I/O) owns the status latch
   (`VALID_STATUS_TRANSITIONS`, single `update_status` seam, `force=` reserved for `reset_halt`),
@@ -167,10 +168,10 @@ pre-trade throttle folded in (SAFE-06); fee/slippage runtime-mutation gated to s
   `str(matched["id"])` is guarded with a typed fail-loud error (CF-7) (§11d).
 - [ ] **SAFE-06**: A **pre-trade submit-rate + max-notional-per-order throttle** rejects order flow
   exceeding configured velocity/notional caps *before* submission (fires ahead of send; complements CF-1's
-  post-error breaker and the per-order `EnhancedOrderValidator`); caps are runtime-mutable via the P10
+  post-error breaker and the per-order `EnhancedOrderValidator`); caps are runtime-mutable via the P9
   allowlist (research GAP / owner decision 2026-07-09).
 
-### Error Subsystem (P9)
+### Error Subsystem (P8)
 
 - [ ] **ERR-01**: An `ErrorPolicy` is injected into `EventHandler` at construction (removes the
   `_on_handler_error` monkeypatch): backtest/replay → fail-fast (re-raise; the parity gate can't
@@ -188,7 +189,7 @@ pre-trade throttle folded in (SAFE-06); fee/slippage runtime-mutation gated to s
 - [ ] **ERR-04**: One error funnel — handler failures, `halt()` (CRITICAL), `PortfolioErrorEvent`,
   `ConnectorFatalEvent` all route through the ERROR route (§12b).
 
-### ★ Runtime-Config Platform (P10)
+### ★ Runtime-Config Platform (P9)
 
 - [ ] **RTCFG-01**: A `RuntimeConfig` overlay (`defaults ← YAML ← env ← persisted runtime overrides`) is
   built by the live factory and injected as `EngineContext.config` — engine-thread-write, snapshot-read;
@@ -211,7 +212,7 @@ pre-trade throttle folded in (SAFE-06); fee/slippage runtime-mutation gated to s
   last_started_at) double as the UI read-model — readable without touching hot-path locks (concerns 22/23,
   §6d). *(Ships regardless of the mutation-path scope.)*
 
-### ★ Strategies Registry (P11)
+### ★ Strategies Registry (P10)
 
 - [ ] **STRAT-01**: `StrategyRegistryStore` persists which strategies are active + config + subscriptions;
   on restart `build_live_system` rehydrates → re-registers active strategies (survives restart)
@@ -222,7 +223,7 @@ pre-trade throttle folded in (SAFE-06); fee/slippage runtime-mutation gated to s
   (quiesce → apply → re-warmup the affected strategy), persisted to `StrategyRegistryStore` — folds
   `pair-strategy-live-reconfiguration.md` (v1.7 shipped only a refusal guard) (owner decision 2026-07-09).
 
-### ★ Multi-Portfolio-Live (P12)
+### ★ Multi-Portfolio-Live (P11)
 
 - [ ] **MPORT-01**: The venue plugin's `new_account(portfolio_ref, config)` mints a per-portfolio account
   (venue-truth → `VenueAccount` scoped to `portfolio.account_id`; compute → a fresh `SimulatedAccount`);
@@ -241,7 +242,7 @@ pre-trade throttle folded in (SAFE-06); fee/slippage runtime-mutation gated to s
 - [ ] **MPORT-06**: Connectors are keyed `(venue, account_id)` (VENUE-03) so multi-account portfolios share
   or decouple connectors correctly without a combinatorial matrix (LR-20/§8c).
 
-### Test Migration + Gates (P13)
+### Test Migration + Gates (P12)
 
 - [ ] **TEST-01**: `run_paper_replay` → `ReplayRunner` in `tests/`; the `replay` plugin (`SimulatedExchange`
   + `ReplayDataProvider` over the golden CSV) is registered **only** by a test fixture; production is
@@ -285,7 +286,7 @@ Explicitly excluded — documented to prevent scope creep.
 
 ## Traceability
 
-Each requirement maps to exactly one phase.
+Each requirement maps to exactly one phase. As of 2026-07-09 the roadmap is created — the 12 phases are formalized in `.planning/ROADMAP.md` (`### Phase 1` .. `### Phase 12`, goals + success criteria + dependency graph). The old P4 (SqlEngine Migrations Relocation) and P5 (New Durable Stores) were merged into a single storage-schema phase P4 (both live-only, off the oracle hot path). Status `Pending` = mapped + roadmapped, awaiting execution.
 
 | Requirement | Phase | Status |
 |-------------|-------|--------|
@@ -305,54 +306,54 @@ Each requirement maps to exactly one phase.
 | CTX-04 | P3 | Pending |
 | SQL-01 | P4 | Pending |
 | SQL-02 | P4 | Pending |
-| STORE-01 | P5 | Pending |
-| STORE-02 | P5 | Pending |
-| STORE-03 | P5 | Pending |
-| STORE-04 | P5 | Pending |
-| STORE-05 | P5 | Pending |
-| VENUE-01 | P6 | Pending |
-| VENUE-02 | P6 | Pending |
-| VENUE-03 | P6 | Pending |
-| VENUE-04 | P6 | Pending |
-| VENUE-05 | P6 | Pending |
-| VENUE-06 | P6 | Pending |
-| VENUE-07 | P6 | Pending |
-| RUN-01 | P7 | Pending |
-| RUN-02 | P7 | Pending |
-| RUN-03 | P7 | Pending |
-| RUN-04 | P7 | Pending |
-| RUN-05 | P7 | Pending |
-| RUN-06 | P7 | Pending |
-| RUN-07 | P7 | Pending |
-| SAFE-01 | P8 | Pending |
-| SAFE-02 | P8 | Pending |
-| SAFE-03 | P8 | Pending |
-| SAFE-04 | P8 | Pending |
-| SAFE-05 | P8 | Pending |
-| SAFE-06 | P8 | Pending |
-| ERR-01 | P9 | Pending |
-| ERR-02 | P9 | Pending |
-| ERR-03 | P9 | Pending |
-| ERR-04 | P9 | Pending |
-| RTCFG-01 | P10 | Pending |
-| RTCFG-02 | P10 | Pending |
-| RTCFG-03 | P10 | Pending |
-| RTCFG-04 | P10 | Pending |
-| RTCFG-05 | P10 | Pending |
-| RTCFG-06 | P10 | Pending |
-| STRAT-01 | P11 | Pending |
-| STRAT-02 | P11 | Pending |
-| STRAT-03 | P11 | Pending |
-| MPORT-01 | P12 | Pending |
-| MPORT-02 | P12 | Pending |
-| MPORT-03 | P12 | Pending |
-| MPORT-04 | P12 | Pending |
-| MPORT-05 | P12 | Pending |
-| MPORT-06 | P12 | Pending |
-| TEST-01 | P13 | Pending |
-| TEST-02 | P13 | Pending |
-| TEST-03 | P13 | Pending |
-| TEST-04 | P13 | Pending |
+| STORE-01 | P4 | Pending |
+| STORE-02 | P4 | Pending |
+| STORE-03 | P4 | Pending |
+| STORE-04 | P4 | Pending |
+| STORE-05 | P4 | Pending |
+| VENUE-01 | P5 | Pending |
+| VENUE-02 | P5 | Pending |
+| VENUE-03 | P5 | Pending |
+| VENUE-04 | P5 | Pending |
+| VENUE-05 | P5 | Pending |
+| VENUE-06 | P5 | Pending |
+| VENUE-07 | P5 | Pending |
+| RUN-01 | P6 | Pending |
+| RUN-02 | P6 | Pending |
+| RUN-03 | P6 | Pending |
+| RUN-04 | P6 | Pending |
+| RUN-05 | P6 | Pending |
+| RUN-06 | P6 | Pending |
+| RUN-07 | P6 | Pending |
+| SAFE-01 | P7 | Pending |
+| SAFE-02 | P7 | Pending |
+| SAFE-03 | P7 | Pending |
+| SAFE-04 | P7 | Pending |
+| SAFE-05 | P7 | Pending |
+| SAFE-06 | P7 | Pending |
+| ERR-01 | P8 | Pending |
+| ERR-02 | P8 | Pending |
+| ERR-03 | P8 | Pending |
+| ERR-04 | P8 | Pending |
+| RTCFG-01 | P9 | Pending |
+| RTCFG-02 | P9 | Pending |
+| RTCFG-03 | P9 | Pending |
+| RTCFG-04 | P9 | Pending |
+| RTCFG-05 | P9 | Pending |
+| RTCFG-06 | P9 | Pending |
+| STRAT-01 | P10 | Pending |
+| STRAT-02 | P10 | Pending |
+| STRAT-03 | P10 | Pending |
+| MPORT-01 | P11 | Pending |
+| MPORT-02 | P11 | Pending |
+| MPORT-03 | P11 | Pending |
+| MPORT-04 | P11 | Pending |
+| MPORT-05 | P11 | Pending |
+| MPORT-06 | P11 | Pending |
+| TEST-01 | P12 | Pending |
+| TEST-02 | P12 | Pending |
+| TEST-03 | P12 | Pending |
+| TEST-04 | P12 | Pending |
 
 **Coverage:**
 - v1 requirements: 64 total
@@ -361,4 +362,4 @@ Each requirement maps to exactly one phase.
 
 ---
 *Requirements defined: 2026-07-09*
-*Last updated: 2026-07-09 after initial definition (full scope P1–P13 + 3 owner refinements)*
+*Last updated: 2026-07-09 — roadmap revised to 12 phases (old P4 SqlEngine Migrations Relocation folded into old P5 New Durable Stores → merged storage-schema phase P4; all downstream phases renumbered −1); 64/64 requirements mapped, 0 orphans; full scope P1–P12 + 3 owner refinements*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,364 @@
+# Requirements: iTrader v1.8 — Live System Refactor & Live-Readiness Hardening
+
+**Defined:** 2026-07-09
+**Core Value:** A single backtest run of `SMA_MACD` on `data/BTCUSD_1d_ohlcv_2018_2026.csv` produces
+correct, deterministic, cross-validated numbers (`134 / 46189.87730727451`). v1.8 decomposes the
+2,171-line `LiveTradingSystem` God object into a clean, venue-parametrized, FastAPI-ready live engine
+**without disturbing that oracle or the OKX import-inertness gate.**
+
+**Design source:** `docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md`
+(LR-00..LR-22, CF-1..CF-10). **Research:** `.planning/research/` (SUMMARY validates the design vs
+Nautilus/LEAN; zero new dependencies; 4 build-order refinements). **Owner refinements (2026-07-09):**
+pre-trade throttle folded in (SAFE-06); fee/slippage runtime-mutation gated to simulated venues
+(RTCFG-05); strategy-parameter atomic runtime reconfiguration in scope (STRAT-03).
+
+## Milestone-wide gates (apply to EVERY phase — not numbered requirements)
+
+1. **Oracle byte-exact** — `SMA_MACD` stays `134 / 46189.87730727451` (`check_exact=True`), determinism
+   double-run identical. **Per-PLAN gate** on the foundational + universe-wiring phases (P1–P4, P6, and
+   P7's `UniverseWiring` extraction — the highest oracle-risk seam). Any re-baseline (LR-02) is explicit
+   + externally cross-validated (backtesting.py + backtrader), never silent.
+2. **OKX import-inertness** — `tests/integration/test_okx_inertness.py` stays green; extended to assert
+   register-vs-build on P1/P2/P5/P6. Registering a venue imports no `ccxt.pro` until built; `SystemConfig`
+   never constructs Postgres `SqlSettings` at import; `FifoEventBus`/`EngineContext(sql_engine=None)` pull
+   nothing heavy. **Zero new third-party dependency, no poetry change** anywhere in P1–P13 (research STACK).
+3. **Held throughout** — Decimal money end-to-end; single UUIDv7; determinism (business `time`, seeded RNG,
+   injected clock); `mypy --strict` clean on new code; `filterwarnings=["error"]` green; tabs/spaces
+   indentation matched to the file (never normalized).
+
+## v1 Requirements
+
+### Config Centralization (P1)
+
+- [ ] **CFG-01**: `SystemConfig` aggregates all system-wide config (`performance`, `monitoring`,
+  `runtime`, `sql`, `order`) with an import-safety split — eager fields (plain `BaseModel`, safe defaults)
+  vs a lazy `sql` accessor that resolves Postgres `SqlSettings` only on first access, never at import
+  (LR-04/§6a).
+- [ ] **CFG-02**: `itrader.config` (root) exposes immutable base defaults importable via
+  `from itrader import config`; the backtest path reads these unchanged (concern 24/§6c).
+- [ ] **CFG-03**: Scattered module constants fold into domain config — `_STREAM_RECONNECT_*` →
+  `StreamSettings`/`ConnectionSettings`, `_WARMUP_MARGIN`/`_BACKFILL_PAGE` → feed/provider config;
+  `_OKX_*`/`_PAPER_*` deleted (concern 17/§6f).
+- [ ] **CFG-04**: Dead-config audit removes unused settings + stale `__pycache__`; `extra` policy
+  normalized across config models (concern 21/§6f).
+- [ ] **CFG-05**: A typed `HaltReason` enum in `core/enums/system.py` replaces free-string halt reasons;
+  the `'baseline-residual'` off-vocabulary string is retired (CF-8).
+- [ ] **CFG-06**: The D-03a dual-validator paragraph is applied to `.planning/codebase/CONVENTIONS.md`
+  during the P1 cleanup pass (CF-6, doc).
+
+### Event Bus (P2)
+
+- [ ] **BUS-01**: An `EventBus` Protocol (`put`/`get`/`get_nowait`/`qsize`/`empty`/`depth_by_tier`) with
+  two implementations — `FifoEventBus` (backtest) + `PriorityEventBus` (live) — shares one `.put(event)`
+  surface; no handler `.put` call-site changes (LR-11/§4a).
+- [ ] **BUS-02**: `PriorityEventBus` orders `(tier, seq, event)` with `tier ∈ {CONTROL=0, BUSINESS=1}`
+  assigned from a declarative `_CONTROL_EVENT_TYPES` frozenset and a globally-unique monotonic `seq`; a
+  test asserts the tuple comparison never dereferences the (non-orderable) frozen event and preserves
+  strict within-tier FIFO (§4a).
+- [ ] **BUS-03**: New CONTROL `EventType` members (`STREAM_STATE`, `CONNECTOR_FATAL`, `CONFIG_UPDATE`) are
+  added; backtest uses `FifoEventBus` so the oracle stays byte-exact (zero priority-bus on the backtest
+  path) (arch refinement 3).
+- [ ] **BUS-04**: A minimal `EngineContext` skeleton is introduced in P2 so `compose_engine`'s signature
+  settles once rather than being double-edited across P2/P3 (arch refinement 2).
+
+### EngineContext + Storage-in-Handler (P3)
+
+- [ ] **CTX-01**: `EngineContext` (frozen: `bus`, `config`, `environment`, `sql_engine`) is threaded once
+  into `compose_engine(ctx, spec)`; infra-only, never a god-parameter (LR-14/§7a).
+- [ ] **CTX-02**: Order + Strategies handlers own their storage init from `(environment, sql_engine)` with
+  an optional `storage=` override (following `PortfolioHandler`'s shape); `compose_engine` reads the
+  concrete instance back off `.storage` for wiring (LR-13/§7b, concern 20).
+- [ ] **CTX-03**: Backtest (`environment='backtest', sql_engine=None`) yields the same in-memory storage
+  instances → oracle byte-exact; factory SQL imports stay lazy → inertness green (§7b).
+- [ ] **CTX-04**: `SqlBackend` is renamed to `SqlEngine` (`storage/backend.py` → `storage/engine.py`;
+  field/param `sql_engine`); all importers updated (LR-18, rename folded into P3 per arch refinement 4).
+
+### SqlEngine Migrations Relocation (P4)
+
+- [ ] **SQL-01**: `itrader/storage/migrations/` relocates to project-root `migrations/`; `alembic.ini`
+  `script_location` updated; `env.py` keeps importing the `build_*_table` registrars + `NAMING_CONVENTION`
+  from `itrader.storage`; migrations stay out of the shipped wheel (LR-18/§7e).
+- [ ] **SQL-02**: An Alembic gate confirms `alembic upgrade head` on a clean DB, `alembic heads == 1`
+  (single head), and a `create_all`/migration parity test (research PITFALLS).
+
+### New Durable Stores (P5)
+
+- [ ] **STORE-01**: `SystemStore` (cardinality 1, key-value `(key, value_json, updated_at)`, namespaced
+  upsert) holds system-wide config overrides + operational state + the latest stats snapshot (LR-22/§6d).
+- [ ] **STORE-02**: `VenueStore` (cardinality N) holds per-venue config + which venues are enabled; never
+  stores secrets (LR-22/§7d).
+- [ ] **STORE-03**: `StrategyRegistryStore` (cardinality N) holds which strategies trade + per-strategy
+  config + subscriptions (LR-22/§7d).
+- [ ] **STORE-04**: Each store follows the `HaltRecordStore` template (composes `sql_engine`, own
+  `build_*_table` registrar, chained Alembic migration `d10_halt_records → system_store → venue_config →
+  strategy_registry`) and rehydrates on restart (§7d).
+- [ ] **STORE-05**: An in-memory fallback keeps the backtest path untouched — the new stores are live-only
+  composition-root infrastructure (§7c).
+
+### Venue Registry + Bundle (P6)
+
+- [ ] **VENUE-01**: Two registries — `ExecutionVenueRegistry` + `DataProviderRegistry` — select execution
+  venue + data provider independently via `SystemSpec` (`execution_venue` + `data_provider`) (LR-17/§8a-b).
+- [ ] **VENUE-02**: A `VenuePlugin` Protocol builds a `VenueBundle` (optional connector, exchange,
+  mandatory per-portfolio account factory) with concretions lazy-imported inside `build_bundle` —
+  registering `'okx'` pulls no `ccxt.pro` until built; `test_okx_inertness.py` is the P6 acceptance gate
+  (§8a, concerns 2/3).
+- [ ] **VENUE-03**: Connectors are memoized by `(venue, account_id)` at the composition root; credentials
+  are per-`account_id`, env-sourced, never persisted (LR-17/LR-20/§8c).
+- [ ] **VENUE-04**: Precision + validation become exchange capabilities (`resolve_precision(symbol)`,
+  `validate_symbol(symbol)` on `AbstractExchange`); `_OkxPrecisionResolver`/`_PrecisionResolver` deleted;
+  `_precision_to_scale` → a shared money util (concern 15/§8a).
+- [ ] **VENUE-05**: A `LiveDataProvider` Protocol (required core + optional streaming seams via a
+  `BaseLiveDataProvider` giving no-op defaults) wires every provider uniformly — no `hasattr` sprinkling
+  (concern 14/§8b).
+- [ ] **VENUE-06**: A `VenueLifecycle` orchestrator encodes the fixed start/stop order and None-guards
+  absent members (paper/replay skip connector/account steps) — every `if exchange=='okx'` /
+  `elif exchange=='paper'` removed (concerns 6/13/§8d).
+- [ ] **VENUE-07**: A shared `StreamSupervisor` replaces the triplicated `_run_stream_supervisor` +
+  `_STREAM_RECONNECT_*` (CF-4); connector-contract docstrings added to `connectors/base.py` (CF-3); OKX
+  markets-map freshness closes the fail-open-before-load window via the existing `validate_symbol` →
+  removal path (CF-9) (§8f).
+
+### LiveRunner + Factory + Facade Shrink (P7)
+
+- [ ] **RUN-01**: `build_live_system(spec)` is the live factory / composition root — reads centralized
+  config, builds the one `sql_engine`, resolves venue plugin(s), assembles `EngineContext`, calls
+  `compose_engine`, builds bundle(s) + `LiveRunner` + controllers (LR-10/§5).
+- [ ] **RUN-02**: `LiveRunner` owns the drain loop + injected `ErrorPolicy` + worker supervision,
+  replacing `_event_processing_loop` (§5).
+- [ ] **RUN-03**: `LiveTradingSystem` shrinks to a ~200-line facade (lifecycle, status/read-model,
+  `add_event`; delegates everything else); legacy `print_status`/`get_statistics` dropped;
+  `__init__` sheds `exchange`/`to_sql`/`queue_timeout`/`max_idle_time` (from config/spec) (concerns 8/25,
+  §11e).
+- [ ] **RUN-04**: A shared `UniverseWiring` helper (`derive_membership → build Universe → inject
+  exchange/order/portfolio/strategies → feed.bind`) is extracted and reused by both `BacktestRunner` and
+  the live `SessionInitializer`, moved as one intact unit incl. the WR-03 desync assert — **oracle
+  byte-exact** (§13a, oracle-sensitive).
+- [ ] **RUN-05**: `LiveRouteRegistrar` composes live routes (incl. CONTROL routes) into the single
+  `EventHandler` declaratively (list order = execution order); no subclass, no runtime mutation; backtest
+  gets base routes only (LR-16/§13c).
+- [ ] **RUN-06**: `UniverseHandler` is constructed at the live composition root as a first-class handler
+  with explicit deps (`bus`, `universe`, `feed`, `config`) — zero OKX coupling (symbol validation/precision
+  via `set_venue_metadata(exchange)`) (concern 10/§13b).
+- [ ] **RUN-07**: `_LiveWarmupConsumer` is rehomed to `price_handler/feed/cache_registration.py` as a
+  reusable `StrategyWarmupConsumer` sized to `max(strategy.warmup)`; the depth-hint seam is shaped for
+  CF-10 (the K-computation change itself stays deferred) (concern 26/§13d).
+
+### Safety + Reconciliation + Stream Recovery (P8)
+
+- [ ] **SAFE-01**: A `SafetyController` (pure state machine, no venue I/O) owns the status latch
+  (`VALID_STATUS_TRANSITIONS`, single `update_status` seam, `force=` reserved for `reset_halt`),
+  `halt(reason)` (winner-only → CRITICAL `ErrorEvent` → durable `HaltRecordStore.record_halt`),
+  `is_halted`/`reset_halt`, `pause_submission`/`resume_submission` + bounded deferred-protective queue,
+  and the dispatch gate (concern 12/§11a).
+- [ ] **SAFE-02**: `safety.check_durable_halt_on_start()` runs first (before any venue I/O), refuses
+  RUNNING on an unresolved durable halt, and re-latches from the persisted reason via `update_status`
+  (no second durable write) (§11b).
+- [ ] **SAFE-03**: Connector stream up/down + fatal arrive as CONTROL events (`StreamStateEvent` →
+  pause / `StreamRecoveryHandler.on_reconnect`; `ConnectorFatalEvent` → `halt`) running on the engine
+  thread — the flag side-channel (`_pending_stream_resume`/`_pending_connector_halt`/etc.) is deleted
+  (concern 11/§11c).
+- [ ] **SAFE-04**: `StreamRecoveryHandler` owns reconnect resume I/O (catch-up missed fills + account
+  snapshot on the engine thread + all-streams-healthy gate → `resume_submission`); CF-2
+  `backfill_on_resume` lands **loop-native** (connector loop via the reconnect callback), never a second
+  concurrent engine-thread ring writer (§11c, CF-2).
+- [ ] **SAFE-05**: A `ReconciliationCoordinator` owns the startup sequence (rehydrate → venue reconcile
+  for venue-truth accounts → baseline guard), keyed on account *kind* not `exchange=='okx'`; the bare
+  `str(matched["id"])` is guarded with a typed fail-loud error (CF-7) (§11d).
+- [ ] **SAFE-06**: A **pre-trade submit-rate + max-notional-per-order throttle** rejects order flow
+  exceeding configured velocity/notional caps *before* submission (fires ahead of send; complements CF-1's
+  post-error breaker and the per-order `EnhancedOrderValidator`); caps are runtime-mutable via the P10
+  allowlist (research GAP / owner decision 2026-07-09).
+
+### Error Subsystem (P9)
+
+- [ ] **ERR-01**: An `ErrorPolicy` is injected into `EventHandler` at construction (removes the
+  `_on_handler_error` monkeypatch): backtest/replay → fail-fast (re-raise; the parity gate can't
+  false-green), live → publish-and-continue; per-handler granularity preserved; carries the WR-06 source
+  guard (concern 19/§12a).
+- [ ] **ERR-02**: An `ErrorHandler` formalizes the ERROR-route consumer (severity-mapped structured
+  logging, CRITICAL → the pluggable alert sink, persist latest error → `SystemStore state.last_error`,
+  WR-06 consumer guard); two-guard terminal safety (source + consumer). The alert-sink seam is threaded so
+  a CRITICAL halt *can* reach a real sink (CF-5; substantive egress stays the FastAPI milestone) (§12b).
+- [ ] **ERR-03**: A **CF-1 aggregate circuit breaker** on the publish-and-continue seam — a
+  route-classified ring (SETTLEMENT halt-on-first, ORDER-IO N=3/60s, ADMISSION N=3/300s, LOOP-BACKSTOP
+  N=5/60s) that **actually trips** (verified by a "money route failing every event" test), preserves the
+  WR-06 terminal swallow, and leaves backtest fail-fast byte-for-byte unchanged (CF-1, hard acceptance
+  criterion).
+- [ ] **ERR-04**: One error funnel — handler failures, `halt()` (CRITICAL), `PortfolioErrorEvent`,
+  `ConnectorFatalEvent` all route through the ERROR route (§12b).
+
+### ★ Runtime-Config Platform (P10)
+
+- [ ] **RTCFG-01**: A `RuntimeConfig` overlay (`defaults ← YAML ← env ← persisted runtime overrides`) is
+  built by the live factory and injected as `EngineContext.config` — engine-thread-write, snapshot-read;
+  handlers read it so they see runtime changes (LR-04/§6c).
+- [ ] **RTCFG-02**: A scoped `ConfigUpdateEvent(scope, key, value)` (CONTROL plane) is validated against an
+  **allowlist** of runtime-mutable keys + type/range check, routed on the engine thread to the owning store
+  (`system`→SystemStore, `portfolio:{id}`→Portfolio+portfolio store, `venue:{name}`→VenueStore,
+  `order`→SystemStore), applied to the overlay + relevant `handler.update_config(...)`, and persisted
+  (§6e). Allowlist (v1.8): venue fee/slippage (see RTCFG-05) + enabled; order trail/TIF defaults; portfolio
+  risk limits + sizing defaults; system poll_cadence + universe_remove_policy + idle/timeout knobs; strategy
+  enable/disable + params (STRAT-03).
+- [ ] **RTCFG-03**: Persisted overrides survive restart — `build_live_system` layers them over defaults
+  on boot (§6e).
+- [ ] **RTCFG-04**: Immutable-at-runtime keys (`rng_seed`, money precision, SQL credentials, venue API
+  credentials, `environment`, IDs) are rejected by the allowlist (§6e / owner decision).
+- [ ] **RTCFG-05**: Fee/slippage config keys are runtime-mutable **only for simulated venues**; a
+  `ConfigUpdateEvent` targeting a *live* venue's fee/slippage is rejected (venue-kind-aware validation —
+  real-venue fees/slippage come from actual venue fills, not engine config) (owner decision 2026-07-09).
+- [ ] **RTCFG-06**: The `system_store` `stats.snapshot` + `state.*` (status / halt_reason / last_error /
+  last_started_at) double as the UI read-model — readable without touching hot-path locks (concerns 22/23,
+  §6d). *(Ships regardless of the mutation-path scope.)*
+
+### ★ Strategies Registry (P11)
+
+- [ ] **STRAT-01**: `StrategyRegistryStore` persists which strategies are active + config + subscriptions;
+  on restart `build_live_system` rehydrates → re-registers active strategies (survives restart)
+  (concern 18/§9).
+- [ ] **STRAT-02**: Runtime add / remove / enable / disable via `STRATEGY_COMMAND` (CONTROL) →
+  `StrategiesHandler` applies + persists (§9).
+- [ ] **STRAT-03**: A strategy's config parameters are mutable at runtime via **atomic reconfiguration**
+  (quiesce → apply → re-warmup the affected strategy), persisted to `StrategyRegistryStore` — folds
+  `pair-strategy-live-reconfiguration.md` (v1.7 shipped only a refusal guard) (owner decision 2026-07-09).
+
+### ★ Multi-Portfolio-Live (P12)
+
+- [ ] **MPORT-01**: The venue plugin's `new_account(portfolio_ref, config)` mints a per-portfolio account
+  (venue-truth → `VenueAccount` scoped to `portfolio.account_id`; compute → a fresh `SimulatedAccount`);
+  `_link_venue_account_to_portfolios` + its `RuntimeError(>1)` guard are deleted (LR-03/§10b).
+- [ ] **MPORT-02**: A distinct-`account_id` invariant fails **loud** at composition time — multiple
+  portfolios sharing one venue `account_id` is rejected (pooled buying power the venue can't split back
+  out is deferred) (§10a).
+- [ ] **MPORT-03**: A signal fans out to each subscribed portfolio; each sizes/orders independently against
+  its own account; the venue partitions balance/positions/fills by `account_id` (§10a).
+- [ ] **MPORT-04**: `clOrdId` is renamed `client_order_id` (venue↔engine correlation), distinct from
+  `portfolio_id` (attribution); every submitted order is tagged with its portfolio; fills route via
+  `client_order_id`/`venue_order_id` → engine order → `FillEvent(portfolio_id)` → the right
+  `Portfolio.on_fill` (LR-19/§10c).
+- [ ] **MPORT-05**: `PortfolioSpec` gains `account_id`; the `ReconciliationCoordinator` iterates active
+  portfolios, reconciling each against its own `VenueAccount`/`account_id` (§10b-c).
+- [ ] **MPORT-06**: Connectors are keyed `(venue, account_id)` (VENUE-03) so multi-account portfolios share
+  or decouple connectors correctly without a combinatorial matrix (LR-20/§8c).
+
+### Test Migration + Gates (P13)
+
+- [ ] **TEST-01**: `run_paper_replay` → `ReplayRunner` in `tests/`; the `replay` plugin (`SimulatedExchange`
+  + `ReplayDataProvider` over the golden CSV) is registered **only** by a test fixture; production is
+  replay-free (`run_paper_replay` + `PAPER_PARITY_*`/`_PAPER_*` leave production) (concern 9/§13/§8e).
+- [ ] **TEST-02**: A live-smoke gate exercises the decomposed live surface end-to-end (facade → factory →
+  `LiveRunner` → controllers) on the replay fixture.
+- [ ] **TEST-03**: A config-restart gate proves persisted runtime overrides survive a restart (RTCFG-03).
+- [ ] **TEST-04**: A multi-portfolio attribution gate proves fills route to the correct portfolio and the
+  distinct-`account_id` invariant fails loud (MPORT-02/MPORT-04).
+
+## v2 / Future Requirements
+
+Deferred seams — carried and marked, not built this milestone (spec §14).
+
+### Deferred Platform Seams
+
+- **FEED-ROUTER-01**: Multi-provider feed-router (`set_provider` → provider-router keyed by
+  symbol/asset-class) for concurrent providers (crypto aggregator + forex). The two-registry decoupling
+  *enables* it.
+- **CONN-OPT-01**: Single-connector-multi-`account_id` optimization (OKX master key + per-account routing on
+  one session) vs one connector per `account_id`.
+- **RISK-ALLOC-01**: Shared-`account_id` risk allocator (multiple portfolios pooling one venue account).
+- **AUDIT-01**: Config audit-trail table (`system_config_audit`).
+- **ERRHIST-01**: Errors-history table.
+- **STATSHIST-01**: Stats-history table split (if periodic `stats.snapshot` upserts contend with config
+  writes).
+
+## Out of Scope
+
+Explicitly excluded — documented to prevent scope creep.
+
+| Feature | Reason |
+|---------|--------|
+| FastAPI app / routes / ASGI code (LR-01) | This milestone makes the engine *interfacable* (clean control/query seams, event ingress, centralized config); the web layer is a downstream consumer milestone. |
+| `livebarfeed-depandas-time-model-datetime` refactor | Large look-ahead-safety-critical own-refactor of the same file — flagged as a co-located follow-on, not folded (spec §18). |
+| `mutable-instrument-refactor` | Margin/carry-model concern, orthogonal to the God-object teardown. |
+| `margin-equity-double-counts-notional-wr01` fix | Gated on re-freezing 6 owner-frozen goldens + external cross-validation; adjudicate before any live margin consumer (not this milestone). |
+| `unify-backtest-direct-bar-generation` | Oracle-risky backtest-loop rewrite — conflicts with the LR-02 byte-exact gate. |
+| Perp realism Phase B (FUND-01..04), production screener, multi-asset (forex/equities) | Out of the crypto-first live-refactor scope; backlog. |
+| New third-party dependency / poetry change | Research STACK: every mechanic is stdlib or already-pinned; adding a dep regresses inertness. |
+
+## Traceability
+
+Each requirement maps to exactly one phase.
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| CFG-01 | P1 | Pending |
+| CFG-02 | P1 | Pending |
+| CFG-03 | P1 | Pending |
+| CFG-04 | P1 | Pending |
+| CFG-05 | P1 | Pending |
+| CFG-06 | P1 | Pending |
+| BUS-01 | P2 | Pending |
+| BUS-02 | P2 | Pending |
+| BUS-03 | P2 | Pending |
+| BUS-04 | P2 | Pending |
+| CTX-01 | P3 | Pending |
+| CTX-02 | P3 | Pending |
+| CTX-03 | P3 | Pending |
+| CTX-04 | P3 | Pending |
+| SQL-01 | P4 | Pending |
+| SQL-02 | P4 | Pending |
+| STORE-01 | P5 | Pending |
+| STORE-02 | P5 | Pending |
+| STORE-03 | P5 | Pending |
+| STORE-04 | P5 | Pending |
+| STORE-05 | P5 | Pending |
+| VENUE-01 | P6 | Pending |
+| VENUE-02 | P6 | Pending |
+| VENUE-03 | P6 | Pending |
+| VENUE-04 | P6 | Pending |
+| VENUE-05 | P6 | Pending |
+| VENUE-06 | P6 | Pending |
+| VENUE-07 | P6 | Pending |
+| RUN-01 | P7 | Pending |
+| RUN-02 | P7 | Pending |
+| RUN-03 | P7 | Pending |
+| RUN-04 | P7 | Pending |
+| RUN-05 | P7 | Pending |
+| RUN-06 | P7 | Pending |
+| RUN-07 | P7 | Pending |
+| SAFE-01 | P8 | Pending |
+| SAFE-02 | P8 | Pending |
+| SAFE-03 | P8 | Pending |
+| SAFE-04 | P8 | Pending |
+| SAFE-05 | P8 | Pending |
+| SAFE-06 | P8 | Pending |
+| ERR-01 | P9 | Pending |
+| ERR-02 | P9 | Pending |
+| ERR-03 | P9 | Pending |
+| ERR-04 | P9 | Pending |
+| RTCFG-01 | P10 | Pending |
+| RTCFG-02 | P10 | Pending |
+| RTCFG-03 | P10 | Pending |
+| RTCFG-04 | P10 | Pending |
+| RTCFG-05 | P10 | Pending |
+| RTCFG-06 | P10 | Pending |
+| STRAT-01 | P11 | Pending |
+| STRAT-02 | P11 | Pending |
+| STRAT-03 | P11 | Pending |
+| MPORT-01 | P12 | Pending |
+| MPORT-02 | P12 | Pending |
+| MPORT-03 | P12 | Pending |
+| MPORT-04 | P12 | Pending |
+| MPORT-05 | P12 | Pending |
+| MPORT-06 | P12 | Pending |
+| TEST-01 | P13 | Pending |
+| TEST-02 | P13 | Pending |
+| TEST-03 | P13 | Pending |
+| TEST-04 | P13 | Pending |
+
+**Coverage:**
+- v1 requirements: 64 total
+- Mapped to phases: 64
+- Unmapped: 0 ✓
+
+---
+*Requirements defined: 2026-07-09*
+*Last updated: 2026-07-09 after initial definition (full scope P1–P13 + 3 owner refinements)*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -10,6 +10,7 @@
 - ✅ **v1.5 — Backtest Performance Optimization** — Phases 1-8 (shipped 2026-06-26; numbering reset; performance half of Backlog 999.2, split out from Persistence; Phases 7-8 added 2026-06-25 from post-phase re-profiles)
 - ✅ **v1.6 — N+3b Persistence Foundation** — Phases 1-5 (shipped 2026-06-30; numbering reset; promoted the **persistence half** of Backlog 999.2)
 - ✅ **v1.7 — Live Trading Readiness (trimmed N+4 / Backlog 999.3)** — Phases 1-7 + 05.1/05.2/05.3 (shipped 2026-07-07; numbering reset; promoted Backlog 999.3; three remediation waves inserted after Phase 5; Phase 7 added 2026-07-06 from the Phase 6 code review)
+- 🚧 **v1.8 — Live System Refactor & Live-Readiness Hardening** — Phases 1-12 (in progress; numbering reset; decomposes the 2,171-line `LiveTradingSystem` God object into a thin facade over focused collaborators — full scope incl. the three ★ feature-adds)
 
 Full milestone detail (phase goals, success criteria, per-plan breakdown) is archived per milestone:
 v1.0 — [`milestones/v1.0-ROADMAP.md`](./milestones/v1.0-ROADMAP.md) ·
@@ -47,7 +48,229 @@ v1.0 phase working dirs are archived under `milestones/v1.0-phases/`; v1.1 under
 > (2026-06-26); its **persistence half** shipped as **v1.6 — N+3b Persistence Foundation**
 > (2026-06-30). **Backlog 999.3 (N+4 — Live) shipped as v1.7 — Live Trading Readiness**
 > (2026-07-07; trimmed N+4 = the minimum surface to deploy live, paper-first). The whole 999.x backlog
-> through N+4 is now consumed; the next milestone is not yet defined (`/gsd:new-milestone`).
+> through N+4 is now consumed; **v1.8 — Live System Refactor & Live-Readiness Hardening** is the active
+> milestone (owner's stated direction: `live_trading_system.py` God-object refactor + halt-vocabulary
+> review, making the engine FastAPI-ready without building FastAPI itself).
+
+## Active Milestone: v1.8 — Live System Refactor & Live-Readiness Hardening
+
+**Milestone Goal:** Decompose the 2,171-line `LiveTradingSystem` God object (~17 concerns) into a thin
+facade (~200 lines) over focused, independently-testable collaborators — venue-parametrized (zero
+`if self.exchange == …`), config-centralized, and FastAPI-ready — **without disturbing the byte-exact
+backtest oracle (`134 / 46189.87730727451`) or the OKX import-inertness gate**
+(`tests/integration/test_okx_inertness.py`). Full scope: the core refactor (P1–P8 + P12) **plus** the
+three ★ feature-adds (P9–P11; LR-03/LR-04). FastAPI itself is out of scope (LR-01) — this milestone
+makes the engine *interfacable*, shipping no ASGI code.
+
+**Design source:** `docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md` (LR-00..LR-22,
+CF-1..CF-10). **Research:** `.planning/research/SUMMARY.md` (validates the design vs Nautilus/LEAN; zero
+new third-party dependencies; 4 build-order refinements folded in). Requirements + traceability:
+`.planning/REQUIREMENTS.md` (64 v1 requirements across 13 categories → 12 phases; the SQL + STORE
+categories share the merged storage-schema phase P4).
+
+**Milestone-wide gates (apply to EVERY phase — restated as success criteria):**
+1. **Oracle byte-exact** — `SMA_MACD` stays `134 / 46189.87730727451` (`check_exact=True`), determinism
+   double-run identical. This is a **per-PLAN gate** on the foundational + universe-wiring phases (P1–P4,
+   P5, and **P6's `UniverseWiring` extraction** — the highest oracle-risk seam). Any re-baseline (LR-02)
+   is explicit + externally cross-validated (backtesting.py + backtrader), never silent. Live-only phases
+   (P7–P11) stay byte-exact because they are backtest-dark.
+2. **OKX import-inertness** — `tests/integration/test_okx_inertness.py` stays green, extended to assert
+   **register-vs-build** on P1/P2/P4/P5 (registering a venue imports no `ccxt.pro` until built;
+   `SystemConfig` never constructs Postgres `SqlSettings` at import; `FifoEventBus`/
+   `EngineContext(sql_engine=None)` pull nothing heavy). **Zero new third-party dependency / no poetry
+   change** anywhere in P1–P12.
+3. **Held throughout** — Decimal money end-to-end; single UUIDv7; determinism (business `time`, seeded
+   RNG, injected clock); `mypy --strict` clean on new code; `filterwarnings=["error"]` green; tabs/spaces
+   indentation matched to the file (never normalized).
+
+**Trim boundary (noted, NOT taken this milestone):** P1–P8 + P12 = the core God-object refactor; **P9–P11
+(★)** are the feature-adds (LR-03/LR-04) — deferrable at milestone-init without destabilizing the core.
+Owner chose **full scope**, so all 12 phases are in. The ★ marker keeps the boundary visible. The ten
+folded backlog TODOs (**CF-1..CF-10**) all land in core (non-★) phases (P1/P5/P6/P7/P8), so the trim
+boundary is unaffected.
+
+## Phases
+
+**Phase Numbering:** Numbering reset to Phase 1 for v1.8 (every v1.1–v1.7 milestone reset the same way).
+Integer phases are planned milestone work; decimal phases (e.g. 2.1) would be urgent insertions (marked
+INSERTED). ★ = trimmable feature-add (in scope this milestone). Execution follows the dependency graph
+below, not strict numeric order (P4 waits on P3; P5 on P2+P3; P6 on P4+P5; etc.).
+
+- [ ] **Phase 1: Config Centralization** - One import-safe `SystemConfig` (eager/lazy split), module-constant migration, dead-config audit, typed `HaltReason` (CFG-01..06)
+- [ ] **Phase 2: Event Bus** - Two-tier `EventBus` Protocol (`FifoEventBus`/`PriorityEventBus`) + CONTROL EventTypes + minimal `EngineContext` skeleton (BUS-01..04)
+- [ ] **Phase 3: EngineContext + Storage-in-Handler** - `EngineContext` threaded into `compose_engine(ctx, spec)`, handler-owns storage init, `SqlBackend→SqlEngine` rename (CTX-01..04)
+- [ ] **Phase 4: Storage Schema: Migrations Relocation + New Durable Stores** - `migrations/` → project root FIRST, then `SystemStore`/`VenueStore`/`StrategyRegistryStore` chained on the `HaltRecordStore` template; single-head + parity Alembic gate over the FULL chain + rehydrate (SQL-01..02, STORE-01..05)
+- [ ] **Phase 5: Venue Registry + Bundle** - Two registries, `VenuePlugin`/`VenueBundle`, precision/validate on the exchange, connector memoization, shared `StreamSupervisor` — kills every `if exchange==` (VENUE-01..07)
+- [ ] **Phase 6: LiveRunner + Factory + Facade Shrink** - `build_live_system`, `LiveRunner`, shared `UniverseWiring` *(oracle-sensitive)*, `LiveRouteRegistrar`, ~200-line facade (RUN-01..07)
+- [ ] **Phase 7: Safety + Reconciliation + Stream Recovery** - `SafetyController`, `ReconciliationCoordinator`, `StreamRecoveryHandler`, CONTROL routes, pre-trade throttle — flag machinery deleted (SAFE-01..06)
+- [ ] **Phase 8: Error Subsystem** - Injected `ErrorPolicy`, formalized `ErrorHandler`, two-guard terminal safety, CF-1 aggregate circuit breaker (ERR-01..04)
+- [ ] **Phase 9 ★: Runtime-Config Platform** - `RuntimeConfig` overlay, scoped `ConfigUpdateEvent` + allowlist, restart layering, stats/state UI read-model (RTCFG-01..06)
+- [ ] **Phase 10 ★: Strategies Registry** - Durable `StrategyRegistryStore` rehydrate, enable/disable via `STRATEGY_COMMAND`, atomic strategy-param reconfiguration (STRAT-01..03)
+- [ ] **Phase 11 ★: Multi-Portfolio-Live** - Per-`account_id` account factory, distinct-`account_id` invariant (fail loud), per-portfolio reconcile, `clOrdId→client_order_id` (MPORT-01..06)
+- [ ] **Phase 12: Test Migration + Gates** - `run_paper_replay`→`ReplayRunner` in `tests/` (production replay-free); live-smoke / config-restart / multi-portfolio-attribution gates (TEST-01..04)
+
+## Phase Details
+
+### Phase 1: Config Centralization
+**Goal**: Centralize all system-wide configuration into one import-safe `SystemConfig` (eager fields vs a lazy `sql` accessor), fold scattered module constants into their domain config, retire dead config, and introduce a typed `HaltReason` — the backtest path reading base defaults unchanged.
+**Depends on**: Nothing (first phase)
+**Requirements**: CFG-01, CFG-02, CFG-03, CFG-04, CFG-05, CFG-06
+**Success Criteria** (what must be TRUE):
+  1. `from itrader import config` exposes immutable base defaults; the backtest reads them unchanged and the SMA_MACD oracle stays byte-exact `134 / 46189.87730727451` (per-PLAN gate, LR-02).
+  2. `SystemConfig` aggregates `performance`/`monitoring`/`runtime`/`sql`/`order` with the Postgres `sql` arm resolved only on first access — importing it constructs no `SqlSettings`, so `test_okx_inertness.py` stays green (extended register-vs-build assertion).
+  3. Scattered module constants fold into domain config (`_STREAM_RECONNECT_*` → `StreamSettings`/`ConnectionSettings`, `_WARMUP_MARGIN`/`_BACKFILL_PAGE` → feed/provider config); `_OKX_*`/`_PAPER_*` are gone (grep-clean) and the `extra` policy is normalized.
+  4. A typed `HaltReason` enum in `core/enums/system.py` replaces free-string halt reasons and the off-vocabulary `'baseline-residual'` string is retired (CF-8).
+  5. The dead-config audit removes unused settings + stale `__pycache__`, and the D-03a dual-validator paragraph is applied to `.planning/codebase/CONVENTIONS.md` (CF-6).
+**Plans**: TBD
+
+### Phase 2: Event Bus
+**Goal**: Introduce a stdlib two-tier `EventBus` (CONTROL > BUSINESS) with FIFO and priority implementations behind one `.put()` surface, add the new CONTROL `EventType` members, and settle the `compose_engine` signature via a minimal `EngineContext` skeleton — backtest wiring `FifoEventBus` at zero oracle risk.
+**Depends on**: Nothing
+**Requirements**: BUS-01, BUS-02, BUS-03, BUS-04
+**Success Criteria** (what must be TRUE):
+  1. `FifoEventBus` (backtest) and `PriorityEventBus` (live) satisfy one `EventBus` Protocol (`put`/`get`/`get_nowait`/`qsize`/`empty`/`depth_by_tier`) sharing a single `.put(event)` surface with no handler call-site changes; backtest wires `FifoEventBus` and the oracle stays byte-exact (per-PLAN gate).
+  2. A test proves `PriorityEventBus` orders `(tier, seq, event)` by a globally-unique monotonic `seq` (`itertools.count`) — the comparison never dereferences the non-orderable frozen event — and preserves strict within-tier FIFO.
+  3. New CONTROL `EventType` members (`STREAM_STATE`, `CONNECTOR_FATAL`, `CONFIG_UPDATE`) exist and are assigned CONTROL tier from a declarative `_CONTROL_EVENT_TYPES` frozenset; backtest uses `FifoEventBus` (zero priority-bus on the backtest path).
+  4. A minimal `EngineContext` skeleton settles `compose_engine`'s signature once; `test_okx_inertness.py` stays green (`FifoEventBus`/`EngineContext(sql_engine=None)` pull nothing heavy; extended register-vs-build assertion).
+**Plans**: TBD
+
+### Phase 3: EngineContext + Storage-in-Handler
+**Goal**: Thread a frozen `EngineContext` once into `compose_engine(ctx, spec)`, move storage initialization into the Order and Strategies handlers (following `PortfolioHandler`'s shape), and rename `SqlBackend` to `SqlEngine` — with backtest yielding the same in-memory instances.
+**Depends on**: Phase 1, Phase 2
+**Requirements**: CTX-01, CTX-02, CTX-03, CTX-04
+**Success Criteria** (what must be TRUE):
+  1. `compose_engine(ctx, spec)` takes the frozen `EngineContext` (`bus`, `config`, `environment`, `sql_engine`); backtest (`environment='backtest', sql_engine=None`) yields the same in-memory storage instances and the oracle stays byte-exact (per-PLAN gate).
+  2. Order + Strategies handlers own their storage init from `(environment, sql_engine)` with an optional `storage=` override; `compose_engine` reads the concrete instance back off `.storage` for the `set_order_storage(...)` wiring.
+  3. `SqlBackend` is renamed to `SqlEngine` (`storage/backend.py` → `storage/engine.py`, field/param `sql_engine`); all importers are updated and `mypy --strict` is clean.
+  4. Factory SQL imports stay lazy, so `test_okx_inertness.py` stays green on the backtest path.
+**Plans**: TBD
+
+### Phase 4: Storage Schema: Migrations Relocation + New Durable Stores
+**Goal**: Land the full live storage schema as one cohesive unit — FIRST relocate the Alembic migrations tree from the shipped package to project root (staying out of the wheel), THEN add the three new durable SQL stores (`SystemStore`, `VenueStore`, `StrategyRegistryStore`) on the `HaltRecordStore` template, extending the chained migration sequence in the new location and rehydrating on restart. Live-only composition-root infrastructure that leaves the backtest path untouched. (Mechanical relocation; the `SqlBackend→SqlEngine` rename was folded into P3.)
+**Depends on**: Phase 3
+**Requirements**: SQL-01, SQL-02, STORE-01, STORE-02, STORE-03, STORE-04, STORE-05
+**Success Criteria** (what must be TRUE):
+  1. `itrader/storage/migrations/` relocates to project-root `migrations/` **first**; `alembic.ini` `script_location` is updated and `env.py` still imports the `build_*_table` registrars + `NAMING_CONVENTION` from `itrader.storage`; migrations stay out of the shipped wheel (SQL-01).
+  2. `SystemStore` (cardinality 1 key-value `(key, value_json, updated_at)` namespaced upsert), `VenueStore` (per-venue config + which venues are enabled; never stores secrets), and `StrategyRegistryStore` (which strategies trade + per-strategy config + subscriptions) each compose `sql_engine` with their own `build_*_table` registrar and rehydrate their state on restart (STORE-01..04).
+  3. The chained migration `d10_halt_records → system_store → venue_config → strategy_registry` is authored in the relocated `migrations/` tree, and the SQL-02 Alembic gate validates the FULL new chain — `alembic upgrade head` on a clean DB, `alembic heads == 1` (single head incl. the three new stores), and a `create_all`/migration parity test.
+  4. An in-memory fallback keeps the backtest path untouched — the backtest oracle stays byte-exact (per-PLAN gate) and `test_okx_inertness.py` stays green (extended register-vs-build assertion; the relocated migrations + new stores pull nothing heavy at import).
+**Plans**: TBD
+
+### Phase 5: Venue Registry + Bundle
+**Goal**: Build two independent registries (execution venue + data provider) plus a `VenuePlugin`/`VenueBundle` system with lazy plugins that parametrize every venue — killing every `if exchange==` — with connector memoization by `(venue, account_id)`, precision/validate as exchange capabilities, a per-portfolio account factory, and a shared `StreamSupervisor`.
+**Depends on**: Phase 2, Phase 3
+**Requirements**: VENUE-01, VENUE-02, VENUE-03, VENUE-04, VENUE-05, VENUE-06, VENUE-07
+**Success Criteria** (what must be TRUE):
+  1. `ExecutionVenueRegistry` + `DataProviderRegistry` select execution venue and data provider independently via `SystemSpec`; registering `'okx'` lazy-imports its concretions only inside `build_bundle`, so `test_okx_inertness.py` (the P5 acceptance gate; register-vs-build) stays green.
+  2. Precision + validation become `AbstractExchange` capabilities (`resolve_precision(symbol)`, `validate_symbol(symbol)`); `_OkxPrecisionResolver`/`_PrecisionResolver` are deleted and `_precision_to_scale` becomes a shared money util.
+  3. A `LiveDataProvider` Protocol (+ `BaseLiveDataProvider` no-op defaults) wires every provider uniformly (no `hasattr` sprinkling), and a `VenueLifecycle` orchestrator None-guards absent members so every `if exchange=='okx'` / `elif =='paper'` is removed.
+  4. A shared `StreamSupervisor` replaces the triplicated `_run_stream_supervisor` + `_STREAM_RECONNECT_*` (CF-4); connector-contract docstrings are added to `connectors/base.py` (CF-3); OKX markets-map freshness closes the fail-open-before-load window via the existing `validate_symbol` → removal path (CF-9).
+  5. Connectors are memoized by `(venue, account_id)` with per-`account_id` env-sourced credentials never persisted; the backtest oracle stays byte-exact (per-PLAN gate).
+**Plans**: TBD
+
+### Phase 6: LiveRunner + Factory + Facade Shrink
+**Goal**: Make `build_live_system` the live composition root over a new `LiveRunner`, shrinking `LiveTradingSystem` to a ~200-line facade — with the shared `UniverseWiring` extracted byte-exact (the highest oracle-risk seam) and reused by both runners, and live routes composed declaratively.
+**Depends on**: Phase 4, Phase 5
+**Requirements**: RUN-01, RUN-02, RUN-03, RUN-04, RUN-05, RUN-06, RUN-07
+**Success Criteria** (what must be TRUE):
+  1. The shared `UniverseWiring` helper (`derive_membership → build Universe → inject exchange/order/portfolio/strategies → feed.bind`, incl. the WR-03 desync assert) is extracted as one intact unit and reused by both `BacktestRunner` and the live `SessionInitializer` — **BacktestRunner stays byte-exact `134 / 46189.87730727451`** (per-PLAN gate on the `UniverseWiring` extraction; the milestone's highest oracle risk).
+  2. `build_live_system(spec)` assembles centralized config → one `sql_engine` → venue plugin(s) → `EngineContext` → `compose_engine` → bundle(s) + `LiveRunner` + controllers; `LiveRunner` owns the drain loop + injected `ErrorPolicy` + worker supervision, replacing `_event_processing_loop`.
+  3. `LiveTradingSystem` shrinks to a ~200-line facade (lifecycle, status/read-model, `add_event`); legacy `print_status`/`get_statistics` are dropped and `__init__` sheds `exchange`/`to_sql`/`queue_timeout`/`max_idle_time`.
+  4. `LiveRouteRegistrar` composes live + CONTROL routes declaratively (list order = execution order; no subclass, no runtime mutation) with backtest getting base routes only; `UniverseHandler` is a first-class handler with explicit deps and zero OKX coupling; `StrategyWarmupConsumer` is rehomed sized to `max(strategy.warmup)` with the CF-10 depth-hint seam shaped (K-computation deferred).
+  5. `test_okx_inertness.py` stays green (live decomposition imports no `ccxt.pro` on the backtest path).
+**Plans**: TBD
+
+### Phase 7: Safety + Reconciliation + Stream Recovery
+**Goal**: Extract a pure `SafetyController` state machine, a `ReconciliationCoordinator`, and a `StreamRecoveryHandler`; convert connector stream/fatal handoff into CONTROL events (flag side-channel deleted); and add a pre-trade submit-rate + max-notional throttle.
+**Depends on**: Phase 6
+**Requirements**: SAFE-01, SAFE-02, SAFE-03, SAFE-04, SAFE-05, SAFE-06
+**Success Criteria** (what must be TRUE):
+  1. A pure `SafetyController` (no venue I/O) owns the status latch (`VALID_STATUS_TRANSITIONS`, single `update_status`, `force=` reserved for `reset_halt`), `halt(reason)` (winner-only → CRITICAL `ErrorEvent` → durable `HaltRecordStore.record_halt`), `pause_submission`/`resume_submission` + a bounded deferred-protective queue, and the dispatch gate; `check_durable_halt_on_start()` runs first (before any venue I/O) and refuses RUNNING on an unresolved durable halt.
+  2. Connector stream up/down + fatal arrive as CONTROL events (`StreamStateEvent` → pause / `StreamRecoveryHandler.on_reconnect`; `ConnectorFatalEvent` → `halt`) on the engine thread; the `_pending_stream_resume`/`_pending_connector_halt` flag side-channel is deleted.
+  3. `StreamRecoveryHandler` owns reconnect resume I/O (catch-up missed fills + account snapshot on the engine thread + all-streams-healthy gate → `resume_submission`), with CF-2 `backfill_on_resume` landing **loop-native** (connector loop via the reconnect callback) and an assertion no engine-thread path reaches the ring writer.
+  4. A pre-trade submit-rate + max-notional-per-order throttle (SAFE-06) rejects order flow exceeding configured velocity/notional caps **before** submission; the `ReconciliationCoordinator` keys on account *kind* (not `exchange=='okx'`) and guards the bare `str(matched["id"])` with a typed fail-loud error (CF-7).
+  5. The backtest oracle stays byte-exact (live-only, backtest-dark) and `test_okx_inertness.py` stays green.
+**Plans**: TBD
+
+### Phase 8: Error Subsystem
+**Goal**: Inject an `ErrorPolicy` into `EventHandler` (removing the monkeypatch), formalize the `ErrorHandler` ERROR-route consumer with two-guard terminal safety, and ship the CF-1 aggregate circuit breaker that actually trips — all leaving backtest fail-fast byte-for-byte unchanged.
+**Depends on**: Phase 6
+**Requirements**: ERR-01, ERR-02, ERR-03, ERR-04
+**Success Criteria** (what must be TRUE):
+  1. An `ErrorPolicy` is injected into `EventHandler` at construction (backtest/replay → fail-fast re-raise; live → publish-and-continue) with per-handler granularity preserved and the WR-06 source guard; the backtest fail-fast path is byte-for-byte unchanged and the oracle stays byte-exact.
+  2. The **CF-1 aggregate circuit breaker** (route-classified ring: SETTLEMENT halt-on-first, ORDER-IO N=3/60s, ADMISSION N=3/300s, LOOP-BACKSTOP N=5/60s) **actually trips** — proven by a "money route failing every event" test — while preserving the WR-06 terminal swallow (hard acceptance criterion).
+  3. `ErrorHandler` formalizes the ERROR-route consumer (severity-mapped structured logging, CRITICAL → the pluggable alert-sink seam CF-5, persist latest error → `SystemStore state.last_error`, WR-06 consumer guard); handler failures, `halt()` (CRITICAL), `PortfolioErrorEvent`, and `ConnectorFatalEvent` all funnel through the one ERROR route.
+  4. `test_okx_inertness.py` stays green.
+**Plans**: TBD
+
+### Phase 9 ★: Runtime-Config Platform
+**Goal**: Build a durable, restart-surviving runtime-config platform — a `RuntimeConfig` overlay injected as `EngineContext.config`, a scoped `ConfigUpdateEvent` gated by an allowlist with venue-kind-aware validation — plus the SystemStore stats/state UI read-model. (★ trimmable feature-add; in scope this milestone.)
+**Depends on**: Phase 4, Phase 7
+**Requirements**: RTCFG-01, RTCFG-02, RTCFG-03, RTCFG-04, RTCFG-05, RTCFG-06
+**Success Criteria** (what must be TRUE):
+  1. A `RuntimeConfig` overlay (`defaults ← YAML ← env ← persisted runtime overrides`) is built by the live factory and injected as `EngineContext.config` (engine-thread-write, snapshot-read); handlers read it and see runtime changes.
+  2. A scoped `ConfigUpdateEvent(scope, key, value)` on the CONTROL plane is validated against an allowlist + type/range, routed on the engine thread to the owning store (`system`→SystemStore, `portfolio:{id}`→Portfolio+portfolio store, `venue:{name}`→VenueStore, `order`→SystemStore), applied to the overlay + relevant `handler.update_config(...)`, and persisted; immutable-at-runtime keys (`rng_seed`, money precision, SQL + venue credentials, `environment`, IDs) are rejected.
+  3. Fee/slippage config keys are runtime-mutable **only for simulated venues** — a `ConfigUpdateEvent` targeting a live venue's fee/slippage is rejected (venue-kind-aware validation, RTCFG-05).
+  4. Persisted overrides survive restart (`build_live_system` layers them over defaults on boot), and the `system_store` `stats.snapshot` + `state.*` (status / halt_reason / last_error / last_started_at) serve as the UI read-model without touching hot-path locks (RTCFG-06).
+  5. The backtest oracle stays byte-exact and `test_okx_inertness.py` stays green.
+**Plans**: TBD
+
+### Phase 10 ★: Strategies Registry
+**Goal**: Make the strategy roster durable — a `StrategyRegistryStore` that survives restart, with runtime add/remove/enable/disable via `STRATEGY_COMMAND` and atomic strategy-parameter reconfiguration. (★ trimmable feature-add; in scope this milestone.)
+**Depends on**: Phase 4, Phase 6
+**Requirements**: STRAT-01, STRAT-02, STRAT-03
+**Success Criteria** (what must be TRUE):
+  1. `StrategyRegistryStore` persists which strategies are active + config + subscriptions; on restart `build_live_system` rehydrates it and re-registers the active strategies (survives restart).
+  2. Runtime add / remove / enable / disable via `STRATEGY_COMMAND` (CONTROL) is applied by `StrategiesHandler` and persisted.
+  3. A strategy's config parameters are mutable at runtime via **atomic reconfiguration** (quiesce → apply → re-warmup the affected strategy), persisted to `StrategyRegistryStore` (STRAT-03; folds `pair-strategy-live-reconfiguration.md`).
+  4. The backtest oracle stays byte-exact (live-only, backtest-dark) and `test_okx_inertness.py` stays green.
+**Plans**: TBD
+
+### Phase 11 ★: Multi-Portfolio-Live
+**Goal**: Let multiple portfolios trade live independently — a per-`account_id` account factory replacing the single-portfolio guard, a distinct-`account_id` invariant that fails loud, per-portfolio reconciliation, and two-key attribution (`client_order_id` vs `portfolio_id`). (★ feature-add — LR-03 mandate, never trim.)
+**Depends on**: Phase 5, Phase 7
+**Requirements**: MPORT-01, MPORT-02, MPORT-03, MPORT-04, MPORT-05, MPORT-06
+**Success Criteria** (what must be TRUE):
+  1. The venue plugin's `new_account(portfolio_ref, config)` mints a per-portfolio account (venue-truth → `VenueAccount` scoped to `portfolio.account_id`; compute → a fresh `SimulatedAccount`); `_link_venue_account_to_portfolios` + its `RuntimeError(>1)` guard are deleted, and `PortfolioSpec` gains `account_id`.
+  2. A distinct-`account_id` invariant fails **loud** at composition time — multiple portfolios sharing one venue `account_id` is rejected (pooled buying power the venue can't split is deferred).
+  3. A signal fans out to each subscribed portfolio, each sizing/ordering independently against its own account; `clOrdId` is renamed `client_order_id` (distinct from `portfolio_id`) and fills route via `client_order_id`/`venue_order_id` → engine order → `FillEvent(portfolio_id)` → the right `Portfolio.on_fill`.
+  4. Connectors are keyed `(venue, account_id)` (VENUE-03) so multi-account portfolios share/decouple correctly, and the `ReconciliationCoordinator` iterates active portfolios reconciling each against its own `VenueAccount`/`account_id`.
+  5. The backtest oracle stays byte-exact and `test_okx_inertness.py` stays green.
+**Plans**: TBD
+
+### Phase 12: Test Migration + Gates
+**Goal**: Move the replay driver into `tests/` so production is replay-free, and add the live-smoke, config-restart, and multi-portfolio-attribution gates that lock the decomposed live surface. Lands last (needs the whole surface incl. multi-portfolio).
+**Depends on**: Phase 6, Phase 11
+**Requirements**: TEST-01, TEST-02, TEST-03, TEST-04
+**Success Criteria** (what must be TRUE):
+  1. `run_paper_replay` → `ReplayRunner` in `tests/`; the `replay` plugin (`SimulatedExchange` + `ReplayDataProvider` over the golden CSV) is registered **only** by a test fixture, and production is replay-free (`run_paper_replay` + `PAPER_PARITY_*`/`_PAPER_*` leave production).
+  2. A live-smoke gate exercises the decomposed live surface end-to-end (facade → factory → `LiveRunner` → controllers) on the replay fixture.
+  3. A config-restart gate proves persisted runtime overrides survive a restart (RTCFG-03).
+  4. A multi-portfolio attribution gate proves fills route to the correct portfolio and the distinct-`account_id` invariant fails loud (MPORT-02/MPORT-04).
+  5. The backtest oracle stays byte-exact and `test_okx_inertness.py` stays green.
+**Plans**: TBD
+
+## Progress (v1.8 — active)
+
+**Execution Order (dependency graph, not strict numeric):**
+`P1 · P2 → P3 → P4` and `P3 → {P5}` with `P2 → P5`; `{P4,P5} → P6 → {P7, P8}`;
+`{P4,P7} → P9 ★`; `{P4,P6} → P10 ★`; `{P5,P7} → P11 ★`; `{P6,P11} → P12`.
+P1 and P2 have no dependencies and can start in parallel.
+
+| Phase | Milestone | Plans Complete | Status | Completed |
+|-------|-----------|----------------|--------|-----------|
+| 1. Config Centralization | v1.8 | 0/TBD | Not started | - |
+| 2. Event Bus | v1.8 | 0/TBD | Not started | - |
+| 3. EngineContext + Storage-in-Handler | v1.8 | 0/TBD | Not started | - |
+| 4. Storage Schema: Migrations Relocation + New Durable Stores | v1.8 | 0/TBD | Not started | - |
+| 5. Venue Registry + Bundle | v1.8 | 0/TBD | Not started | - |
+| 6. LiveRunner + Factory + Facade Shrink | v1.8 | 0/TBD | Not started | - |
+| 7. Safety + Reconciliation + Stream Recovery | v1.8 | 0/TBD | Not started | - |
+| 8. Error Subsystem | v1.8 | 0/TBD | Not started | - |
+| 9 ★. Runtime-Config Platform | v1.8 | 0/TBD | Not started | - |
+| 10 ★. Strategies Registry | v1.8 | 0/TBD | Not started | - |
+| 11 ★. Multi-Portfolio-Live | v1.8 | 0/TBD | Not started | - |
+| 12. Test Migration + Gates | v1.8 | 0/TBD | Not started | - |
 
 ## Phases (shipped — archived detail)
 
@@ -229,10 +452,13 @@ in [`milestones/v1.2-ROADMAP.md`](./milestones/v1.2-ROADMAP.md).
 
 ## Progress
 
-All milestones through v1.7 are shipped and archived under `milestones/`. **No active milestone** —
-the whole 999.x backlog through N+4 is consumed. Start the next cycle with `/gsd:new-milestone`.
+Milestones through v1.7 are shipped and archived under `milestones/`. **v1.8 — Live System Refactor &
+Live-Readiness Hardening is the active milestone** (12 phases, 64 requirements; roadmap created
+2026-07-09, revised to 12 phases 2026-07-09 — old P4 SqlEngine Migrations Relocation folded into old P5
+New Durable Stores → merged storage-schema phase P4). Per-phase v1.8 status is tracked in the
+**Progress (v1.8 — active)** table above.
 
-**Shipped milestones** (full per-phase detail archived under `milestones/`):
+**Milestone summary** (full per-phase detail archived under `milestones/`):
 
 | Milestone | Phases | Plans | Status | Shipped |
 |-----------|--------|-------|--------|---------|
@@ -244,9 +470,9 @@ the whole 999.x backlog through N+4 is consumed. Start the next cycle with `/gsd
 | v1.5 — Backtest Performance Optimization | 1-8 | 26 | ✅ Shipped | 2026-06-26 |
 | v1.6 — N+3b Persistence Foundation | 1-5 | 21 | ✅ Shipped | 2026-06-30 |
 | v1.7 — Live Trading Readiness | 1-7 + 05.1/05.2/05.3 | 75 | ✅ Shipped | 2026-07-07 |
+| v1.8 — Live System Refactor & Live-Readiness Hardening | 1-12 | TBD | 🚧 In progress | - |
 
-**Next:** `/gsd:new-milestone` to define the next milestone (owner's stated direction:
-`live_trading_system.py` refactor + FastAPI control-plane).
+**Next:** `/gsd:plan-phase 1` (Config Centralization) — or plan P1 and P2 in parallel (both dependency-free).
 
 ## Backlog
 
@@ -263,6 +489,22 @@ the whole 999.x backlog through N+4 is consumed. Start the next cycle with `/gsd
 > trimmed N+4). The historical 999.3 seed below is retained as the source intent (like 999.2 → v1.5/v1.6
 > and 999.4 → v1.4). Do not re-plan from here — the shipped detail is in the **Phases (shipped — archived
 > detail)** section above + [`milestones/v1.7-ROADMAP.md`](./milestones/v1.7-ROADMAP.md).
+
+### Next up (post-v1.8): FastAPI application layer
+
+> **The downstream consumer of v1.8.** v1.8 makes the engine *interfacable* (clean control/query seams,
+> event ingress, centralized + runtime config, durable stores, stats/state read-model) but ships **no**
+> FastAPI app / routes / ASGI code (LR-01). The FastAPI application-layer milestone consumes those stable
+> seams. Design context: MEMORY `fastapi-application-layer-plan.md`. Do not fold into v1.8.
+
+### v1.8 deferred platform seams (carried, not built — spec §14)
+
+> Marked seams the v1.8 two-registry / multi-portfolio decoupling *enables* but does not build:
+> multi-provider **feed-router** (`set_provider` → provider-router keyed by symbol/asset-class),
+> **single-connector-multi-`account_id`** optimization (OKX master key + per-account routing on one
+> session), **shared-`account_id` risk allocator** (portfolios pooling one venue account), config
+> **audit-trail table** (`system_config_audit`), **errors-history table**, and a **stats-history table
+> split**. See `.planning/REQUIREMENTS.md` → v2/Future.
 
 ### Phase 999.3: N+4 — Live Trading Readiness (SHIPPED-AS-v1.7 — historical seed)
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,17 +1,16 @@
 ---
 gsd_state_version: 1.0
-milestone: v1.7
-milestone_name: Live Trading Readiness
-status: Awaiting next milestone
-stopped_at: Completed 07-10-PLAN.md (CR-01 gap-closure — warmup re-delivery idempotency)
-last_updated: "2026-07-07T14:06:39.708Z"
-last_activity: 2026-07-07 — Milestone v1.7 completed and archived
+milestone: v1.8
+milestone_name: Live System Refactor & Live-Readiness Hardening
+status: planning
+last_updated: "2026-07-09T07:24:06.624Z"
+last_activity: 2026-07-09
 progress:
-  total_phases: 10
-  completed_phases: 10
-  total_plans: 75
-  completed_plans: 75
-  percent: 100
+  total_phases: 0
+  completed_phases: 0
+  total_plans: 0
+  completed_plans: 0
+  percent: 0
 ---
 
 # Project State
@@ -30,10 +29,10 @@ control-plane). Adjudicate the owner-gated margin-equity WR-01 defect before any
 
 ## Current Position
 
-Phase: Milestone v1.7 complete
+Phase: Not started (defining requirements)
 Plan: —
-Status: Awaiting next milestone
-Last activity: 2026-07-07 — Milestone v1.7 completed and archived
+Status: Defining requirements
+Last activity: 2026-07-09 — Milestone v1.8 started
 
 ## Milestone Gate (v1.7 — applies to EVERY phase)
 
@@ -379,6 +378,7 @@ Carried todo: 14 pending todos in `todos/pending/` (carry-forward backlog — `v
 
 - Start the next milestone with `/gsd:new-milestone` (owner's stated direction: `live_trading_system.py`
   full refactor + halt-reason storage/vocabulary review, and a FastAPI application-layer / control-plane).
+
 - Optionally create the git tag: `git tag -a v1.7 -m "v1.7 Live Trading Readiness"` (deferred at close).
 - Before any live margin/leverage consumer: adjudicate `margin-equity-double-counts-notional-wr01`
   (owner-gated, oracle-dark) with external cross-validation.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -7,11 +7,11 @@ stopped_at: Completed 07-10-PLAN.md (CR-01 gap-closure — warmup re-delivery id
 last_updated: "2026-07-07T14:06:39.708Z"
 last_activity: 2026-07-07 — Milestone v1.7 completed and archived
 progress:
-  total_phases: 11
+  total_phases: 10
   completed_phases: 10
   total_plans: 75
   completed_plans: 75
-  percent: 91
+  percent: 100
 ---
 
 # Project State

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,10 +3,10 @@ gsd_state_version: 1.0
 milestone: v1.8
 milestone_name: Live System Refactor & Live-Readiness Hardening
 status: planning
-last_updated: "2026-07-09T07:24:06.624Z"
+last_updated: "2026-07-09T00:00:00.000Z"
 last_activity: 2026-07-09
 progress:
-  total_phases: 0
+  total_phases: 12
   completed_phases: 0
   total_plans: 0
   completed_plans: 0
@@ -17,70 +17,71 @@ progress:
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-07-07 — v1.7 Live Trading Readiness SHIPPED + archived; no active milestone)
+See: .planning/PROJECT.md (Current Milestone: v1.8 — Live System Refactor & Live-Readiness Hardening)
 
 **Core value:** A single backtest run of `SMA_MACD` on the golden BTCUSD CSV produces correct,
-deterministic, cross-validated numbers (oracle 134 / `46189.87730727451`; v1.5 W1 baseline 15.7 s /
-152.8 MB). v1.7 added a **live operating mode (paper-first on OKX)** with a real correctness gate
-(**paper-parity vs that oracle**) — **without disturbing the byte-exact backtest path**.
-**Current focus:** No active milestone — v1.7 shipped + archived 2026-07-07. Next: `/gsd:new-milestone`
-(owner's stated direction: `live_trading_system.py` full refactor + halt-vocabulary review + FastAPI
-control-plane). Adjudicate the owner-gated margin-equity WR-01 defect before any live margin consumer.
+deterministic, cross-validated numbers (oracle **134 / `46189.87730727451`**; v1.5 W1 baseline 15.7 s /
+152.8 MB). v1.7 shipped a live operating mode (paper-first on OKX) without disturbing that oracle.
+**Current focus:** v1.8 decomposes the 2,171-line `LiveTradingSystem` God object (~17 concerns) into a
+thin ~200-line facade over focused, venue-parametrized, FastAPI-ready collaborators — **without
+disturbing the byte-exact oracle or the OKX import-inertness gate**. FastAPI itself is out of scope
+(LR-01). Full scope: core refactor (P1–P8 + P12) + the three ★ feature-adds (P9–P11).
 
 ## Current Position
 
-Phase: Not started (defining requirements)
+Phase: Not started — 0 of 12 (roadmap created, revised to 12 phases)
 Plan: —
-Status: Defining requirements
-Last activity: 2026-07-09 — Milestone v1.8 started
+Status: Ready to plan (P1 and P2 are both dependency-free — can plan in parallel)
+Last activity: 2026-07-09 — v1.8 ROADMAP.md revised to 12 phases (old P4 SqlEngine Migrations Relocation
+folded into old P5 New Durable Stores → merged storage-schema phase P4; downstream phases renumbered −1;
+64 requirements still mapped, 0 orphans)
 
-## Milestone Gate (v1.7 — applies to EVERY phase)
+Progress: [░░░░░░░░░░] 0%
 
-The live machinery is **inert on the backtest hot path**. Each phase carries the recurring gate:
+## Milestone Gate (v1.8 — applies to EVERY phase)
 
-1. **Oracle byte-exact** — SMA_MACD stays **134 / `46189.87730727451`** (`check_exact=True`),
-   determinism double-run identical.
+1. **Oracle byte-exact** — `SMA_MACD` stays **134 / `46189.87730727451`** (`check_exact=True`),
+   determinism double-run identical. **Per-PLAN gate** on P1–P4, P5, and **P6's `UniverseWiring`
+   extraction** (highest oracle risk). Any re-baseline (LR-02) is explicit + externally cross-validated
+   (backtesting.py + backtrader), never silent. Live-only phases (P7–P11) stay byte-exact (backtest-dark).
+2. **OKX import-inertness** — `tests/integration/test_okx_inertness.py` stays green, extended to assert
+   **register-vs-build** on P1/P2/P4/P5 (registering a venue imports no `ccxt.pro` until built;
+   `SystemConfig` never constructs Postgres `SqlSettings` at import). **Zero new dependency / no poetry
+   change** anywhere in P1–P12.
+3. **Held throughout** — Decimal money end-to-end; single UUIDv7; determinism (business `time`, seeded
+   RNG, injected clock); `mypy --strict` clean on new code; `filterwarnings=["error"]` green; tabs/spaces
+   indentation matched to the file (never normalized).
 
-2. **No W1/W2 perf regression** vs the v1.5 frozen baseline (15.7 s / 152.8 MB) — the backtest path
-   imports no async/connector code.
+## Phase Map (v1.8 — Phases 1-12, numbering reset)
 
-**Phase-specific gates:** Phase 1 = oracle re-confirmed byte-exact after the Account extraction (ACCT-03);
-Phase 4 = **paper-parity gate (DoD)** — golden dataset replayed through the live-paper path yields the
-oracle byte-exact (PAPER-04); Phase 5 = sandbox-validated real path (RECON-06).
+Dependency graph (not strict numeric order): `P1 · P2` (no deps) → `P3{P1,P2}` → `P4{P3}`; `P5{P2,P3}`;
+`P6{P4,P5}` → `P7{P6}` · `P8{P6}`; `P9★{P4,P7}`; `P10★{P4,P6}`; `P11★{P5,P7}`; `P12{P6,P11}`.
 
-**Held throughout, all phases:** Decimal money end-to-end (`to_money` at the connector edge — ccxt
-returns floats); single UUIDv7; determinism (business `time`, never wall-clock); single seeded RNG +
-injected clock; `mypy --strict` clean on new code; `filterwarnings=["error"]` green (`pytest-asyncio`
-configured, global filter never relaxed); tabs/spaces indentation matched to the file.
+| Phase | Name | Requirements | Notes |
+|-------|------|--------------|-------|
+| 1 | Config Centralization | CFG-01..06 | oracle-gated; lazy `sql` inertness lever; `HaltReason` (CF-8); CF-6 doc |
+| 2 | Event Bus | BUS-01..04 | oracle-gated; +CONTROL EventTypes + minimal `EngineContext` skeleton (refinements 2/3) |
+| 3 | EngineContext + Storage-in-Handler | CTX-01..04 | oracle-gated; `SqlBackend→SqlEngine` folded in (refinement 4) |
+| 4 | Storage Schema: Migrations Relocation + New Durable Stores | SQL-01..02, STORE-01..05 | merged (old P4+P5); oracle-gated relocation FIRST, then live-only stores; single-head + parity Alembic gate over the FULL chain + rehydrate |
+| 5 | Venue Registry + Bundle | VENUE-01..07 | oracle-gated; **highest inertness risk**; CF-3/4/9 |
+| 6 | LiveRunner + Factory + Facade Shrink | RUN-01..07 | **highest oracle risk** (`UniverseWiring`); CF-10 |
+| 7 | Safety + Reconciliation + Stream Recovery | SAFE-01..06 | CF-2 loop-native; CF-7; SAFE-06 pre-trade throttle |
+| 8 | Error Subsystem | ERR-01..04 | **CF-1 aggregate breaker MUST trip** (hard criterion); CF-5 |
+| 9 ★ | Runtime-Config Platform | RTCFG-01..06 | feature-add; allowlist + venue-kind-aware fee/slippage gate |
+| 10 ★ | Strategies Registry | STRAT-01..03 | feature-add; STRAT-03 atomic re-config folds pair-strategy TODO |
+| 11 ★ | Multi-Portfolio-Live | MPORT-01..06 | LR-03 (never trim); distinct-`account_id` fails loud |
+| 12 | Test Migration + Gates | TEST-01..04 | lands last; production replay-free; attribution gate |
 
-## Phase Map (v1.7 — Phases 1-6, numbering reset)
-
-Execution order: 1 (gates all) → 2 → 3 → 4 (DoD) → 5 → 6. Hard dependencies (design §7 / research
-ARCHITECTURE): Phase 1 oracle-gated, gates everything; Phase 2 data arm feeds Phase 3; **Phase 4 DoD
-reachable on 1 + 3 + connector data arm only (NOT the order arm)**; Phase 5 needs Phase 2 order arm +
-Phase 1 `VenueAccount` + the v1.6 store; Phase 6 pairs with Phase 3 backfill. LX-15 topology (RUN-01)
-decided in the Phase 3→4 handoff before Phase 4 wiring. Phase dirs `01-*..06-*` will not collide with the
-`999.3` backlog placeholder (different prefix).
-
-| Phase | Name | Requirements | Research flag |
-|-------|------|--------------|---------------|
-| 1 | Account Abstraction + Portfolio/Handler Refactor | ACCT-01..06 | SKIP (v1.2 MOD-01 playbook) |
-| 2 | OKX Connector | CONN-01..06 | **NEEDS plan-time research** (OKX confirm + ccxt.pro gap list) |
-| 3 | LiveBarFeed | FEED-01..05 | **NEEDS plan-time research** (ring capacity, reconnect, correction policy) |
-| 4 | Paper Path (DoD) | PAPER-01..04, RUN-01, COV-01 | **NEEDS plan-time research** (parity harness + LX-15 topology) |
-| 5 | Real/Sandbox + Reconciliation + Persistence Live-Drive | RECON-01..06, RES-01 | **NEEDS plan-time research SPRINT** (reconciliation + write-through boundary) |
-| 6 | Dynamic Universe Membership | UNIV-01, UNIV-02 | SKIP (reuses Phase 3 backfill) |
-
-**Cross-cutting homes:** RUN-01 → Phase 4 (decided before wiring), RES-01 → Phase 5 (pieces in 2–3),
-COV-01 → Phase 4 (infra in 2, extends to 5). Coverage: **32/32 mapped, 0 orphans** (the pre-map "31"
-was an off-by-one — see REQUIREMENTS.md count note).
+**Coverage: 64/64 mapped, 0 orphans.** ★ = trimmable feature-add (in scope — owner chose full scope; the
+trim boundary P1–P8+P12 core vs P9–P11 ★ is noted, not taken). Research flags (plan-time research): P6
+(`UniverseWiring` byte-exact discipline), P8 (CF-1 route-classification + livelock test), P11
+(`client_order_id`/`portfolio_id` two-key attribution). Skip research-phase: P2/P4/P5 (specified/mechanical).
 
 ## Performance Metrics
 
-**Velocity (program cumulative through v1.6):**
-
-- Total plans completed: 306 (v1.0 62 + v1.1 28 + v1.2 23 + v1.3 20 + v1.4 35 + v1.5 26 + v1.6 21)
-- v1.7 plans completed: 0
+**Velocity (program cumulative through v1.7):**
+- Total plans completed: 381 (v1.0 62 + v1.1 28 + v1.2 23 + v1.3 20 + v1.4 35 + v1.5 26 + v1.6 21 + v1.7 75)
+- v1.8 plans completed: 0
 
 *Updated after each plan completion. Per-milestone velocity is archived in the respective MILESTONE-AUDIT.md.*
 
@@ -88,297 +89,99 @@ was an off-by-one — see REQUIREMENTS.md count note).
 
 ### Roadmap Evolution
 
-- v1.7 roadmap created 2026-06-30 (promotes Backlog 999.3 / N+4 Live, trimmed): 6 phases derived from the
-  LOCKED design sketch §4 (LX-01..LX-15) + research SUMMARY/ARCHITECTURE build order; all 32 requirements
-  mapped (100% coverage, 0 orphans). Numbering reset to Phase 1 (matching v1.1–v1.6). Backlog 999.3 marked
-  PROMOTED-TO-v1.7 (design intent retained as historical seed). The recurring milestone gate (oracle
-  byte-exact + no W1/W2 regression — live machinery inert on the backtest hot path) is restated as a
-  success criterion in every phase.
-
-- Cross-cutting requirements given definite home phases: RUN-01 → Phase 4 (LX-15 topology decided before
-  Phase 4 wires the runtime), RES-01 → Phase 5 (resilience fully verified on the real path; rate-limit
-  built in Phase 2, reconnect+gap-recovery in Phase 3 FEED-04), COV-01 → Phase 4 (FL-13 on the first
-  end-to-end live surface; `pytest-asyncio` infra lands Phase 2; real-path coverage extends to Phase 5).
-
-- Phase 05.1 inserted after Phase 5: Live-Path Remediation (URGENT)
-
-- Phase 7 added 2026-07-06: Live Dynamic-Universe Hardening — from the Phase 6 code review. Async warmup +
-  per-symbol `isReady` readiness gate (WR-02 centerpiece) plus WR-01/04/05/06; CR-01/WR-03 already fixed in
-  quick task 260706-l48. Detailed WR-04/05/06 design deferred to the Phase 7 discuss session. (Note:
-  `gsd-sdk query phase.add` auto-numbered it Phase 10 by scanning the cumulative cross-milestone ROADMAP —
-  manually corrected to Phase 7 per the v1.7 per-milestone numbering reset; dir renamed 10→07.)
+- v1.8 ROADMAP.md created 2026-07-09 from the LOCKED design spec
+  (`docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md` §16, LR-00..LR-22, CF-1..CF-10)
+  + research SUMMARY's 4 build-order refinements. Phases derived 1:1 from the REQUIREMENTS.md
+  category→phase mapping (authoritative); all 64 v1 requirements mapped (0 orphans). Numbering reset to
+  Phase 1 (matching v1.1–v1.7). The milestone gate (oracle byte-exact + inertness) is a success criterion
+  in every phase; per-PLAN oracle gating on P1–P4/P5/P6-UniverseWiring.
+- **2026-07-09 revision (13→12 phases):** old P4 (SqlEngine Migrations Relocation, SQL-01/02) folded into
+  old P5 (New Durable Stores, STORE-01..05) → a single merged storage-schema phase P4 ("Storage Schema:
+  Migrations Relocation + New Durable Stores"). Both are live-only / off the oracle hot path, and
+  "relocate the migrations dir, then extend the Alembic chain with 3 new stores" is one cohesive unit of
+  work; the SQL-02 single-head + parity gate now validates the FULL chain incl. the 3 new stores. All
+  downstream phases renumbered −1 (old P6→P5 … old P13→P12). Owner-approved.
+- 4 research refinements folded into the spec §16 graph: (1) P3 depends on {P1,P2}; (2) minimal
+  `EngineContext` skeleton lands in P2; (3) P2 adds the CONTROL EventTypes; (4) `SqlBackend→SqlEngine`
+  rename folded into P3 (only migrations *relocation* stays in the merged P4).
 
 ### Decisions
 
-Active program constraints live in PROJECT.md. v1.7-relevant locked decisions (design LX-01..LX-15):
-
-- **Paper-first DoD (LX-01) + refactor-first (LX-02):** Phase 1 extracts the Account abstraction
-  (oracle-gated, behavior-preserving) BEFORE any live code depends on it; the milestone DoD is the
-  paper-parity gate (Phase 4), reachable on the connector **data arm only**.
-
-- **Account owns balance/margin truth (LX-03), 1 account : 1 portfolio (LX-04):** `Simulated*` leaves
-  compute, `Venue*` leaves cache; the order domain reads through the existing `PortfolioReadModel` seam,
-  so Phase 1 is pure code-motion (no ripple into `OrderManager`/validator).
-
-- **`LiveConnector` is ours over ccxt.pro (LX-05) + native escape hatch:** ccxt's unified `watchOHLCV`
-  drops the OKX `confirm` flag (ccxt #21885) — the native read is mandatory before the feed can emit
-  `BarEvent`s. Single `sandbox: bool` routes both ccxt + native (no split-brain).
-
-- **`PaperConnector` reuses the pure `MatchingEngine` (LX-06) + a shared `apply_costs` helper** extracted
-  byte-exact from `SimulatedExchange._emit_fill` (one matching core + one cost core; no dual fill-pricing).
-
-- **`LiveBarFeed` = ring-buffer `BarFeed` (LX-07); confirm-flag closed-bar (LX-08); warmup through the
-  identical `update(bar)` path, no bulk fast-path (LX-09); monotonic-forward-only (LX-10).**
-
-- **Topology (LX-15):** ship separate worker process (option (b) architected as (c) with N=1), Postgres
-  `LISTEN/NOTIFY` command/status channel (zero new dep, reuses the v1.6 store). Decide before Phase 4 wiring.
-
-- **`TradingInterface` deleted (LX-14)** — no production consumer; replaced by a thin typed engine command
-  surface routing through the real order domain. `Portfolio.user_id` stripped (app-layer concern).
-
-- [Phase ?]: D-04 resolved: SMA_MACD oracle runs the SPOT path — SimulatedCashAccount is the verbatim-critical leaf for plan 01-02 (enable_margin=False default + run_backtest.py LONG_ONLY)
-- [Phase ?]: [Phase 1 / 01-04] D-09 recorded: only the surviving engine-command-surface PRINCIPLE is locked (FastAPI -> thin typed command surface, never into LiveTradingSystem internals); concrete method set deferred to Phase 4 (scopes FL-13). TradingInterface deleted (D-08/LX-14) — dead pre-FastAPI bridge with a quantity: float live-path leak; removal helps the no-float-money gate (ACCT-05).
-- [Phase 01]: 01-02: SimulatedCashAccount = CashManager moved byte-for-byte (D-05); .available is a thin Decimal alias of verbatim available_balance to satisfy the Account ABC without altering internals (byte-exact)
-- [Phase 01]: 01-02: SimulatedMarginAccount gains set_universe/_universe — the margin/liq math-pulldown (ACCT-02) moves its Universe dependency down with the math; dark this wave, wired in 01-03. Liquidation emission shell stays in PortfolioHandler
-- [Phase ?]: 01-03: Portfolio/PortfolioHandler delegate all balance/margin/liq truth to the injected Account leaf behind the FROZEN PortfolioReadModel seam; margin surface narrowed via cast/isinstance; liquidation shells skip spot accounts; CashManager deleted; oracle held byte-exact.
-- [Phase ?]: 01-03c: e2e margin scenarios construct the SimulatedMarginAccount leaf at CONSTRUCTION via enable_margin portfolio_config (01-03 D-03) — the post-construction update_config toggle no longer rebuilds the leaf; account caches no config at construction so a minimal enable_margin config suffices. e2e suite green (72 passed); user_id grep-zero across tests/e2e.
-- [Phase ?]: 01-05: Terminal gate PASSED (ACCT-03) — Account extraction proven behavior-preserving: oracle byte-exact (134 / 46189.87730727451), determinism double-run identical, mypy --strict clean (214 files), full suite 1463 passed under filterwarnings=[error], no float-money introduced (edge casts only), no orphaned cash_manager/user_id reference, W1 oracle run within the 15.7s baseline
-- [Phase 02]: 02-01: OkxSettings binds .api_key/.api_secret/.api_passphrase to plain OKX_API_* via validation_alias while keeping env_prefix='' (a bare field under env_prefix='' would read API_KEY not OKX_API_KEY); SecretStr masks the auth triple; passphrase required; OKX_SANDBOX aliases the demo flag (CONN-06 / D-10)
-- [Phase 02]: 02-01: LiveConnector reshaped from a two-arm marker to a session/transport contract (call sync-RPC / spawn stream-task / client / sandbox / connect / disconnect) — the D-02 seam the three arms type against; async/sync bridge bottled at the connector edge; wspap demo-host correction recorded (WS demo via host, not the REST-only x-simulated-trading header)
-- [Phase 02]: 02-02: OkxConnector = loop-on-daemon-thread + one ccxt.pro client built INSIDE the loop (Pitfall 3); single sandbox bool drives set_sandbox_mode (REST header + ccxt WS wspap host swap) AND the exposed flag the native socket keys off — no split-brain (CONN-03); call/spawn async-sync bridge, stream-task set cancelled on disconnect (CONN-04); no domain-event imports (D-02); exported from barrel (D-04)
-- [Phase 02]: 02-03: OkxExchange = live sibling of SimulatedExchange (AbstractExchange), injected OkxConnector session (D-04, never the concretion); create/cancel via connector.call, watch_orders/watch_my_trades via connector.spawn; the EXCHANGE emits FillEvents on global_queue itself (D-07, D-19 MPSC-safe); Decimal edge held (to_money(str) inbound, ccxt amount/price_to_precision strings outbound, CONN-05); FillEvent.time from venue ms timestamp, never wall-clock; on_market_data no-op for live (CONN-02)
-- [Phase 02]: 02-04: OkxDataProvider data arm — native /ws/v5/business candle socket is the confirm-flag escape hatch (ccxt watch_ohlcv drops confirm); gate on confirm==1 index 8 (forming bars dropped, CONN-01); native host driven off connector.sandbox (wspap vs ws, host not header, CONN-03); REST fetch_ohlcv backfill via shared client with to_money(str) Decimal edge (CONN-05); minimal set_bar_sink seam for Phase-3 LiveBarFeed (D-03); types LiveConnector Protocol only (D-04); mypy --strict clean
-- [Phase ?]: 02-05: OkxConnector constructed ONCE at the LiveTradingSystem composition root and the LiveConnector session injected into the three arms (OkxExchange registered 'okx', OkxDataProvider, VenueAccount) — whole OKX stack lazy-imported inside the live path; init_exchanges unchanged; disconnect() wired into stop() (D-04/CONN-04)
-- [Phase ?]: 02-05: VenueAccount LiveConnector import is TYPE_CHECKING-guarded because the account barrel is on the backtest hot path — a runtime connectors-barrel import would pull ccxt.pro and break inertness; body still Phase 5 (RECON-01)
-- [Phase ?]: 02-05: milestone gate green — fresh-subprocess inertness test asserts itrader.connectors.okx + ccxt.pro absent after a backtest-root import; SMA_MACD oracle byte-exact (134 / 46189.87730727451); suite 1498 passed / 1 skipped
-- [Phase ?]: 03-01: D-12 resolved — ClosedBar carries its own (symbol, timeframe) routing keys; live path stamps from self._symbol/self._timeframe, backfill path from method params (ad-hoc symbol correctness); keys never read from the untrusted venue row (T-03-01-TAMPER). Shared socket-free tests/unit/price/conftest.py fixtures (closed_bar, closed_bar_sequence, _StubProvider) stand up the LiveBarFeed offline matrix.
-- [Phase 03]: 03-02: LiveBarFeed(BarFeed) — capacity-sized deque ring per (symbol,timeframe) + FEED-04 monotonic guard (in-sequence/gap-backfill-replay/duplicate/revision/stale, D-06/D-07) + direct single-ticker BarEvent emission (D-02/D-03/D-04); dormant no-op generate_bar_event (D-05); public set_provider seam (D-01/D-13); TYPE_CHECKING ClosedBar import + absent from feed barrel keeps it hot-path-inert
-- [Phase ?]: 03-04: LiveBarFeed lazy-wired as the live driver at the LiveTradingSystem composition root (FEED-05) — provider-less unconditional construct + okx-arm set_provider injection (writes private _provider warmup reads) + set_bar_sink(feed.update); D-13 _LiveWarmupConsumer(max strategy.warmup) registered before bind so cache_capacity()==100 (Pitfall 1 guard); warmup OKX-gated before start_stream. Inertness probe extended to forbid live_bar_feed on the backtest path; oracle byte-exact.
-- [Phase 04]: 04-01: ReplayDataProvider = offline synchronous stand-in for OkxDataProvider replaying the golden CsvPriceStore as Decimal-edge ClosedBar dicts (to_money(str) edge, ts=int(index.value//1e6) epoch-ms bar-open, symbol/timeframe stamped from config not the row D-12); drop-in on set_bar_sink/fetch_ohlcv_backfill + synchronous replay_bar replacing the async _stream_candles (D-03); ClosedBar imported not redefined; golden rows via CsvPriceStore so iter is byte-identical to backtest (parity anchor D-01/D-02). PAPER-03/COV-01 fixture.
-- [Phase 04]: Paper venue reuses the 'simulated' SimulatedExchange as-is (D-04/D-05/D-06); run_paper_replay() drives golden bars synchronously through the real live seam with backtest per-tick + run-end discipline (parity by construction, D-01/D-09)
-- [Phase ?]: 04-03: RUN-01 runnable paper worker (scripts/run_live_paper.py) delivered per D-08 — offline run_paper_replay (CI-safe default) + opt-in okx manual smoke over start/stop/get_status; channel + web-framework wrapper deferred to Phase 5. COV-01 lifecycle half added (FL-13: clean startup / graceful thread-joining stop / status-before-start, exchange=paper offline).
-- [Phase ?]: 04-04: paper-parity DoD gate shipped (PAPER-04/COV-01) — one test drives run_paper_replay() AND a fresh backtest on the golden dataset, asserts trades+equity frame-equal EXACT (tz-normalized UTC); anchored to the fresh backtest not the frozen 46189 artifact (D-01), survives a backtest-loop rework; inertness _FORBIDDEN extended to replay_provider (D-12), oracle untouched
-- [Phase 05]: 05-11: WR-02 closed — OkxExchange.adopt_venue_correlation() repopulates the three correlation maps + drains buffered fills for rehydrated orders; VenueReconciler.reconcile() adopts per working-set order with a venue_order_id (exchange=self._okx_exchange). Post-restart fills reach the mirror instead of being silently buffered.
-- [Phase 05]: 05-11: WR-03 closed — reconcile_manager validates the PARTIALLY_FILLED transition BEFORE mutating filled_quantity; a rejected transition leaves the mirror literally unchanged. WR-05 recorded documented-only (portfolio_handler.py untouched).
-- [Phase 05]: 05-12: RECON-06 closed — tests/e2e/test_okx_sandbox_recon.py runs `3 passed` against the real OKX EEA demo venue (order->fill->reconcile->restart loop, human-observed 2026-07-03). Reaching green needed 4 follow-on integration fixes (committed separately): OKX_REGION=eea host derivation (REST eea.okx.com / WS wseeapap.okx.com — 50119/60032 otherwise), unified `1d` timeframe to ccxt backfill, live pair BTC/USDT->BTC/USDC (EEA/MiCA sCode 51155; make pair configurable via universe next phase), and store rewired onto unified ITRADER_DATABASE_* (dropped SYSTEM_DB_URL).
-- [Phase 05.1]: 05.1-01: CONF-A RED spine slice 1 — A1 3-leaf account-conformance (V17-01/D-01,D-02) + A4 spot-no-drift-halt (V17-04/D-03,D-04) authored RED; AUD-7 spot/derivative fixture split. Spot fixture is the NEW-cluster default (legacy fixture kept for full-suite green). A4 seeds venue truth via snapshot() from fetch_balance total[BTC] so it is RED now and GREEN after the D-03 base-balance adapter.
-- [Phase 05.1]: 05.1-02: CONF-A RED spine slice 2 — A3 halt-latch (V17-03/D-05), A2 venue_order_id persistence (V17-02/D-06), A5 redeliver-dedup (V17-06/D-08) authored RED. A3 injects the reconcile halt by wrapping _initialize_live_session on the offline paper venue; A2/A5 encode observable end-state so the 05.2 fixes turn them GREEN without rewrite. A3 GREEN in 05.1-05; A2/A5 GREEN in Phase 05.2.
-- [Phase ?]: [Phase 05.1]: 05.1-03: CONF-A RED spine slice 3 — A6 supervisor-catchall (V17-07/D-11), A7 submit-timeout-in-flight (V17-09/D-13), A8 pause-defer-replay (V17-11/D-14) authored RED. A6 covers 3 silent-death surfaces (unclassified ExchangeError, unguarded json.loads, bare-while-True VenueAccount stream); A7/A8 carry control arms (definitive-rejection still REFUSED; entry stays suppressed) to force the fix to branch. All GREEN in Phase 05.3; CONF-A spine A1..A8 complete.
-- [Phase ?]: 05.1-04: D-01 delivered — 7-member Account ABC settlement surface; VenueAccount as a locally-ledgered account (balance = cached venue balance + local fill-delta; snapshot reconciles the delta). available_balance nets settled balance not the venue free field; assert_funds_invariant raises before any mutation. A1 GREEN all 3 leaves; oracle byte-exact.
-- [Phase ?]: 05.1-04: A1 BUY facet made leaf-relative (before-10) — hardcoded 149990 assumed a 150000 start absent on the venue leaf (fixture total[USDC]=78999.79). test_venue_account_cache .available renames deferred to 05.1-06; A4 spot-drift RED deferred to 05.1-08.
-- [Phase 05.1]: D-05: HALTED is a latched state — VALID_STATUS_TRANSITIONS (HALTED->set()) enforced at the single _update_status seam; halt() routed through it; start() refuses RUNNING-from-HALTED post-reconcile; reset_halt() is the sole off-table exit (verify-then-trust)
-- [Phase 05.1]: 05.1-06: D-02 delivered — Portfolio.account re-typed to the Account ABC; both cast(SimulatedMarginAccount,...) narrowings replaced by a single _require_margin_account isinstance guard raising a typed StateError BEFORE any mutation (closes V17-14 partial-mutation cast arm). F/U-4 resolved to a typed conformance module (account/conformance.py) making mypy --strict see the ABC-vs-concretion live wiring; pyproject untouched. A1 permanent gate 16 passed (incl. venue+margin guard case); 7 venue-cache .available->available_balance renames GREEN; oracle byte-exact; mypy clean 228 files.
-- [Phase ?]: 05.1-07: D-03 truth arm — VenueAccount venue-type-aware; spot derives per-symbol position truth from total[BASE] (fetch_positions [] on spot), derivative channel unchanged. market_type/symbol ctor params (base from symbol left leg); spot skips _stream_positions/fetch_positions. A4 spot_drift stays RED (GREEN in 05.1-08); oracle byte-exact; mypy strict clean.
-- [Phase 05.1]: D-03/D-04: real quote + spot market-type wired into VenueAccount at the composition root; post-reconcile baseline guard latches halt('baseline-residual') on unexplained base-asset residual (never auto-adopts)
-- [Phase 05.1]: D-04 spurious-halt band: on-fill compare absorbs the just-applied-fill vs not-yet-refreshed-venue-snapshot transient via a signed fill delta; periodic sweep + baseline guard remain the drift backstops
-- [Phase 05.1]: 05.1-09 (D-20) Task 1: CONF-B sandbox e2e extended with 4 Wave-1 settlement assertions (position/cash/not-HALTED/spot fetch_positions()==[]) closing the V17-01 blind spot + venue_order_id recorded soft-check (pending D-06/05.2) + ARCH-3 finalization capture to .planning/debug/05.1-confb-<date>.md. Added pytest.mark.live so make test (-m 'not live') fences the network. Task 2 online GREEN run is CHECKPOINT-PENDING (human): `poetry run pytest tests/e2e/test_okx_sandbox_recon.py -k demo_order -x -m live` (verify sandbox=True). Plan NOT fully complete until approved.
-- [Phase 05.2]: 05.2-01: D-06 delivered — new frozen OrderAckEvent (order_id->venue_order_id) emitted by OkxExchange._submit_order once the venue id lands (queue-only, V5 field-bind); OrderHandler.on_order_ack -> OrderManager.stamp_venue_order_id persists via order_storage.update_order (D-18). A2 venue_order_id-persistence GREEN; oracle byte-exact; mypy 229 files. Restart integration fixtures now drive the real ack path (V17-02 hand-stamp deleted; unconfident bracket leg asserted None).
-- [Phase ?]: [Phase 05.2]: 05.2-02: D-09 delivered — VenueReconciler._fetch_trades fetches venue fills per active-order symbol with since=oldest-active-order business time (epoch-ms) + explicit limit=100, NO ccxt auto-pagination (OKX sCode 51000, CONF-B). F/U-13 window guard (_FILLS_HISTORY_WINDOW_DAYS=90) loud-logs WARNING naming the symbol when since predates the venue ~3-month /trade/fills-history window. Oracle byte-exact; mypy clean; paginate grep-clean on the production file.
-- [Phase 05.2]: 05.2-03: D-08 Layers 1+3 delivered — ReconcileManager in-session applied-set (bounded OrderedDict cap 10000) guards _apply_executed BEFORE add_fill so a re-delivered venue trade (same venue_trade_id, fresh fill_id) no-ops (A5 GREEN, filled_quantity stays 0.2); key f'{ticker}:{venue_trade_id}', None-keyed backtest fills skip guard (oracle-dark). VenueCorrelationIndex.resolve dedup re-keyed raw trade_id -> f'{order.ticker}:{trade_id}' (gate moved after resolution), closing V17-12 numeric-tradeId cross-instrument collision. Layer 2 (portfolio_handler) + durable settled-ledger deferred to Plan 04. — D-08 exactly-once settlement per economic venue trade, collision-safe across instruments
-- [Phase 05.2]: 05.2-04: D-07/D-08 delivered — restart remembers positions+cash (new Account.restore_cash restores the persisted cash scalar via rehydrate; open positions already WIRE through the manager read of the rehydrated cache, OQ1) + the settled-trade dedup ledger rehydrates: PortfolioHandler.rehydrate() seeds _settled_venue_trade_ids from durable transactions.venue_trade_id keyed f-string ticker:venue_trade_id; on_fill guard/mark re-keyed symbol-scoped (V17-12). Proven offline vs an in-memory durable double; oracle byte-exact; mypy 229 files. Composition-root wiring + rehydrate-before-reconcile is Plan 05.
-- [Phase ?]: 05.2-05: D-07 durable portfolio ledger wired at the live composition root — PortfolioHandler injects the shared SqlBackend ('live' arm when Postgres spine present, else 'backtest' in-memory), threading environment+backend+portfolio_id into each Portfolio state storage (portfolio.py:96 the only real lever; four manager/account fallbacks honor it defensively). F/U-11 RESOLVED: save_account_state wired on the on_fill settlement path (getattr-guarded, oracle-dark). rehydrate() sequenced strictly BEFORE reconcile() in start() (T-05.2-14). Oracle byte-exact; mypy 229; inertness preserved.
-- [Phase ?]: 05.2-06: D-10 durable HALTED latch survives restart — halt() persists a secret-scrubbed halt record (reason literal + timestamp, V7) on the shared SqlBackend spine; a FRESH LiveTradingSystem refuses RUNNING while unresolved (re-latching in-process via _update_status, not halt(), so no double-write); reset_halt() resolves. New d10_halt_records chained Alembic head (single head); env.py registers the table (autogenerate-safe); idgen.generate_halt_record_id keeps the single UUIDv7 scheme. Oracle byte-exact; mypy clean 231; inertness preserved.
-- [Phase ?]: [Phase 05.3]: 05.3-12: D-28 (WR-03) closed — resume gated on ALL venue stream arms healthy via per-arm is_streaming_healthy() (not _streams_down) + engine compound _all_venue_streams_healthy(); no engine-side aggregation/namespacing; None arm = healthy; gate after D-25 catch-up+snapshot, does not re-set _pending_stream_resume
-- [Phase ?]: [Phase 05.3]: 05.3-12: D-29 (WR-05) closed — gap backfill low-clamps (< since_ms) + raises MalformedDataError on non-contiguous first replayed bar (escalates to connector halt) + _replaying_backfill re-entrancy guard fails loud in update() gap branch. Empty-page hole out of scope; WR-04 deferred
-- [Phase 06]: 06-01: UniverseUpdateEvent (frozen Event, tuple added/removed) + EventType.UNIVERSE_UPDATE + explicit-empty _routes entry (three-step flow, Pitfall 5) — dispose notification DISTINCT from ScreenerEvent (D-04); backtest-inert
-- [Phase 06]: 06-01: Universe.apply(desired, instruments)->UniverseDelta slice-assigns _members in place (identity preserved, Pitfall 4) with oracle-dark empty-delta fast path; connector-free (D-03, caller passes resolved instruments, _DEFAULT_* ladder fallback); leaving-set surface (mark/read-copy/clear) for the plan-04 admission gate. UNIV-01 left Pending (foundation only, no consumers)
-- [Phase 06]: 06-02: OkxDataProvider.subscribe/unsubscribe + {symbol: asyncio.Task} registry (D-05, Arm B data plane) — idempotent subscribe spawns one supervised candle coroutine on the connector loop; unsubscribe cancels via the connector cooperative-cancel teardown (no new teardown); provider carries zero membership knowledge
-- [Phase 06]: 06-02: per-symbol supervisor keys — member symbol threaded as stream_name through _stream_candles/_connect_and_consume_candles (replaces shared 'candles' literal, Pitfall 2); one symbol's drop no longer marks all streams down, one payload no longer resets all budgets; is_streaming_healthy keeps any-symbol-down; confirm='0' snapshot still dropped, warmup-before-subscribe contract documented
-- [Phase 06]: 06-03: UniverseHandler on_time (source-guard -> D-06 validate_symbol filter -> Universe.apply -> emit UniverseUpdateEvent only on non-empty delta) + on_universe_update ADD branch (warmup-before-subscribe, Pitfall 6); zero membership duplication. Dedicated 4-space handler isolates the live-only poll route from the backtest _routes[TIME] literal (Pitfall 3/A3). Lean UniverseSelectionModel + StaticUniverseSelectionModel grown in membership.py (D-20). on_time passes instruments=None (plan-01 default-ladder); venue-precision deferred to plan-05. UNIV-01 still Pending (remove=04, wiring=05)
-- [Phase ?]: [Phase 06]: 06-04: OrderTriggerSource.ADMISSION_LEAVING + AdmissionManager._enforce_leaving_symbol_admission wired FIRST (before direction) — audited-REJECTS a new entry for a symbol in Universe.leaving_symbols() while PASSING a sanctioned exit (SELL vs LONG / BUY vs SHORT); no-op with no universe/empty leaving-set (oracle-dark, D-01)
-- [Phase ?]: [Phase 06]: 06-04: UniverseHandler remove-policy consumer — orphan-and-track (mark_leaving, DEFER unsubscribe until flat; unsubscribe-now only when nothing held) vs force-close (emit opposite-side full-exit SignalEvent then unsubscribe) + on_fill detach-on-flat (unsubscribe+clear_leaving once flat). remove_policy on the live/poll-seam ctor NOT SystemConfig — oracle untouched (D-01/§8)
-- [Phase ?]: [Phase 06]: 06-04: remove-policy proven deterministically offline via remove_policy_harness — two synthetic symbols driven through LiveBarFeed.update (the OKX seam) settling force-close through the reused SimulatedExchange (FillEvent->PortfolioHandler.on_fill); plan-04 on_universe_update/on_fill seams direct-called against the REAL PortfolioHandler read model (route wiring is plan 05). UNIV-02 remove-half done
-- [Phase ?]: [Phase 06]: 06-05: _OKX_STREAM_SYMBOL un-hardcoded — live subscription set sourced from universe.members (warmup-before-subscribe per member); generalized ring-key vs window()-ticker assertion, ConfigurationError shape preserved (D-05)
-- [Phase ?]: [Phase 06]: 06-05: live-only UniverseHandler + poll-timer daemon (configurable cadence default 60s, control-plane TimeEvent(now UTC) only) + LIVE-ONLY _routes mutation on the live EventHandler's own dict — backtest _routes literal UNTOUCHED (RESEARCH §11.1); remove_policy + cadence on MonitoringSettings NOT PerformanceSettings (§8/D-01/D-02)
-- [Phase ?]: [Phase 06]: 06-05 milestone gate GREEN — oracle byte-exact (134/46189.87730727451), determinism identical, inertness green (universe_handler forbidden on backtest import), W1 14.5s -7.4% vs 15.7s baseline; UNIV-01 closed + human-observed live-demo dynamic DATA subscribe/unsubscribe on OKX demo (1 passed 127.85s, sandbox verified)
-- [Phase ?]: [Phase 07] 07-01: Readiness tri-state enum + four EventType members (UNIVERSE_POLL/STRATEGY_COMMAND/BARS_LOADED/BARS_LOAD_FAILED) + four frozen msgspec event structs + explicit-empty backtest _routes — additive-only, backtest-inert by construction (contracts-first; downstream 07-02..07 implement against these). StrategyCommandEvent add/remove_ticker factories (D-09); BarsLoadFailed.reason scrub discipline documented (T-05-27)
-- [Phase 07]: 07-02: Universe holds ONE TrackedInstrument record map (_entries) replacing the desync-prone _instruments map + _leaving set (D-02, WR-01 bug class); apply stops popping removed symbols (D-13 keep-until-flat), add-branch clobber-guarded (D-14), discard_instrument is the single atomic three-field teardown; construction members default READY (oracle-inert), apply-added PENDING; is_ready/mark_ready/mark_failed readiness surface (WR-02)
-- [Phase ?]: 07-03: split synchronous warmup into two WR-02 halves — non-emitting LiveBarFeed.absorb_warmup (silent ring/L absorb = _deliver minus _emit, D-03b/OQ1) + async OkxDataProvider.spawn_warmup (loop-native REST fetch via connector.spawn threadsafe -> ONE BarsLoaded bulk transport, or ONE scrubbed BarsLoadFailed reason=exception-TYPE-only T-05-27/V5). _build_bar promoted @staticmethod for the single canonical ClosedBar->Bar conversion (D-03a). Live-only, oracle byte-exact
-- [Phase 07]: 07-04: WR-02 readiness gate composed BEFORE strategy.is_ready in calculate_signals (None-guarded single O(1) universe.is_ready read, no allocation; backtest wires no universe so oracle byte-exact); update-before-gate kept so a PENDING symbol still warms (D-03c). on_bars_loaded warms concerned strategies via strategy.update with NO signals (D-03). on_strategy_command mutates .tickers idempotently (emptying-remove refused, non-empty invariant) then EMITS UniversePollEvent follow-on (D-11 queue-only, never calls UniverseHandler)
-- [Phase 07]: 07-05: on_time->on_poll consumes the dedicated UniversePollEvent (WR-06/D-06, off the shared TIME route); set_freeze_gate early-return freeze-in-place at the top of on_poll (WR-05/D-07, level-triggered self-heal, no replay); _PrecisionResolver + set_precision_resolver resolves added-symbol venue precision (WR-04/D-16, Universe stays connector-free, paper falls to _DEFAULT_* ladder). All 3 seams inert-by-default; route/predicate/resolver wiring is Plan 07
-- [Phase ?]: 07-08: PRIMARY WR-02 readiness admission gate (D-01) — _enforce_readiness_admission wired SECOND (after leaving, before direction) rejects a non-READY (PENDING/FAILED) symbol's unsized signal at admission even when it bypasses the strategy-loop SECONDARY check (07-04); sanctioned exit passes; oracle-inert (None-guard + construction members READY). ADMISSION_READINESS trigger source added
-- [Phase ?]: [Phase 07] 07-06: WR-02 warmup pipeline handler-side — add-branch spawns async provider.spawn_warmup (paper: synchronous feed.warmup + IMMEDIATE mark_ready, never PENDING) with per-symbol try isolation (D-04); on_bars_loaded absorb→mark_ready→subscribe (D-03b); on_bars_load_failed marks FAILED kept-in-membership retried-next-poll
-- [Phase ?]: [Phase 07] 07-06: WR-01 keep-until-flat finished — discard_instrument at exactly 2 final points (no-holder removal + on_fill detach-on-flat, D-13); StrategyDerivedSelectionModel reads get_strategies_universe() live each select (D-12/OP-SEAM) so ticker edits propagate
-- [Phase 07]: 07-10 (POST-CLOSEOUT gap-closure): CR-01 closed via Option B "unified monotonic idempotency" (Level 2). absorb_warmup reuses the EXISTING _last_delivered cursor (reject bar.time <= cursor before ring.append; == silent, < warns) — zero new feed state, cursor stays pd.Timestamp (de-pandas deferred). Strategy.update gains a per-symbol _last_bar_time cursor (raw datetime) rejecting bar.time <= last before ANY state mutation; cleared in reset()/_reset_ticker() so evaluate() replay still works. A CR-02 retry re-warm can no longer duplicate the ring, inflate indicators, or flip a symbol tradeable on corrupted state.
-- [Phase 07]: 07-10: Level-2 retry policy — on_poll cadence-gates FAILED re-warms to one per bar interval (_last_rewarm_at + to_timedelta(timeframe)); 3-strike consecutive-failure warn (_rewarm_fail_streak at both failure sites, reset on mark_ready success); NEVER auto-drop (Level 3 quarantine explicitly OUT). RED-first headline regression proved the corruption reachable pre-fix and unreachable after; oracle byte-exact (134 / 46189.87730727451), mypy --strict clean on the 3 modules, full unit 1752 + integration/e2e 228 green.
-- [Phase 07]: 07-10 deviation (Rule 1): the base Strategy has no self.logger (added a module-level bound logger); causal-guard tests fed a constant sentinel time=0 that the new monotonic guard rejected as duplicates — _Bar stub now auto-increments its tick (anchor value stays don't-care).
+Active program constraints live in PROJECT.md. v1.8 locks (design LR-00..LR-22): two-tier priority
+`EventBus` CONTROL>BUSINESS (LR-11); single-writer engine-thread contract (LR-12); handler-owns storage
+init (LR-13); `EngineContext` infra-only (LR-14); two registries execution-venue + data-provider (LR-17);
+connectors memoized `(venue, account_id)` (LR-17/LR-20); `SqlBackend→SqlEngine`, migrations→root (LR-18);
+`clOrdId→client_order_id` (LR-19); config at its owner's cardinality (LR-21); one `system_store` KV +
+`VenueStore` + `StrategyRegistryStore` (LR-22). Ten backlog TODOs fold in as CF-1..CF-10 across
+P1/P5/P6/P7/P8 (all live-only / backtest-dark).
 
 ### Pending Todos
 
-[From .planning/todos/pending/ — carried; both now in-scope for v1.7]
-
-- Live-start indicator backfill through the same `update(bar)` path (`live-backfill-through-update.md`)
-  — **now Phase 3 (FEED-03 / LX-09)**: REST warmup replayed one-by-one through `update(bar)`, no bulk
-  `warmup_from` fast-path.
-
-- Correct single-pass per-bar portfolio valuation (`single-pass-portfolio-valuation.md`) — deferred
-  v1.5, profile-first gated (future perf phase, NOT v1.7).
+Ten v1.7-carryforward TODOs are **folded into v1.8** as CF-1..CF-10 (set `resolves_phase` at milestone
+init; migrate to `todos/completed/` when the owning phase verifies): CF-1→P8 (aggregate breaker, HIGH,
+the one with teeth), CF-2/7→P7, CF-3/4/9→P5, CF-5→P8, CF-6/8→P1 (CF-8 also P7), CF-10→P6. Deliberately
+**not** folded (kept separate): `livebarfeed-depandas-time-model-datetime`, `mutable-instrument-refactor`,
+`margin-equity-double-counts-notional-wr01` (owner-gated), `unify-backtest-direct-bar-generation`
+(oracle-risky). `pair-strategy-live-reconfiguration` is folded into P10 (STRAT-03).
 
 ### Blockers/Concerns
 
-- **Confirm-flag / forming-bar risk (research Pitfall 1):** the single most likely source of
-  paper-parity failure — ccxt.pro does not surface OKX's `confirm` flag. The native escape hatch is
-  mandatory; produce the OKX native-vs-ccxt gap list at Phase 2 plan time before locking the design.
-
-- **ccxt returns floats everywhere (Pitfall 2):** every new connector price/amount/fee/balance must
-  route through `to_money` (= `Decimal(str(x))`); failure is invisible until reconciliation drift accrues.
-
-- **Wall-clock in business `time` is contagious (Pitfall 3):** existing `LiveTradingSystem` has multiple
-  `datetime.now(UTC)` usages; audit every new `datetime.now` on the live path before merge.
-
-- **Phase 5 reconciliation is the most under-specified area:** do not start coding without decisions on
-  auto-correct tolerance, halt-and-alert triggers, bracket parent/child restart, write-through boundary
-  (the v1.6 carried flag). Build a research sprint into Phase 5 planning.
-
-- **`filterwarnings=["error"]` + async tests:** unclosed ccxt.pro session/transport or unset
-  `asyncio_default_fixture_loop_scope` fails the whole suite. Use mocked/recorded connectors; never
-  relax the global filter (`pytest-asyncio` configured in Phase 2).
-
-- **Hot-path inertness (carried from v1.6):** the live machinery must add zero backtest hot-path cost —
-  the backtest path imports no async/connector code. W1/W2 within v1.5 ±5% is the proof, every phase.
-
+- **P6 `UniverseWiring` = the highest oracle-risk seam** (analogous to v1.2 MOD-01): move as one intact
+  unit incl. the WR-03 desync assert; byte-exact oracle + determinism double-run as a per-PLAN gate.
+- **Inertness regression** is the recurring failure mode: no eager import via a barrel re-export, no
+  non-lazy `SqlSettings`, no registry importing concretions at registration. `test_okx_inertness.py` is
+  the P5 acceptance gate (extended register-vs-build for P1/P2/P4/P5).
+- **CF-1 must ACTUALLY TRIP** (P8 hard acceptance criterion): a breaker "green with zero settlements" or
+  one reintroducing the WR-06 error→error livelock is a false-green failure.
+- **CF-2 threading contract** (P7): `backfill_on_resume` must be loop-native (connector loop), never a
+  second concurrent engine-thread ring writer — assert no engine-thread path reaches it.
+- **Alembic chain divergence** (P4): relocation + 3-store chain must stay single-head with a
+  create_all/migration parity test (the merged storage-schema phase owns the full-chain gate).
 - **Indentation hazard:** handler modules use tabs; `config/`, `core/`, `price_handler/feed/`,
-  `itrader/storage/`, events package use 4 spaces. New files MUST match the sibling — a mixed-indent tab
-  file fails to import.
-
+  `itrader/storage/`, events package use 4 spaces. Match the sibling file — never normalize.
+- **Zero new dependency / no poetry change** anywhere in P1–P12 (adding a lib regresses inertness).
 - New requirements discovered during execution are added to REQUIREMENTS.md with traceability, not
   silently folded into a running phase.
 
-### Quick Tasks Completed
-
-| # | Description | Date | Commit | Directory |
-|---|-------------|------|--------|-----------|
-| 260701-l33 | Add `smoke` pytest marker (register + tag 3 files + `make test-smoke` + tagging rule) | 2026-07-01 | 40c13992 | [260701-l33-add-smoke-marker](./quick/260701-l33-add-smoke-marker/) |
-| 260702-m8d | Apply Phase 04 code-review fix-now bucket (IN-01..04, WR-05, WR-03, WR-02 window guard) + sync stale REQUIREMENTS.md | 2026-07-02 | 148836a6 | [260702-m8d-apply-phase-04-code-review-fix-now-bucke](./quick/260702-m8d-apply-phase-04-code-review-fix-now-bucke/) |
-| 260703-030 | Rewire live operational store onto unified SqlSettings, drop legacy SYSTEM_DB_URL | 2026-07-02 | 8947cc27 | [260703-030-rewire-live-operational-store-onto-unifi](./quick/260703-030-rewire-live-operational-store-onto-unifi/) |
-| fast | Make OKX connector hostname configurable (OKX_HOSTNAME) for EEA regional entity — fixes 50119 on eea.okx.com keys | 2026-07-02 | 3790990f | — (fast, inline) |
-| fast | Fix OKX backfill timeframe: pass unified "1d" (not OKX "1D") to ccxt fetch_ohlcv — unblocks LiveTradingSystem.start() warmup | 2026-07-02 | d6d225b6 | — (fast, inline) |
-| 260703-bza | Add OKX_REGION config deriving REST+WS hosts (global/eea); wire ws_hostname through connector + native candle socket — enables EEA demo (wseeapap.okx.com) | 2026-07-03 | b5826909 | [260703-bza-add-okx-region-config-deriving-rest-ws-h](./quick/260703-bza-add-okx-region-config-deriving-rest-ws-h/) |
-| fast | Hardcode OKX live pair BTC/USDT->BTC/USDC (EEA restricts USDT/MiCA, sCode 51155); universe phase will make it configurable | 2026-07-03 | f51fc34a | — (fast, inline) |
-| 260703-dob | Add OKX live-connectivity integration test + new `live` pytest marker (creds-free public reachability + creds-gated demo auth via OkxConnector); fence default `make test`/`test-integration` with `not live`, add `make test-live` | 2026-07-03 | b97690d5 | [260703-dob-okx-live-connectivity-marker](./quick/260703-dob-okx-live-connectivity-marker/) |
-| fast | Remove OKX cred diagnostic script + diagnose-okx make target (redundant — test_okx_connectivity.py auth test now verifies creds via OkxConnector) | 2026-07-03 | 8f7acd0c | — (fast, inline) |
-| 260703-hl5 | Persist `venue_trade_id` on the transactions table (tail of CR-01 fill-dedup): nullable column + chained Alembic migration + both sql_storage mappers + Postgres round-trip test | 2026-07-03 | b142cbc5 | [260703-hl5-persist-venue-trade-id-on-the-transactio](./quick/260703-hl5-persist-venue-trade-id-on-the-transactio/) |
-| 260705-fqe | Adapt e2e OKX sandbox recon test to run against a non-flat demo account (seed engine position to live venue balance; assert BUY delta) — unblocks online settlement proof on OKX-seeded ~1 BTC EEA account | 2026-07-05 | f2070431 | [260705-fqe-adapt-e2e-okx-sandbox-recon-test-to-run-](./quick/260705-fqe-adapt-e2e-okx-sandbox-recon-test-to-run-/) |
-| fast | Make ARCH-3 capture best-effort + fix OKX fetch_my_trades param (limit=100, no paginate — sCode 51000) — online settlement proof now fully GREEN (3/3) | 2026-07-05 | 81fc39aa | — (fast, inline) |
-| 260705-m3m | Test-infra: session-autouse guard clears dev-DB env so no test reaches operational Postgres at localhost:5544 + one shared session testcontainers Postgres for live-path DB tests to opt into (D-11 skip-safe, single-container); prereq for 05.2 durable-SQL tests | 2026-07-05 | 2f43faec | [260705-m3m-add-a-session-autouse-guard-in-tests-con](./quick/260705-m3m-add-a-session-autouse-guard-in-tests-con/) |
-| 260706-l48 | Apply Phase 06 mechanical code-review fixes: CR-01 (okx `unsubscribe` clears stale `_streams_down`/`_reconnect_attempts` supervisor state — un-wedges live resume gate) + WR-03 (`universe_poll_cadence_s` bounded `gt=0.0`). WR-01/02/04/05/06 routed to Phase 7. | 2026-07-06 | e08424d2 | [260706-l48-apply-mechanical-code-review-fixes-cr-01](./quick/260706-l48-apply-mechanical-code-review-fixes-cr-01/) |
-| 260707-iy6 | Apply 07-REVIEW CR-01 gap-closure fixes: WR-01 (`absorb_warmup` warns on genuine revision, silent on byte-identical dup via `_same_ohlcv`) + WR-02 (off-grid rejection protecting the shared `_last_delivered` cursor) + IN-01/IN-02 docstrings. Oracle byte-exact, mypy clean. | 2026-07-07 | 8eb66f73 | [260707-iy6-fix-07-review-cr-01-gap-closure-findings](./quick/260707-iy6-fix-07-review-cr-01-gap-closure-findings/) |
-| Phase 03 P01 | 3min | 2 tasks | 4 files |
-| Phase 03 P02 | 9min | 2 tasks | 2 files |
-| Phase 03 P03 | 3min | 1 tasks | 2 files |
-| Phase 03 P04 | 14min | 2 tasks | 4 files |
-| Phase 04 P01 | 6min | 2 tasks | 2 files |
-| Phase 04 P02 | 8min | 2 tasks | 1 files |
-| Phase 04 P03 | 6min | 2 tasks | 2 files |
-| Phase Phase 04 P04 P04 | 5min | 2 tasks | 2 files |
-| Phase 05 P10 | 20min | 3 tasks | 3 files |
-| Phase 05 P11 | ~15min | 2 tasks | 6 files |
-| Phase 05.1 P01 | 18min | 3 tasks | 4 files |
-| Phase 05.1 P02 | 16min | 3 tasks | 3 files |
-| Phase 05.1 P03 | 17min | 3 tasks | 3 files |
-| Phase 05.1 P04 | 15min | 2 tasks | 4 files |
-| Phase 05.1 P05 | 35min | 2 tasks | 3 files |
-| Phase 05.1 P06 | 90min | 2 tasks | 4 files |
-| Phase 05.1 P07 | 12min | 1 tasks | 2 files |
-| Phase 05.1 P08 | 20min | 2 tasks | 3 files |
-| Phase 05.2 P01 | 18min | 2 tasks | 10 files |
-| Phase 05.2 P02 | 12min | 2 tasks | 2 files |
-| Phase 05.2 P03 | 15min | 2 tasks | 4 files |
-| Phase 05.2 P04 | 12min | 2 tasks | 7 files |
-| Phase 05.2 P05 | 20min | 2 tasks | 8 files |
-| Phase 05.2 P06 | 22min | 2 tasks | 6 files |
-| Phase 05.3 P12 | 12min | 2 tasks | 6 files |
-| Phase 06 P01 | 22min | 2 tasks | 7 files |
-| Phase 06 P02 | 9min | 2 tasks | 4 files |
-| Phase 06 P03 | 6min | 2 tasks | 5 files |
-| Phase 06 P04 | 20min | 3 tasks | 8 files |
-| Phase 06 P05 | 35min | 3 tasks | 4 files |
-| Phase 06 P05 | 35min | 3 tasks | 4 files |
-| Phase 07 P07-01 | 3min | 3 tasks | 7 files |
-| Phase 07 P07-02 | 6min | 2 tasks | 3 files |
-| Phase 07 P07-03 | 10min | 2 tasks | 4 files |
-| Phase 07 P07-04 | 5min | 3 tasks | 2 files |
-| Phase 07 P07-05 | 5min | 2 tasks | 3 files |
-| Phase 07 P07-08 | 4min | 1 tasks | 3 files |
-| Phase 07 P07-06 | 12min | 3 tasks | 5 files |
-| Phase 07 P07-10 | 11min | 4 tasks | 8 files |
-
 ## Deferred Items
 
-Program-level items deferred across milestones. The four v1.7-promoted rows are now **DELIVERED**;
-the v1.7-close carry-forward (14 pending todos, acknowledged at close 2026-07-07) follows below.
+Program-level items carried across milestones (v1.7-close carry-forward + v2 platform seams). The
+substantive owner-gated item is `margin-equity-double-counts-notional-wr01`.
 
 | Category | Item | Status | Target |
 |----------|------|--------|--------|
-| Live drive | Persistence driven by a real live feed + venue reconciliation | ✅ **Delivered v1.7** (Phase 5, RECON-04/05) | — |
-| Live account | `Account` abstraction + reconciliation mirror (ACCT) | ✅ **Delivered v1.7** (Phase 1 + Phase 5 `VenueAccount`) | — |
-| Live coverage | `LiveTradingSystem` test coverage (FL-13) | ✅ **Delivered v1.7** (COV-01, Phase 4→5) | — |
-| Cleanup | `Portfolio.user_id` removal (app-layer multi-tenancy) | ✅ **Delivered v1.7** (ACCT-04, Phase 1) | — |
-| D-screener | Production screener / ranking / rebalance loop | Deferred (v1.7 shipped only the lean poll seam, Phase 6/7) | v2 |
-| Optimization | Optuna sampler + sweep loop (OPT-01) — v1.6 ships the FK-ready substrate only | Deferred | v2 |
-| Turso/libSQL | `sqlalchemy-libsql` opt-in backend (TURSO-01) — interface stays Turso-ready | Deferred | v2 (post-beta + measured) |
+| Owner-gated defect | `margin-equity-double-counts-notional-wr01` — dark on the all-spot golden; a fix moves 6 owner-frozen goldens → needs external cross-validation before any live margin/leverage consumer reads margin equity | ⚠ Owner-gated | next milestone (pre-margin/live) |
+| v1.8 deferred seam | Multi-provider feed-router; single-connector-multi-`account_id`; shared-`account_id` risk allocator; config audit table; errors-history table; stats-history split | Marked (spec §14) | v2 / FastAPI-era |
+| Downstream consumer | FastAPI application layer / routes / ASGI (LR-01) — v1.8 makes the engine *interfacable* only | Deferred | post-v1.8 milestone |
+| Separate refactors | `livebarfeed-depandas-time-model-datetime`, `mutable-instrument-refactor`, `unify-backtest-direct-bar-generation` | Deferred (not folded) | future milestones |
+| D-screener | Production screener / ranking / rebalance loop | Deferred | v2 |
 | Perp realism (Phase B) | FUND-01..04 (funding accrual, mark-price liq, funding pipeline, freqtrade oracle) | Deferred | v2 |
-| Live data fidelity | TRADE-01 trade-aggregation bar source (LX-12; klines now, trades later) | Deferred | v2 |
-| Perf (v1.5) | Correct single-pass per-bar portfolio valuation (profile-first gated) | Deferred | future perf phase |
-| Perf (v1.5) | Nyquist VALIDATION.md gaps (advisory; oracle + A/B perf gate are the real lock) | Deferred | optional `/gsd:validate-phase` backfill |
-| Deferred perf (v2) | PERF-09 / PERF-10 (strategy-level dedup, O(n²)-in-symbol guard) | Deferred | future (large universes) |
+| Optimization | Optuna sampler + sweep loop (OPT-01) — v1.6 shipped the FK-ready substrate only | Deferred | v2 |
+| Turso/libSQL | `sqlalchemy-libsql` opt-in backend — interface stays Turso-ready | Deferred | v2 (post-beta) |
+| Perf (v1.5) | Single-pass per-bar portfolio valuation (profile-first gated); PERF-09/PERF-10; advisory Nyquist VALIDATION gaps | Deferred | future perf phase |
 | D-multiasset | Multi-currency accounting, trading calendars, corporate actions | Deferred | indefinite (crypto-first) |
-
-**v1.7 close carry-forward (14 pending todos, acknowledged 2026-07-07 — indexed by
-`todos/pending/v17-residual-carryforward.md`; none block the paper-spot DoD):**
-
-| Item (`todos/pending/`) | Class | Status | Target |
-|-------------------------|-------|--------|--------|
-| `margin-equity-double-counts-notional-wr01` | Real defect (01-REVIEW WR-01) | ⚠ **Owner-gated** — dark on the all-spot golden (degenerates to correct); a fix moves 6 owner-frozen goldens → needs external cross-validation before any live margin/leverage/short consumer reads margin equity | next milestone (pre-margin/live) |
-| `off-vocabulary-halt-reason-baseline-residual-wr04` | Minor (05.1-REVIEW WR-04) | Deferred by owner decision → the next-milestone `live_trading_system.py` full refactor + halt-vocabulary review (a typed `HaltReason` enum, owned there, not a pre-close patch) | next milestone |
-| `pair-strategy-live-reconfiguration` | Next-milestone feature (07 CR-01) | Deferred by design — v1.7 shipped a refusal guard; atomic ordered-pair leg swap is future work | next milestone |
-| 11× refactor/feature todos (multi-timeframe consolidator, `Instrument` split, deep shared-bar history, de-pandas LiveBarFeed time model, single-pass valuation, synthetic-spread instrument, native tagged MTF, OKX markets-map freshness, unify backtest bar-gen, warmup-depth K seam, …) | Future features/refactors | Rolling backlog | future milestones |
-
-v1.0–v1.6 milestone-close acknowledgments are recorded in the respective MILESTONE-AUDIT.md files under
-`milestones/`. **v1.7 audit (`passed`, no blockers, `milestones/v1.7-MILESTONE-AUDIT.md`):** 32/32
-requirements satisfied, 10/10 phases passed, 9/9 seams wired, 4/4 E2E flows; the 18-item pre-close
-open-artifact scan resolved to the 14 carry-forward todos above (10 quick-task false positives cleared
-with completion markers, 2 CONF-B debug captures + 1 stale UAT gap re-stamped to their verified GREEN
-status). The single substantive open item is `margin-equity-double-counts-notional-wr01` (owner-gated,
-oracle-dark).
-| Phase 01 P01 | 3min | 3 tasks | 5 files |
-| Phase 01 P04 | 2min | 2 tasks | 3 files |
-| Phase 01 P02 | 4min | 2 tasks | 2 files |
-| Phase 1 P3 | 10 | 3 tasks | 11 files |
-| Phase 01 P03b | 26min | 3 tasks | 38 files |
-| Phase 01 P03c | 5min | 2 tasks | 59 files |
-| Phase 01 P05 | 3min | 2 tasks | 1 files |
-| Phase 02 P01 | 7min | 3 tasks | 8 files |
-| Phase 02 P02 | 12min | 2 tasks | 3 files |
-| Phase 02 P03 | 9min | 2 tasks | 2 files |
-| Phase 02 P04 | 18min | 2 tasks | 2 files |
-| Phase 02 P05 | 9min | 3 tasks | 4 files |
 
 ## Bookkeeping
 
-- **At v1.6 close (done 2026-06-30):** v1.6 phase dirs `git mv`'d to `milestones/v1.6-phases/`;
-  `ROADMAP`/`REQUIREMENTS`/`MILESTONE-AUDIT` archived as `milestones/v1.6-*`. Only the `999.3` backlog
-  seed dir remains in `.planning/phases/`, so the new v1.7 `01-*..06-*` dirs will not collide.
-
-- **At v1.7 close (done 2026-07-07):** all 10 v1.7 phase dirs (`01-*..07-*` + `05.1/05.2/05.3-*`)
-  `git mv`'d to `milestones/v1.7-phases/`; `ROADMAP`/`REQUIREMENTS`/`MILESTONE-AUDIT` archived as
-  `milestones/v1.7-*`; `.planning/phases/` is now empty (no `999.3` seed dir remained). Pre-close
-  open-artifact scan resolved to 14 carry-forward todos (see Deferred Items). `REQUIREMENTS.md` removed
-  via `git rm` (fresh for the next milestone). Git tag `v1.7` NOT created (owner deferred tagging to a
-  manual step).
+- **At v1.7 close (done 2026-07-07):** all v1.7 phase dirs `git mv`'d to `milestones/v1.7-phases/`;
+  ROADMAP/REQUIREMENTS/MILESTONE-AUDIT archived as `milestones/v1.7-*`; `.planning/phases/` is empty
+  (no `999.3` seed dir remained). The new v1.8 `01-*..12-*` dirs will not collide (`phase_dir_count=0`).
+- Git tag `v1.7` NOT created (owner deferred tagging to a manual step).
 
 ## Session Continuity
 
-Last session: 2026-07-07 — v1.7 milestone close
-Stopped at: Milestone v1.7 completed and archived (PROJECT.md evolved, ROADMAP collapsed, MILESTONES entry, retrospective updated)
+Last session: 2026-07-09 — v1.8 roadmap revision (13→12 phases)
+Stopped at: ROADMAP.md revised (12 phases, merged storage-schema P4, all downstream renumbered −1, goals +
+success criteria + dependencies + 64/64 coverage); STATE.md refreshed for 12 phases; REQUIREMENTS.md
+traceability + category tags + gates renumbered.
 Resume file: None
-Carried todo: 14 pending todos in `todos/pending/` (carry-forward backlog — `v17-residual-carryforward.md` is the index; the only substantive open item is `margin-equity-double-counts-notional-wr01`, owner-gated)
+Carried todo: 14 pending todos in `todos/pending/` (10 fold into v1.8 as CF-1..CF-10; `v17-residual-carryforward.md`
+is the index; the substantive open item is `margin-equity-double-counts-notional-wr01`, owner-gated).
 
 ## Operator Next Steps
 
-- Start the next milestone with `/gsd:new-milestone` (owner's stated direction: `live_trading_system.py`
-  full refactor + halt-reason storage/vocabulary review, and a FastAPI application-layer / control-plane).
-
-- Optionally create the git tag: `git tag -a v1.7 -m "v1.7 Live Trading Readiness"` (deferred at close).
+- `/gsd:plan-phase 1` (Config Centralization) — or plan **P1 and P2 in parallel** (both dependency-free).
+- At milestone init, set each folded TODO's front-matter `resolves_phase: P#` + `status: scheduled` so it
+  is not double-tracked against the live backlog (CF-1..CF-10; see spec §18).
 - Before any live margin/leverage consumer: adjudicate `margin-equity-double-counts-notional-wr01`
   (owner-gated, oracle-dark) with external cross-validation.

--- a/.planning/research/ARCHITECTURE.md
+++ b/.planning/research/ARCHITECTURE.md
@@ -1,549 +1,330 @@
-# Architecture Research — v1.7 Live Trading Readiness
+# Architecture Research — v1.8 Live System Refactor Integration Map
 
-> ## ⚠ Superseded framing — read `phases/02-okx-connector/02-CONTEXT.md` first
->
-> The Phase-2 discussion (2026-07-01) revised the live architecture; this snapshot
-> predates it and still describes the **two-arm `LiveConnector`** model (the §2
-> `LiveConnector(Protocol)` code block, the §4 `PaperConnector` section, and the
-> parity-spine table below all reflect the OLD shape). **Superseded framings**
-> (everything else — reuse assets, matching-core reuse, pitfalls — remains valid):
-> - Connector is a **session/transport primitive**, not a two-arm venue object; the data/order/account arms are **domain adapters** (`OkxDataProvider` in `price_handler/providers/` / `OkxExchange` in `execution_handler/exchanges/` impl `AbstractExchange` / `VenueAccount`), **injected** with the session, never cross-domain-imported.
-> - The **`OkxExchange` adapter emits `FillEvent`** — the connector owns no operations and emits no domain events.
-> - Paper needs **no connector**: the paper execution adapter implements **`AbstractExchange`** (not `LiveConnector`), composing `MatchingEngine` + `apply_costs` + `SimulatedAccount`.
-> - `OkxSettings` reads **plain `OKX_API_*` (no env prefix)** — not `ITRADER_OKX_*`.
->
-> See design-doc LX-05/LX-06 revision notes and `02-CONTEXT.md` D-01..D-10.
+**Domain:** Brownfield decomposition of a 2,171-line `LiveTradingSystem` God object into a factory + shared `compose_engine` + `LiveRunner` + focused controllers, around an existing event-driven single-queue engine (Python 3.13).
+**Researched:** 2026-07-09
+**Confidence:** HIGH — every integration point below is traced against the real existing files (`compose.py`, `full_event_handler.py`, `backtest_runner.py`, `portfolio_handler.py`, `order_handler.py`, `storage/backend.py`). The design spec (`docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md`) locks the topology; this doc validates how it lands on the codebase.
 
-**Domain:** Live-trading integration onto an event-driven backtest engine (iTrader, paper-first OKX)
-**Researched:** 2026-06-30
-**Confidence:** HIGH (existing code mapped directly; locked design `2026-06-30-live-trading-milestone-design.md` LX-01..LX-15; one MEDIUM external grounding — OKX confirm-flag in ccxt.pro)
+**Two gates govern EVERY foundational seam:**
+- **ORACLE (LR-02):** the SMA_MACD backtest run stays byte-exact (`134 trades / final_equity 46189.87730727451`). Blocking for P1–P4 and P7's `UniverseWiring`.
+- **INERTNESS:** `tests/integration/test_okx_inertness.py` stays green — importing the backtest composition root pulls no `ccxt.pro`, no async connector, no Postgres `SqlSettings`.
 
-> Scope: how the NEW live components integrate WITHIN the locked decisions. The
-> existing event core, handlers, BarFeed ABC, MatchingEngine, and v1.6 store are
-> NOT re-researched — they are the integration surface. Every recommendation is
-> grounded in a real file/class. "New" vs "modified" is called out per component.
+Every seam is tagged `[ORACLE]` and/or `[INERT]` where it touches a gate.
 
 ---
 
-## Standard Architecture
+## Standard Architecture — target topology (LR-10)
 
-### Target system overview (paper path = the DoD)
+The v1.8 end-state mirrors the already-proven backtest 4-layer split (`SystemSpec → factory → shared compose_engine → Runner → thin facade`) onto the live path:
 
 ```
 ┌──────────────────────────────────────────────────────────────────────┐
-│  FastAPI app layer (future; user_id -> portfolio_id mapping)          │
-│   reads STATUS/RESULTS from Postgres; writes COMMANDS to a channel    │
-└───────────────┬──────────────────────────────────────────────────────┘
-                │ Postgres LISTEN/NOTIFY (command + status channel)
-                ▼
-┌──────────────────────────────────────────────────────────────────────┐
-│  LiveTradingSystem worker process  (1 worker : 1 portfolio : 1 acct)  │
-│                                                                        │
-│   ┌────────────────────────┐      enqueue (thread-safe put)           │
-│   │ Connector thread        │ ───────────────────────────────┐        │
-│   │  (own asyncio loop)      │   BarEvent / FillEvent /        │        │
-│   │  OkxConnector|Paper      │   balance+position updates      ▼        │
-│   │  watch_ohlcv / fills     │                         ┌──────────────┐│
-│   └────────────────────────┘                          │ global_queue ││
-│                                                        │ (queue.Queue)││
-│   ┌─────────────────────────────────────────┐         └──────┬───────┘│
-│   │ ENGINE THREAD (single writer, D-19)      │ ◄──────────────┘        │
-│   │  EventHandler._routes dispatch           │  get()+_dispatch        │
-│   │   BAR -> LiveBarFeed.window / strategies │                         │
-│   │        -> PaperConnector.on_bar (fills)  │                         │
-│   │   SIGNAL -> OrderHandler                  │                         │
-│   │   FILL  -> PortfolioHandler / OrderHandler│                        │
-│   │  Portfolio -> Account (balance/margin)   │                         │
-│   └─────────────────────────────────────────┘                         │
-│                       │ write-through (v1.6 operational store)         │
-└───────────────────────┼───────────────────────────────────────────────┘
-                        ▼
-              ┌────────────────────────┐
-              │ Postgres (system of    │  orders / portfolio_state /
-              │ record, v1.6)          │  signals + command/status
-              └────────────────────────┘
+│  COMPOSITION ROOT (mode-specific factories)                            │
+│  ┌────────────────────────┐        ┌──────────────────────────────┐   │
+│  │ build_backtest_system  │        │ build_live_system   [NEW P7]  │   │
+│  │ (exists)               │        │ reads SystemConfig; builds    │   │
+│  │ env='backtest'         │        │ ONE sql_engine; resolves venue│   │
+│  │ sql_engine=None        │        │ plugin(s); builds stores      │   │
+│  │ bus=FifoEventBus       │        │ bus=PriorityEventBus          │   │
+│  └───────────┬────────────┘        └───────────────┬──────────────┘   │
+│              │      builds EngineContext(bus,config,env,sql_engine)    │
+│              └───────────────┬───────────────────────┘                 │
+├──────────────────────────────┼─────────────────────────────────────────┤
+│  SHARED SEAM                  ▼                                         │
+│  compose_engine(ctx, spec)  [MODIFIED P2/P3 — signature change]        │
+│  builds the mode-agnostic component graph; handlers own their storage  │
+│  → returns Engine holder                                               │
+├──────────────────────────────┬─────────────────────────────────────────┤
+│  RUN DRIVERS                  │                                         │
+│  ┌────────────────────────┐   │   ┌──────────────────────────────┐     │
+│  │ BacktestRunner (exists)│   │   │ LiveRunner        [NEW P7]    │     │
+│  │ sync fail-fast for-loop│   │   │ drain loop bus.get(timeout)  │     │
+│  │ bus.get_nowait()       │   │   │ + injected ErrorPolicy (P9)  │     │
+│  └────────────────────────┘   │   │ + WorkerSupervisor           │     │
+│                               │   └──────────────────────────────┘     │
+├──────────────────────────────┼─────────────────────────────────────────┤
+│  FACADE                       │                                         │
+│  TradingSystem (thin, exists) │   LiveTradingSystem (SHRUNK ~200 lines) │
+│                               │   lifecycle + status latch delegation   │
+├──────────────────────────────┴─────────────────────────────────────────┤
+│  ONE EventHandler (single, data-driven — NO subclass, LR-16)           │
+│  routes = base literal + LiveRouteRegistrar additions [MODIFIED P7]     │
+│  backtest → base routes only (explicit-empty live slots = inertness)   │
+├─────────────────────────────────────────────────────────────────────────┤
+│  LIVE-ONLY CONTROLLERS [NEW P6-P12]                                     │
+│  VenueRegistry+bundle · SafetyController · StreamRecoveryHandler ·       │
+│  ReconciliationCoordinator · SessionInitializer · ErrorHandler ·        │
+│  UniverseHandler(proper init) · new durable stores                      │
+└─────────────────────────────────────────────────────────────────────────┘
 ```
 
-The whole live machinery is **inert on the backtest hot path**: backtest keeps
-`TimeGenerator` -> `BacktestBarFeed.generate_bar_event` -> `SimulatedExchange`,
-and `Portfolio` -> `SimulatedAccount` computes the same numbers the oracle froze.
-
-### The parity spine (left column shared by paper)
-
-| World | Time source | Account | Execution |
-|---|---|---|---|
-| Backtest | `TimeGenerator` (pinned grid) | `SimulatedAccount` (computes) | `SimulatedExchange` (`MatchingEngine`) |
-| Paper (live feed) | closed-bar arrival | `SimulatedAccount` (computes) | `PaperConnector` (reuses `MatchingEngine`) |
-| Live real | closed-bar arrival | `VenueAccount` (caches+reconciles) | `OkxConnector` |
-
-Paper shares the backtest's **Account** computation — that is the mechanism that
-makes the paper-parity gate (LX-11) hold.
+**The two loops + the deleted third mechanism (§4c):** the connector asyncio loop (own daemon thread, `ccxt.pro` streaming) and the engine thread (`LiveRunner` drain) both stay; **the queue is the bulkhead**. The `threading.Event` flag side-channel (`_pending_stream_resume`, `_pending_connector_halt`, `_maybe_*` pollers, the `queue.Empty`-branch polling) is **deleted** — replaced by CONTROL-plane events that wake `bus.get(timeout)` naturally.
 
 ---
 
-## 1. Account abstraction extraction (Phase 1) — concrete layering
+## Component Responsibilities — NEW vs MODIFIED vs UNCHANGED
 
-### Where balance/margin truth lives TODAY (the smell)
+| Component | Status | Owns / Change | Gate | Phase |
+|-----------|--------|---------------|------|-------|
+| `EventBus` Protocol + `FifoEventBus` / `PriorityEventBus` (`events_handler/bus.py`) | **NEW** | tiered `.put()` routing; drop-in for `queue.Queue` surface | `[INERT]` Fifo pulls nothing heavy | P2 |
+| `EngineContext` (`bus, config, environment, sql_engine`) | **NEW** | frozen infra carrier, threaded once into `compose_engine` | `[INERT]` `sql_engine=None` on backtest | P3 |
+| `compose_engine` | **MODIFIED** | signature `(ctx, spec)`; stops creating the queue; reads `ctx.bus`; handlers own storage; reads `.storage` back | `[ORACLE]` backtest graph byte-identical | P2, P3 |
+| `Engine` holder | **MODIFIED** | `global_queue` field → `bus` reference | `[ORACLE]` | P2/P3 |
+| `EventHandler` | **MODIFIED** | ctor takes bus; routes = base literal + injected `LiveRouteRegistrar` additions; `ErrorPolicy` injected (P9) | `[ORACLE]` backtest base routes only | P2/P7/P9 |
+| `BacktestRunner` | **MODIFIED** | `engine.global_queue.put` → `engine.bus.put`; `UniverseWiring` call extracted | `[ORACLE]` | P3, P7 |
+| `OrderHandler` / `StrategiesHandler` | **MODIFIED** | adopt `PortfolioHandler`'s `environment`/`sql_engine`/`storage=` shape; expose `.storage` read-back | `[ORACLE]` in-memory same-instance | P3 |
+| `SqlBackend → SqlEngine` (`storage/backend.py → engine.py`) | **MODIFIED** | mechanical rename; migrations → project root | `[INERT]` lazy | P4 |
+| `SystemStore` / `VenueStore` / `StrategyRegistryStore` | **NEW** | durable KV + cardinality-N tables; `HaltRecordStore` template | `[INERT]` live-only, in-memory fallback | P5 |
+| `ExecutionVenueRegistry` + `DataProviderRegistry` + `VenuePlugin`/`VenueBundle` | **NEW** | 4-collaborator venue bundle; kills every `if self.exchange==` | `[INERT]` lazy-import concretions in `build_bundle` | P6 |
+| `LiveDataProvider` Protocol + `BaseLiveDataProvider` | **NEW** | formal provider contract; no-op optional seams | — | P6 |
+| shared `StreamSupervisor` | **NEW** | collapses triplicated `_run_stream_supervisor` | — | P6 |
+| `LiveRunner` | **NEW** | replaces `_event_processing_loop`; drain + workers + ErrorPolicy | — | P7 |
+| `build_live_system` factory | **NEW** | live composition root | `[INERT]` all SQL/ccxt imports lazy here | P7 |
+| `SessionInitializer` + shared `UniverseWiring` | **NEW (extract)** | universe/route wiring; `UniverseWiring` shared with backtest | `[ORACLE]` pure code-motion | P7 |
+| `LiveRouteRegistrar` | **NEW** | declarative live route composition (no subclass, no runtime mutation) | `[ORACLE]` backtest gets none | P7 |
+| `UniverseHandler` | **MODIFIED** | first-class ctor at live root; zero OKX coupling via `set_venue_metadata` | `[INERT]` routes explicit-empty on backtest | P7 |
+| `StrategyWarmupConsumer` (rehomed `_LiveWarmupConsumer`) | **MODIFIED (rehome)** | `price_handler/feed/cache_registration.py`; sized `max(warmup)` | — | P7 |
+| `SafetyController` | **NEW (extract)** | status latch, halt/pause, deferred-protective queue, dispatch gate | — | P8 |
+| `StreamRecoveryHandler` | **NEW (extract)** | reconnect resume I/O on engine thread | — | P8 |
+| `ReconciliationCoordinator` | **NEW (extract)** | rehydrate → reconcile → baseline guard; iterates portfolios | — | P8 |
+| CONTROL routes (`STREAM_STATE`/`CONNECTOR_FATAL`/`CONFIG_UPDATE`) | **NEW** | flag machinery → events | — | P8/P10 |
+| `ErrorPolicy` + `ErrorHandler` + CF-1 circuit breaker | **NEW (extract+add)** | injected failure policy; formalized ERROR consumer; aggregate tripwire | `[ORACLE]` backtest fail-fast identical | P9 |
 
-| Concern | Current home | File:symbol |
-|---|---|---|
-| Cash balance (`_balance`), reservations, locked margin | `CashManager` (owned by `Portfolio`) | `cash/cash_manager.py` |
-| `Portfolio.cash` read | property -> `cash_manager.balance` | `portfolio.py:199` |
-| Spot settlement cash effects | `Portfolio._process_transaction_spot` | `portfolio.py:308` |
-| Margin lock-and-settle cash effects | `Portfolio._process_transaction_margin` | `portfolio.py:391` |
-| Short borrow carry -> cash | `Portfolio._accrue_short_carry` | `portfolio.py:730` |
-| `available_cash` / `reserve` / `release` | `PortfolioHandler` (delegating to CashManager) | `portfolio_handler.py:260/276/282` |
-| `maintenance_margin` / `margin_ratio` | **`PortfolioHandler`** (mis-housed) | `portfolio_handler.py:339/374` |
-| Isolated-liq math (`_isolated_liq_price`, `_is_breached`, `_liquidation_penalty`, `_liq_inputs`) | **`PortfolioHandler`** (mis-housed) | `portfolio_handler.py:399–460` |
-| Liquidation engine (`_run_liquidation_pass`, `_collect_breaches_over_prices`, `_liquidate_position`) | **`PortfolioHandler`** (mixes truth + queue I/O) | `portfolio_handler.py:462–651` |
-
-### Target layering
-
-```
-Account (ABC)                      owns BALANCE / MARGIN TRUTH + decisions
-├── CashAccount    → SimulatedCashAccount    | VenueCashAccount   (interface-only P1)
-└── MarginAccount  → SimulatedMarginAccount  | VenueMarginAccount (interface-only P1)
-       (N+2 computed liq model)                (caches venue balance/margin)
-```
-
-- **`Account` (ABC)** — the truth surface that the `PortfolioReadModel` Protocol
-  already names: `balance`/`available_cash`, `reserve`/`release`, `maintenance_margin`,
-  `margin_ratio`. NEW abstraction, but the *Protocol contract already exists*
-  (`core/portfolio_read_model.py`) — Phase 1 moves the implementation behind it,
-  the seam stays. This is the single most important integration fact: **the order
-  domain already reads through `PortfolioReadModel`, so re-homing the truth does
-  not ripple into `OrderManager`/validator** (mypy-enforced structural conformance).
-- **`SimulatedCashAccount`** ≈ today's `CashManager` verbatim (`_balance`,
-  reservations, locked-margin, `apply_fill_cash_flow`, `assert_funds_invariant`,
-  `assert_lock_fits_buying_power`, `reserve_cash`/`release_reservation`). The
-  cash-vs-margin axis maps cleanly onto the existing
-  `_process_transaction_spot` (CashAccount) vs `_process_transaction_margin`
-  (MarginAccount) split — those two methods are the seam line.
-- **`SimulatedMarginAccount`** = CashAccount + the lock-and-settle path
-  (`lock_margin`/`release_margin`) + the **margin math** moved out of
-  `PortfolioHandler` (`maintenance_margin`, `margin_ratio`, `_isolated_liq_price`,
-  `_is_breached`, `_liquidation_penalty`, `_liq_inputs`).
-- **`Venue*` leaves: interface-only in Phase 1.** They cache the connector's
-  balance/margin/position streams (Phase 5 impl).
-
-### `Portfolio.cash` -> `Portfolio.account.cash` without disturbing the oracle
-
-- `Portfolio` gains an injected `self.account` exactly as it injects four managers
-  in `_init_managers` (`portfolio.py:83`). `Portfolio.cash` (`portfolio.py:199`)
-  changes from `self.cash_manager.balance` to `self.account.balance`. The cash
-  SETTER is already deleted (`portfolio.py:208`), so there is no write seam to chase.
-- **Byte-exact discipline = pure code-motion** (the v1.2 MOD-01 OrderManager-
-  decomposition playbook). `_process_transaction_spot` is the documented
-  "byte-exact site #2" (`portfolio.py:309`) — operand-for-operand identical
-  Decimal ops, in order. The extraction must preserve operand order and the
-  `apply_fill_cash_flow` full-precision (no-quantize) contract. Gate: SMA_MACD
-  `134 / 46189.87730727451`, determinism double-run, `mypy --strict`.
-
-### The queue-vs-truth seam for liquidation (the one non-trivial split)
-
-`_liquidate_position` (`portfolio_handler.py:462`) does TWO things: (1) computes
-liq price/penalty (truth) and (2) **mints an `Order`, writes `order_storage`, and
-`global_queue.put(FillEvent)`** (I/O). Convention forbids a manager/Account from
-holding the queue. **Recommended split:**
-
-- `SimulatedMarginAccount` owns the **decision**: "is this position breached, and
-  at what liq price/penalty?" (`_isolated_liq_price`, `_is_breached`,
-  `_liquidation_penalty`, `maintenance_margin`).
-- `PortfolioHandler` keeps the **emission**: `_run_liquidation_pass` stays as the
-  queue-owning orchestrator that asks the Account for breaches and mints the
-  forced-close `FillEvent` + `order_storage` write.
-
-This keeps the queue-only / no-queue-in-manager convention intact and is
-oracle-dark (default-off: zero breaches on the spot golden path), so it moves
-safely.
-
-### Positions stay in Portfolio — seam confirmed
-
-`PositionManager` stays on `Portfolio` (`portfolio.py:96`). `maintenance_margin`
-needs positions + `Universe` + current price; under **LX-04 (1 account : 1
-portfolio)** Account and Portfolio share scope, so `maintenance_margin` is a
-**computed read-model that composes Account (locked margin) + Portfolio
-(positions) + Universe** — no ownership conflict. Confirmed: do NOT relocate
-positions in Phase 1.
-
-### `Portfolio.user_id` strip (paired Phase-1 cleanup)
-
-`user_id` is set in `Portfolio.__init__` (`portfolio.py:52`), passed by
-`PortfolioHandler.add_portfolio(user_id, ...)` (`portfolio_handler.py:152`), and
-surfaced in `to_dict` (`portfolio.py:851`). Multi-tenancy is app-layer (FastAPI
-maps `user_id -> portfolio_id`); it must NOT relocate onto `Account`. This is a
-constructor-signature ripple that touches golden-master wiring -> re-confirm
-byte-exact.
+**Deleted:** `_OkxPrecisionResolver`, `_precision_to_scale`, `_link_venue_account_to_portfolios` (+ its `RuntimeError(>1)` guard), `print_status`, `get_statistics`, the flag side-channel methods, `run_paper_replay` (→ `tests/`), `_PAPER_*`/`_OKX_*` module constants.
 
 ---
 
-## 2. LiveConnector interface (ours, over ccxt.pro — LX-05)
+## Recommended structure — new & relocated files
 
-### Shape (NEW abstraction; shaped on OKX reality)
+```
+itrader/
+├── events_handler/
+│   ├── bus.py                          # NEW P2 — EventBus Protocol + Fifo/Priority
+│   └── full_event_handler.py           # MODIFIED P2/P7/P9 — bus ctor, injected routes+policy
+├── trading_system/
+│   ├── compose.py                      # MODIFIED P2/P3 — compose_engine(ctx, spec)
+│   ├── engine_context.py               # NEW P3 — EngineContext frozen dataclass
+│   ├── build_live_system.py            # NEW P7 — live factory / composition root
+│   ├── live_runner.py                  # NEW P7 — LiveRunner drain
+│   ├── live_trading_system.py          # SHRUNK P7 — thin facade ~200 lines
+│   ├── session_initializer.py          # NEW P7 — SessionInitializer
+│   ├── universe_wiring.py              # NEW P7 — shared UniverseWiring [ORACLE]
+│   ├── live_route_registrar.py         # NEW P7 — declarative live routes
+│   ├── safety_controller.py            # NEW P8
+│   ├── stream_recovery_handler.py      # NEW P8
+│   ├── reconciliation_coordinator.py   # NEW P8
+│   └── error_policy.py / error_handler.py  # NEW P9
+├── execution_handler/
+│   ├── venue/registry.py, plugin.py, bundle.py, lifecycle.py  # NEW P6
+│   └── stream_supervisor.py            # NEW P6 — shared
+├── price_handler/
+│   ├── providers/base_live_provider.py # NEW P6 — LiveDataProvider Protocol
+│   └── feed/cache_registration.py      # MODIFIED P7 — StrategyWarmupConsumer
+└── storage/
+    ├── engine.py                       # RENAMED P4 (was backend.py)
+    ├── system_store.py, venue_store.py, strategy_registry_store.py  # NEW P5
+    └── (migrations moved OUT →) <repo-root>/migrations/            # RELOCATED P4
+```
+
+**Structure rationale:** live-only modules live in their handler's package but are **never re-exported from a backtest-path `__init__` barrel** — that is the mechanical rule that keeps the inertness gate green. `build_live_system` is the single place lazy SQL/ccxt imports are allowed.
+
+---
+
+## Architectural Patterns — the integration seams
+
+### Pattern 1: EventBus as a drop-in `queue.Queue` surface `[ORACLE][INERT]`
+
+**What:** A small `EventBus` Protocol (`put`, `get(timeout)`, `get_nowait`, `qsize`, `empty`, `depth_by_tier`). `FifoEventBus` wraps `queue.Queue`; `PriorityEventBus` wraps `queue.PriorityQueue` keyed `(tier, seq, event)`.
+
+**Why the `.put()` call sites don't change (the load-bearing claim):** handlers receive the bus **in the same constructor slot they receive `global_queue` today** and keep calling `self.global_queue.put(event)`. The bus is API-compatible with `queue.Queue.put`. Tier assignment happens **inside** `PriorityEventBus.put` by consulting a declarative `_CONTROL_EVENT_TYPES` frozenset — no call-site edits. The monotonic `seq` (`itertools.count()`) guarantees the tuple comparison never falls through to the (non-orderable, frozen) event and preserves strict FIFO within a tier.
+
+**Why zero oracle risk:** backtest injects `FifoEventBus`; its `get_nowait()` re-raises `queue.Empty`, so `EventHandler.process_events()` (lines 125-130, the `get_nowait()`+`queue.Empty`→`break` drain) is **unchanged**. The priority bus is only ever constructed by `build_live_system` and never touches `BacktestRunner`/`process_events()`.
+
+**Backtest vs live drain divergence:** backtest keeps `process_events()` → `bus.get_nowait()` (drain-to-empty). Live's `LiveRunner` uses `bus.get(timeout)` (blocking, wakes on CONTROL events). Same bus Protocol, two consumers.
+
+### Pattern 2: EngineContext threaded once (LR-14) `[INERT]`
+
+**What:** `@dataclass(frozen=True) EngineContext(bus, config: RuntimeConfig, environment: str, sql_engine: Optional[SqlEngine])`. Infra-only. `compose_engine(ctx, spec)` hands each handler only what it needs.
+
+**Signature ripple (traced concretely against current `compose.py`):** today `compose_engine` is keyword-only over `order_storage, signal_store, csv_paths, start_date, end_date, timeframe, exchange_config, order_config, results_store` and creates `global_queue = queue.Queue()` internally (line 164). After P3:
+- `queue.Queue()` creation is **deleted** — `compose_engine` reads `ctx.bus`.
+- `order_storage`/`signal_store` params **removed** — handlers build their own from `ctx.environment`/`ctx.sql_engine` (Pattern 3); `compose_engine` reads the concrete back off `.storage`.
+- `csv_paths`/`start_date`/`end_date`/`timeframe`/`exchange_config`/`order_config`/`results_store` **move into `spec`** (`SystemSpec` already exists and is mode-agnostic).
+- The `Engine` holder's `global_queue` field → `bus`.
+
+**Byte-exactness contract:** backtest factory builds `EngineContext(bus=FifoEventBus(queue.Queue()), config=<defaults>, environment='backtest', sql_engine=None)`. The wiring body of `compose_engine` (lines 169-246: clock → store → feed → screeners → portfolio → execution → commission estimator → strategies → order → `set_order_storage` → time_generator → EventHandler) stays in the exact same order → identical graph → byte-exact.
+
+### Pattern 3: Handler-owns-storage-init (LR-13) `[ORACLE]`
+
+**What:** `OrderHandler`/`StrategiesHandler` adopt the shape `PortfolioHandler` already ships (`portfolio_handler.py:68-69`: `environment='backtest', backend=None` → `PortfolioStateStorageFactory.create(environment=..., backend=...)`):
 
 ```python
-class LiveConnector(Protocol):   # mirrors AbstractExchange's role for live
-    # --- data arm (feeds Phase 3 LiveBarFeed) ---
-    async def watch_ohlcv(self, symbol, timeframe) -> AsyncIterator[ClosedBar]: ...
-    async def fetch_ohlcv(self, symbol, timeframe, limit) -> list[Bar]:  # REST backfill (LX-09)
-    # --- order arm (exercised in Phase 5 sandbox) ---
-    async def submit(self, order) -> Ack: ...
-    async def cancel(self, order_id) -> Ack: ...
-    async def watch_fills(self) -> AsyncIterator[Fill]: ...
-    # --- account arm (feeds Phase 5 VenueAccount) ---
-    async def fetch_balances(self) -> Balances: ...
-    async def watch_balances(self) -> AsyncIterator[Balances]: ...
-    async def fetch_positions(self) -> Positions: ...
+OrderHandler(..., *, environment='backtest', sql_engine=None, storage=None)
+    → self.storage = storage or OrderStorageFactory.create(environment, backend=sql_engine)
 ```
 
-- `OkxConnector` implements it with **ccxt.pro by default + a native OKX escape
-  hatch** behind the interface (LX-05). A single `sandbox: bool` routes BOTH
-  ccxt (`set_sandbox_mode`) and native calls (`x-simulated-trading` header) to
-  OKX demo — no split-brain.
-- Reuse plumbing from existing `price_handler/providers/ccxt_provider.py` and
-  `binance_stream.py` (those are read-only providers; the connector is the
-  live-feed + order arm).
+The factory already exists with exactly this signature: `OrderStorageFactory.create(environment: str, backend: Optional[SqlBackend]=None)` (`storage/storage_factory.py:24-25`).
 
-### Async loop -> synchronous `global_queue` (the determinism boundary)
+**The read-back seam (byte-exact-critical):** currently `compose_engine` receives `order_storage` and injects the **same instance** into both `OrderHandler` and `portfolio_handler.set_order_storage(order_storage)` (line 234). After P3, `OrderHandler` builds it internally (via `OrderManager`, which owns storage per D-18 — the handler retains no ref). So P3 must add a `.storage` read-back property on `OrderHandler` returning the **actual instance `OrderManager` holds**, and `compose_engine` calls `portfolio_handler.set_order_storage(order_handler.storage)`. Backtest env→`InMemoryOrderStorage`, same instance both places → byte-exact. **Flag:** if the read-back returns a copy or a different instance, the BAR-route liquidation forced-close (LIQ-03) writes to the wrong mirror — silent divergence.
 
-This boundary already exists and is documented:
+### Pattern 4: LiveRouteRegistrar — routes composed at construction, not mutated (LR-16) `[ORACLE][INERT]`
 
-- `SimulatedExchange` docstring: *"queue.Queue is the thread boundary — other
-  threads only put events"* (D-19, `simulated.py:44`). `Portfolio`/`PortfolioHandler`
-  carry the same single-writer contract.
-- `LiveTradingSystem._event_processing_loop` already drains on a daemon thread and
-  dispatches via `event_handler._dispatch(event)` (`live_trading_system.py:365`).
+**What:** The single `EventHandler` already carries explicit-empty live slots in its routes literal (`full_event_handler.py:105-111`): `SCREENER`, `UPDATE`, `UNIVERSE_UPDATE`, `UNIVERSE_POLL`, `STRATEGY_COMMAND`, `BARS_LOADED`, `BARS_LOAD_FAILED` are all `[]`. Backtest keeps them empty (proven inert by `test_okx_inertness`). Live composes consumers **into** these lists + adds the NEW CONTROL routes.
 
-**Integration rule:** the connector runs its **own asyncio loop in its own
-thread**; on every venue message it translates to a frozen domain event and calls
-`global_queue.put(...)` — a thread-safe handoff. It NEVER mutates engine state
-directly. All state mutation stays on the single engine thread (the existing D-19
-single-writer contract). Therefore:
+**Integration mechanism (no subclass, no runtime mutation):** `EventHandler.__init__` gains an optional `extra_routes: dict[EventType, list[Callable]] | None = None` merged into the base literal at construction. `LiveRouteRegistrar` builds the live additions; `build_live_system` passes them in. Backtest passes `None` → base routes only. This modifies `EventHandler.__init__` — **`[ORACLE]`: the base literal must be byte-identical when `extra_routes` is None.**
 
-- **Determinism of the backtest path is untouched** — the async bridge does not
-  exist on the backtest path at all (inert).
-- Live runs are inherently wall-clock-nondeterministic, but the engine-thread
-  *processing* is still a serialized FIFO drain, so per-event handler logic stays
-  reproducible given the same event sequence. The async boundary is "bottled at
-  the connector edge" (sketch §4 Phase 2).
-- **Event `time` must be the venue bar/fill business time, never wall clock**
-  (the bar-timing contract + the determinism convention). The connector stamps
-  domain events from venue timestamps.
+**New EventType members required in P2** (so `PriorityEventBus._CONTROL_EVENT_TYPES` can reference them): `STREAM_STATE`, `CONNECTOR_FATAL`, `CONFIG_UPDATE` are **new** in `core/enums/event.py`; `STRATEGY_COMMAND`, `BARS_LOADED`, `BARS_LOAD_FAILED` already exist. `_dispatch` raises `NotImplementedError` on unrouted types, but backtest never *emits* the CONTROL types, so no backtest route is strictly required — adding explicit-empty entries (matching the existing pattern) is the safer, convention-consistent choice.
 
----
+### Pattern 5: Shared UniverseWiring extraction (§13a) `[ORACLE]` — the highest-risk seam
 
-## 3. LiveBarFeed as a BarFeed impl (Phase 3, LX-07)
+**What:** `BacktestRunner._initialise_backtest_session` (`backtest_runner.py:50-131`) contains the ordered block: `derive_membership → derive_instruments → WR-03 desync assert → Universe(...) → set on exchange/order/portfolio → feed.bind`, then **backtest-only** ping-grid `reduce(pd.Index.union)` + `time_generator.set_dates` + per-strategy `feed.precompute`.
 
-### NEW concrete class; same ABC the engine already consumes
+**Extraction:** the common prefix (`derive_membership → … → feed.bind`, lines 64-113) moves into a shared `UniverseWiring` helper both `BacktestRunner` and the live `SessionInitializer` call. The ping-grid/precompute tail (lines 119-131) stays backtest-only.
 
-`LiveBarFeed(BarFeed)` implements the four abstract methods (`feed/base.py:75`):
-`current_bars`, `window`, `megaframe`, `newest_bar`. The engine above the feed is
-unchanged — strategies, screeners, execution all speak the same contract.
+**Why it's the riskiest oracle seam:** this is a **pure code-motion** refactor of the exact block that builds the `Universe` value object and injects it into three domains in a fixed order (`exchange.set_universe → order_handler.set_universe → portfolio_handler.set_universe → feed.bind`). It is the direct analog of the v1.2 MOD-01 order-manager decomposition (pure code-motion, byte-for-byte). The WR-03 desync assert (lines 84-90) and the injection ordering must move as **one intact unit**. Any reorder changes the graph → oracle breaks. **Recommend: byte-exact diff gate on this extraction specifically; no re-baseline permitted (LR-02 default target holds).**
 
-| Concern | BacktestBarFeed (existing) | LiveBarFeed (new) |
+### Pattern 6: Connector flag side-channel → CONTROL events (§4b/§11c)
+
+**What:** The connector asyncio loop does only venue I/O + `bus.put()`; it never touches handler state. Stream/fatal signals that were `threading.Event` flags become CONTROL events on the priority bus:
+
+| CONTROL event | Route → | Runs on |
 |---|---|---|
-| Backing store | whole frame precomputed; monotonic int64 cursor | **bounded `deque(maxlen=cap)` per `(symbol, timeframe)`** |
-| Capacity | holds full history | `cap = cache_capacity()` — the SAME `cache_registration.derive` over registered consumers (`feed/base.py:118`), i.e. `max(lookback)` (warmup=100 for SMA_MACD) |
-| `window(asof, max_window)` | `iloc` slice of cached frame | trailing N from the ring |
-| `newest_bar` | last `current_bars` walk writes `_newest_bars` | set on each `update(bar)` |
-| Time source | `TimeGenerator` pinned grid | **closed-bar arrival** |
+| `StreamStateEvent(down)` | `SafetyController.pause_submission` | engine thread |
+| `StreamStateEvent(up)` | `StreamRecoveryHandler.on_reconnect` | engine thread |
+| `ConnectorFatalEvent(reason)` | `SafetyController.halt(reason)` | engine thread |
 
-### Replacing TimeGenerator's role
-
-- Backtest: `TimeGenerator` yields `TimeEvent`s; the TIME route calls
-  `feed.generate_bar_event(time_event)` -> `BarEvent` (`bar_feed.py:448`).
-- Live: there is no pinned grid. The connector's closed bar drives
-  `LiveBarFeed.update(bar)` which appends to the ring and **emits the `BarEvent`
-  directly**. Downstream BAR-route cycle (portfolio mark -> matching -> strategies)
-  is unchanged.
-- **Integration gap to flag:** `LiveTradingSystem` records portfolio metrics on
-  `EventType.TIME` (`live_trading_system.py:374`). Live has no `TimeEvent` unless
-  the feed/connector synthesizes one per closed bar. Decide at plan time: emit a
-  paired `TimeEvent` on bar close (cleanest — keeps the TIME route semantics), or
-  move metric recording to the BAR route. Recommend: synthesize a `TimeEvent` on
-  closed-bar arrival so the existing `_routes` ordering (TIME before BAR) holds.
-
-### Bar-close detection (LX-08) — the native escape hatch earns its keep
-
-OKX's native WS kline channel carries a `confirm` field (`"0"` forming, `"1"`
-closed). **ccxt.pro `watchOHLCV` does not reliably surface a closed/confirm flag**
-across exchanges (it is exchange-specific and not part of the unified return)
-([ccxt #21885](https://github.com/ccxt/ccxt/issues/21885)). This is exactly the
-LX-05 native-escape-hatch case: drive "closed" off OKX's confirm flag via the
-native path, never wall-clock inference. Emit a `BarEvent` only on a completed bar
-(7-rule contract: completed bars only, no forming bucket).
-
-### Warmup/backfill through the IDENTICAL update path (LX-09)
-
-At live-start: REST `fetch_ohlcv` the last K bars, then **replay them one-by-one
-through the same `update(bar)` path** live streaming uses. **No bulk
-`warmup_from(series)` fast-path** — a second state-building path diverges and
-re-opens the parity audit. Stateful indicators (v1.5) self-buffer through the same
-per-bar push, so this is what keeps paper-parity intact.
-
-### Monotonic-forward-only delivery (LX-10)
-
-Both feeds are monotonic by construction (the BacktestBarFeed cursor is
-forward-only with a safe-rebuild on a non-monotonic cutoff, `bar_feed.py:639`).
-LiveBarFeed enforces: gap -> REST-backfill and replay through `update`; duplicate
--> drop; out-of-order/stale -> reject (stateful indicators have no rewind);
-reconnect -> gap-fill the interim.
+**Single-writer contract (LR-12):** all state mutation on the one engine thread; blocking venue I/O triggered by a stream event (resume snapshot, reconcile, durable halt write) runs on the **engine thread inside the CONTROL handler**, never on the connector loop. CONTROL preemption means a `pause_submission` jumps ahead of queued market data — the safety-latency reason for the two-tier bus.
 
 ---
 
-## 4. PaperConnector (Phase 4 — the DoD)
+## Data Flow
 
-### NEW class composing the pure matching core (LX-06), NOT the whole exchange
-
-`SimulatedExchange` (`simulated.py:36`) composes `MatchingEngine` +
-`fee_model`/`slippage_model` and adds I/O (`_emit_fill`, `_emit_rejection`,
-admission, connection telemetry). `PaperConnector` composes the **same pure
-pieces** and satisfies `LiveConnector`:
+### Backtest path (unchanged behavior, new plumbing)
 
 ```
-PaperConnector(LiveConnector)
-├── MatchingEngine            (reused verbatim — pure, I/O-free: submit / on_bar -> decisions)
-├── fee_model + slippage_model (reused)
-└── SimulatedAccount          (Phase 1 — provides balances/positions = backtest math)
+BacktestRunner._run_backtest loop (byte-exact ordering, Trap 4):
+  clock.set_time → bus.put(TimeEvent) → EventHandler.process_events()
+    → bus.get_nowait() drain → _dispatch per base route
+  → portfolio.record_metrics(time)  [DIRECT call, never a reroute]
+  → on_tick hook
 ```
+Only change: `engine.global_queue.put` → `engine.bus.put` (FifoEventBus, identical FIFO).
 
-- `submit`/`cancel` -> `matching_engine.submit`/`cancel`.
-- On each `LiveBarFeed` **closed** bar -> `matching_engine.on_bar(bar)` -> apply
-  fee/slippage -> emit `FillEvent` (bar-based fills only, LX-13).
-- `fetch_balances`/`fetch_positions` -> read `SimulatedAccount` locally.
-
-### Two-adapter-over-one-matching-core symmetry + a refactor to enable it
-
-The fee/slippage application logic lives **only** in `SimulatedExchange._emit_fill`
-(`simulated.py:247`) — maker/taker classification, the D-03 limit-no-slippage
-gate, `to_money` normalization. To avoid two divergent fill-pricing paths (a
-parity hazard), **extract a pure helper** (e.g. `apply_costs(decision, fee_model,
-slippage_model) -> (executed_price, commission)`) that BOTH `SimulatedExchange`
-and `PaperConnector` call. This is the "two adapters over one matching core"
-made real: one matching core (`MatchingEngine`) AND one cost core. Modified:
-`simulated.py` (extract helper, keep behavior byte-exact); New: the helper +
-`PaperConnector`.
-
-### Correctness gate (LX-11)
-
-Paper-parity vs the backtest oracle on the same data: local paper is deterministic
-+ bar-based precisely so this holds. The shared `SimulatedAccount` (column 1) and
-shared `MatchingEngine`/cost-core are the mechanism.
-
----
-
-## 5. Runtime / deployment topology (LX-15)
-
-| Option | Integration points | Verdict |
-|---|---|---|
-| **(a) in-process** — engine thread inside FastAPI | none new; FastAPI calls `LiveTradingSystem` directly | **Reject.** Couples engine+web lifecycles; mixes FastAPI's async loop + connector asyncio thread + engine sync thread in one process; one crash kills both. |
-| **(b) separate worker** — FastAPI controls lifecycle; Postgres system-of-record + command/status channel | v1.6 store (shared truth); Postgres `LISTEN/NOTIFY` (or commands table) for control; worker write-through | **Recommended baseline.** This is *precisely what v1.6's durable store + restart rehydration were built to enable* — store is the shared truth a separate process reads while the worker writes. Crash isolation; FastAPI stays thin. |
-| **(c) process-per-portfolio** — 1 worker : 1 portfolio + shared price-feed service | per-OKX-subaccount isolation; shared feed avoids duplicate streams/rate-limits | **Target end-state under LX-04.** Natural fit for 1 account : 1 portfolio + one OKX subaccount per portfolio. |
-
-### Recommendation (rationale-backed)
-
-**Ship (b) now, architected as (c) with N=1.** Build the worker as a
-**single-portfolio process** (effectively (c) with one portfolio), with the
-price-feed living inside it for v1.7 but behind a seam that can be extracted to a
-shared price-feed service later. Rationale, grounded in three locked facts:
-
-1. **v1.6 store-as-truth** — the operational store + restart rehydration only pay
-   off if a *separate* reader (FastAPI) and writer (worker) share Postgres. (b)
-   activates the v1.6 investment; (a) wastes it.
-2. **The async bridge** — keeping the connector's asyncio thread + the engine's
-   sync thread in their own OS process (not co-resident with FastAPI's event loop)
-   is the cleanest isolation of the three concurrency models.
-3. **LX-04 1:1 constraint** — one portfolio : one OKX subaccount makes
-   per-portfolio process isolation natural; designing the worker as
-   per-portfolio from day one means scaling to (c) is "run N workers + extract the
-   feed," not a re-architecture.
-
-For the v1.7 DoD (one portfolio, paper) a single worker IS (c) with N=1 — so (b)
-and the (c) end-state converge on the same build now. The FastAPI app itself is
-out of v1.7 scope (deferred), but the command/status channel + write-through
-contract must be designed in Phase 4–5 wiring.
-
----
-
-## 6. TradingInterface (LX-14) — DELETE, replace with a thin engine command surface
-
-### What depends on it today
-
-Grep result: **no production consumer.** Only the barrel export
-(`trading_system/__init__.py:6/12`), the class itself, and one *comment* in a test
-(`test_admission_rules.py:267`) + a golden-doc note. `LiveTradingSystem` likewise
-has no production wiring (live composition root deferred per RETAIN-03/D-01). The
-FastAPI app does not exist yet.
-
-### Why delete
-
-`TradingInterface` (`trading_interface.py`) is the *pre-FastAPI* bridge. It is
-also stale: it builds `OrderEvent`s with **float** price/quantity and naive
-`datetime.now()` (`trading_interface.py:79/129`), and **bypasses the order domain's
-sizing/validation** (`SizingResolver`/`EnhancedOrderValidator`) by constructing
-sized orders directly. Under topology (b)/(c), the web layer talks to the worker
-via the Postgres command channel — it never calls `LiveTradingSystem` methods
-in-process — so an in-process bridge is redundant.
-
-**Recommendation:** delete `TradingInterface`; introduce a thin, typed **engine
-command surface** the worker consumes from the command channel (submit-signal /
-cancel / status), routing through the *real* order domain (signal -> sizing ->
-validation -> order), Decimal + UUIDv7 + tz-aware time. This pairs with the
-`user_id` strip (both are "engine vs app layer" cleanups) and **scopes FL-13** —
-test the surface that survives (the command surface + `LiveTradingSystem`
-lifecycle), not the deleted bridge.
-
----
-
-## 7. Suggested build order (honors §7 locked dependencies)
+### Live path (new)
 
 ```
-Phase 1  Account abstraction extraction        [GATES EVERYTHING — oracle-gated]
-  └─ + user_id strip + TradingInterface delete + LiveConnector interface (interface-only)
-         │
-         ├──────────────► Phase 2  OkxConnector (data arm + order arm)
-         │                   └─ data arm ─────► Phase 3  LiveBarFeed (ring buffer)
-         │                                          │
-         ▼                                          ▼
-   (SimulatedAccount ready)                  Phase 4  PaperConnector  ◄── PaperConnector needs
-         └──────────────────────────────────►  = milestone DoD          1 + 3 + connector DATA arm
-                                                  (NOT the order arm)     (paper-parity gate, LX-11)
-                                                       │
-   Phase 2 order arm + Phase 1 VenueAccount + v1.6 store
-                                                       ▼
-                                            Phase 5  Real/sandbox path
-                                              (VenueAccount reconcile + persistence live-drive)
-                                                       
-   Phase 6  Dynamic universe membership  (pairs with Phase 3 — reuses backfill-through-update)
+connector asyncio loop (daemon)            engine thread (LiveRunner)
+  venue I/O                                  bus.get(timeout)  ← wakes on CONTROL
+  ├─ fill/bar    → bus.put(BUSINESS) ──┐        │
+  └─ stream/fatal→ bus.put(CONTROL) ───┼──────► _dispatch via injected ErrorPolicy
+                                       │        ├─ CONTROL: pause/resume/halt (engine-thread I/O)
+                    [queue = bulkhead] │        └─ BUSINESS: BAR→SIGNAL→ORDER→FILL (existing flow)
 ```
 
-**Hard dependencies (from sketch §7, verified against code):**
+### Runtime-config mutation (P10★, scoped)
 
-1. **Phase 1 first, oracle-gated.** Account extraction is behavior-preserving;
-   the `PortfolioReadModel` seam means it does not ripple into the order domain.
-   Everything else implements against the Phase-1 `LiveConnector`/`Account`
-   interfaces.
-2. **Phase 2 data arm before Phase 3.** `LiveBarFeed` consumes the connector's
-   `watch_ohlcv`/`fetch_ohlcv`. The bar-close confirm flag (LX-08) depends on the
-   Phase-2 native escape hatch.
-3. **Phase 4 (DoD) needs 1 + 3 + connector DATA arm only — NOT the order arm.**
-   `PaperConnector` does its own matching (reused `MatchingEngine`); it never
-   submits to OKX. This is the critical sequencing insight: the paper DoD is
-   reachable without any live order I/O.
-4. **Phase 5 needs Phase 2 order arm + Phase 1 `VenueAccount` impl + the v1.6
-   store.** Reconciliation = per-symbol drift detection under LX-04.
-5. **Phase 6 pairs with Phase 3** (warmup-on-add reuses backfill-through-update).
-6. **Topology (LX-15) decided before Phase 4 wires the runtime** (cross-cutting,
-   not a phase).
+```
+ConfigUpdateEvent(scope, key, value) → CONTROL plane → engine-thread handler
+  → route to owner (system→SystemStore, portfolio:{id}→Portfolio+store, venue:{name}→VenueStore)
+  → apply to RuntimeConfig overlay + handler.update_config(...) + persist
+  → on restart: build_live_system layers persisted overrides over defaults
+```
 
 ---
 
-## New vs Modified (explicit ledger for the roadmap)
+## Build-Order Validation — §16 P1→P13 confirmed, with 4 refinements
 
-| Component | Status | File / location |
-|---|---|---|
-| `Account` ABC + `CashAccount`/`MarginAccount` + `Simulated*`/`Venue*` leaves | **NEW** | new `portfolio_handler/account/` |
-| `Portfolio` — inject `self.account`; `cash` -> `account.balance` | **MODIFIED** | `portfolio.py` |
-| `CashManager` math/state -> `SimulatedCashAccount` | **MOVED** (code-motion, byte-exact) | `cash/cash_manager.py` -> account leaf |
-| `PortfolioHandler` margin/liq math -> `SimulatedMarginAccount` | **MOVED** | `portfolio_handler.py:339–460` |
-| `PortfolioHandler._run_liquidation_pass` queue emission | **KEPT** (asks Account for breaches) | `portfolio_handler.py:557` |
-| `PortfolioReadModel` Protocol | **UNCHANGED** (seam preserved) | `core/portfolio_read_model.py` |
-| `Portfolio.user_id` | **REMOVED** (app-layer) | `portfolio.py:52` |
-| `TradingInterface` | **DELETED** + replaced by engine command surface | `trading_interface.py` |
-| `LiveConnector` Protocol | **NEW** (interface-only in P1) | new |
-| `OkxConnector` (ccxt.pro + native escape hatch) | **NEW** | new `execution_handler/connectors/` (or `price_handler/providers/`) |
-| `LiveBarFeed(BarFeed)` ring buffer | **NEW** | new `price_handler/feed/live_bar_feed.py` |
-| `apply_costs` fee/slippage helper (extract from `_emit_fill`) | **NEW** (refactor) | `execution_handler/` |
-| `SimulatedExchange._emit_fill` -> call shared helper | **MODIFIED** (byte-exact) | `simulated.py:247` |
-| `PaperConnector` (MatchingEngine + costs + SimulatedAccount) | **NEW** | new |
-| `VenueAccount` impl (reconcile) | **NEW** (P5; interface in P1) | account leaf |
-| `LiveTradingSystem` — real feed/connector wiring, TimeEvent-on-bar-close, command channel | **MODIFIED** | `live_trading_system.py` |
-| Worker process + Postgres command/status channel | **NEW** | new |
+The overall sequence is **sound**: foundation (config → bus → context → sql → stores) → venue registry → God-object teardown → safety/error → ★ feature-adds → test migration. Dependencies below are real (file-level), and I challenge 4 entries in the §16 table:
+
+| # | Phase | §16 deps | Verdict | Refinement |
+|---|-------|----------|---------|-----------|
+| P1 | Config centralization | — | ✓ | Hosts CF-8 `HaltReason` enum + CF-6 doc; lazy `sql` accessor is the inertness lever. |
+| P2 | Event bus | — | ✓ w/ note | **Must add the NEW CONTROL EventType members** (`STREAM_STATE`/`CONNECTOR_FATAL`/`CONFIG_UPDATE`) here — `_CONTROL_EVENT_TYPES` references them, even though consumers land P8/P10. |
+| P3 | EngineContext + storage-in-handler | P1 | ⚠ **add P2** | `EngineContext.bus` needs the `EventBus` type/instance from P2. The table omits P2→P3. **Recommend P3 deps = {P1, P2}.** |
+| P2+P3 | compose_engine | — | ⚠ double-edit | **P2 and P3 both mutate `compose_engine`'s signature/body** (P2 injects the bus; P3 folds bus+config+env+sql into `EngineContext` and drops storage params). Options: (a) accept the small re-edit, or (b) introduce a minimal `EngineContext` skeleton in P2 so the signature settles once. Prefer (b). |
+| P4 | SqlEngine rename + migrations relocation | P3 | ⚠ ordering | `EngineContext.sql_engine` is typed `Optional[SqlEngine]` in §7a, but the `SqlBackend→SqlEngine` **rename lands in P4, after P3**. Either do the *rename* in/before P3 (P3 references the new name) or let P3 use `SqlBackend` and P4 sweeps `EngineContext` too. The *migrations relocation* is genuinely independent and stays P4. **Recommend: split P4 — rename folds into P3, relocation stays P4-standalone.** |
+| P5 | New stores | P4 | ✓ | Chains Alembic onto relocated `migrations/`; live-only, in-memory fallback keeps backtest dark. |
+| P6 | Venue registry + bundle | P2, P3 | ✓ | Needs bus (CONTROL emitters) + EngineContext. CF-3/4/9 fold here. `[INERT]` lazy `build_bundle`. |
+| P7 | LiveRunner + factory + facade + UniverseWiring | P5, P6 | ✓ | Transitively needs P2 (LiveRunner `bus.get(timeout)`). **UniverseWiring is `[ORACLE]` — gate it hardest.** |
+| P8 | Safety + reconciliation + stream recovery | P7 | ✓ | CONTROL routes consume P2's new EventTypes; flag machinery deleted. CF-2/7/8. |
+| P9 | Error subsystem | P7 | ✓ | `ErrorPolicy` injection modifies `EventHandler.__init__` — `[ORACLE]` backtest fail-fast must stay identical to the current `_on_handler_error` bare-`raise`. CF-1 circuit breaker is the one added acceptance criterion. |
+| P10★ | Runtime-config platform | P5, P8 | ✓ | CONFIG_UPDATE route (CONTROL). |
+| P11★ | Strategies registry | P5, P7 | ✓ | STRATEGY_COMMAND route (already an empty slot today). |
+| P12★ | Multi-portfolio-live | P6, P8 | ✓ | Drops the single-portfolio guard + `_link_venue_account_to_portfolios`; connector keyed `(venue, account_id)`. |
+| P13 | Replay→fixture + gates | P7, P12 | ✓ | Lands last; production replay-free. |
+
+**Net:** no cycle, no blocker. The only substantive corrections are **P3 must depend on P2**, and the **compose_engine signature should settle in one step** (fold a minimal EngineContext into P2) rather than editing the same param list twice. The P4 rename-vs-relocation split is a nicety, not a blocker.
 
 ---
 
-## Anti-Patterns (domain-specific, to flag in the roadmap)
+## Anti-Patterns to avoid (from spec + existing conventions)
 
-### A1: A second state-building path for warmup
-Bulk `warmup_from(series)` alongside the per-bar `update`. Diverges from the live
-path and re-opens the parity audit. **Instead:** replay backfill one-by-one
-through the identical `update(bar)` (LX-09).
+### Anti-Pattern 1: Subclassing EventHandler for live routes
+**What people do:** create `LiveEventHandler(EventHandler)` overriding `routes`. **Why wrong:** two dispatch surfaces to reason about; the inertness proof (base-routes-only) evaporates. **Instead:** LR-16 — one data-driven `EventHandler`, live routes injected at construction via `LiveRouteRegistrar`.
 
-### A2: Mutating engine state from the connector thread
-Any direct call from the asyncio thread into `Portfolio`/`Account`/handlers breaks
-the D-19 single-writer contract and determinism. **Instead:** connector thread
-ONLY `global_queue.put(...)`; all mutation on the engine thread.
+### Anti-Pattern 2: Runtime `routes` mutation
+**What people do:** `event_handler.routes[EventType.X].append(consumer)` at `start()`. **Why wrong:** non-declarative, order-fragile, breaks the "change routing in one reviewable literal" contract. **Instead:** compose routes once at construction.
 
-### A3: Duplicating fill pricing in PaperConnector
-Re-implementing maker/taker + slippage gating instead of reusing the matching core
-+ a shared cost helper. Two pricing paths drift -> paper-parity fails silently.
-**Instead:** one `MatchingEngine`, one `apply_costs` helper, two adapters.
+### Anti-Pattern 3: Changing `.put()` call sites for the priority bus
+**What people do:** add `bus.put(event, tier=CONTROL)` across handlers. **Why wrong:** touches every handler, breaks byte-exactness risk surface, re-litigates the queue-only contract. **Instead:** the bus assigns the tier from `_CONTROL_EVENT_TYPES` inside `put`; call sites stay `self.global_queue.put(event)`.
 
-### A4: Wall-clock bar-close inference
-Inferring "bar closed" from local time instead of OKX's confirm flag. Drops/double-
-counts bars on latency. **Instead:** drive closed off the native confirm flag
-(LX-08), via the native escape hatch (ccxt.pro does not surface it reliably).
+### Anti-Pattern 4: Reordering the UniverseWiring block during extraction
+**What people do:** "tidy" the injection order (exchange/order/portfolio/feed.bind) while extracting. **Why wrong:** the ordering IS the byte-exact contract (Trap 4). **Instead:** move the block verbatim as one unit; diff-gate against the oracle.
 
-### A5: Re-homing `user_id` onto Account
-Multi-tenancy belongs to the FastAPI app layer (`user_id -> portfolio_id`).
-Putting it on Account couples the engine to tenancy. **Instead:** strip it; map
-in the app layer.
+### Anti-Pattern 5: Hoisting a live import to module scope
+**What people do:** `import ccxt.pro` / `from itrader.storage.system_store import SystemStore` at a backtest-reachable module top. **Why wrong:** fails `test_okx_inertness`, silently pulls async/SQL onto the hot path. **Instead:** lazy-import inside `build_live_system` / `VenuePlugin.build_bundle`; never re-export live modules from a backtest-path barrel.
 
-### A6: Liquidation math left in PortfolioHandler
-Leaving `_isolated_liq_price`/`maintenance_margin` in the handler perpetuates the
-exact smell Phase 1 exists to fix and fights the future `VenueAccount` mirror.
-**Instead:** truth/decision in `SimulatedMarginAccount`, queue emission stays in
-the handler.
+### Anti-Pattern 6: `Decimal(float)` / tab-space normalization
+Carried project constraints: money enters Decimal only via `to_money`; handler modules use **tabs**, `config/`/`core/`/`price_handler/feed/`/`events_handler/events/` use **4 spaces** — match the file, never normalize (`bus.py` under `events_handler/` → 4 spaces; `trading_system/` new files → tabs).
 
 ---
 
 ## Integration Points
 
-### External services
+### Internal boundaries (where v1.8 seams meet existing code)
 
-| Service | Integration pattern | Notes / gotchas |
-|---|---|---|
-| OKX (data) | ccxt.pro `watch_ohlcv` + native WS for confirm flag | ccxt.pro does not surface a unified closed/confirm flag — native escape hatch required (LX-05/LX-08) |
-| OKX (orders/account) | ccxt.pro submit/cancel/watch + native, single `sandbox` flag | `set_sandbox_mode` (ccxt) AND `x-simulated-trading` header (native) — route both or split-brain |
-| Postgres (v1.6) | system-of-record + command/status channel (`LISTEN/NOTIFY`) | worker writes; FastAPI reads — the (b) topology enabler |
+| Boundary | Communication | Notes / Gate |
+|----------|---------------|--------------|
+| factory ↔ `compose_engine` | `EngineContext` + `SystemSpec` (data) | `[ORACLE]` backtest arm identical graph |
+| handlers ↔ bus | `global_queue`-slot injection; `.put()` API-compatible | `[ORACLE]` no call-site change; `[INERT]` Fifo light |
+| `compose_engine` ↔ handlers | reads `.storage` back after handler-owns-init | `[ORACLE]` same in-memory instance into `set_order_storage` |
+| `EventHandler` ↔ live controllers | `LiveRouteRegistrar` extra_routes at ctor | `[ORACLE]` None on backtest = base routes |
+| connector loop ↔ engine thread | bus (CONTROL/BUSINESS) — the bulkhead | single-writer; blocking I/O on engine thread only |
+| `VenueRegistry` ↔ `ExecutionHandler` | registry distributes exchange into existing `register_exchange` sub-registry | `on_order` already routes by `event.exchange` |
+| new stores ↔ composition root | built by factory over shared `sql_engine`, handed to controllers | `[INERT]` live-only; `HaltRecordStore` template |
+| `BacktestRunner`/`SessionInitializer` ↔ `UniverseWiring` | shared helper call | `[ORACLE]` pure code-motion |
+| `EventHandler` ↔ `ErrorPolicy` | injected at ctor (removes `_on_handler_error` monkeypatch) | `[ORACLE]` backtest fail-fast identical |
 
-### Internal boundaries
-
-| Boundary | Communication | Notes |
-|---|---|---|
-| connector thread ↔ engine thread | `global_queue.put` only | D-19 single-writer; determinism boundary bottled here |
-| order domain ↔ portfolio truth | `PortfolioReadModel` Protocol | unchanged in P1 — Account moves behind it |
-| `Portfolio` ↔ `Account` | direct (injected, same-process, 1:1) | mirrors the 4-manager delegation; not queue-mediated |
-| feed ↔ engine | `BarFeed` ABC (`current_bars`/`window`/`megaframe`/`newest_bar`) | LiveBarFeed swaps the backing store only |
-| paper execution ↔ matching | `MatchingEngine.submit`/`on_bar` (pure) | reused by both SimulatedExchange and PaperConnector |
+### External services (unchanged integration patterns)
+| Service | Pattern | Notes |
+|---------|---------|-------|
+| OKX | `OkxConnector` (one asyncio loop + one `ccxt.pro` client) | `[INERT]` lazy in `build_bundle`; creds per-`account_id` in env `OkxSettings`, never persisted |
+| Postgres | shared `SqlEngine` (was `SqlBackend`) | `[INERT]` lazy `sql` accessor; raises without credential |
 
 ---
 
-## Confidence & gaps
+## Oracle- & Inertness-sensitive seam register (roadmap must flag these per phase)
 
-- **HIGH** — Account layering, the `PortfolioReadModel` seam, the async->queue
-  boundary, BarFeed ABC reuse, MatchingEngine reuse, TradingInterface deletion
-  (grep-confirmed no consumers): all read directly from the code.
-- **MEDIUM** — OKX confirm-flag exposure in ccxt.pro (web-sourced; verify the
-  exact native channel + confirm semantics at Phase 2/3 plan time — carried
-  research flag).
-- **Gaps for plan-time research:** (1) live `TimeEvent`-on-bar-close vs moving
-  metric recording to the BAR route; (2) ring-buffer capacity when multiple
-  timeframes/consumers register (extend `cache_registration.derive`); (3)
-  reconciliation repair policy (auto-correct vs halt-and-alert); (4) write-through
-  transaction boundary (v1.6 carried flag); (5) exact native-vs-ccxt OKX gap list.
+| Seam | Gate | Phase | Failure mode if mishandled |
+|------|------|-------|----------------------------|
+| `compose_engine` signature + wiring-order | `[ORACLE]` | P2/P3 | any reorder → graph diff → oracle breaks |
+| `FifoEventBus` FIFO/`queue.Empty` parity | `[ORACLE][INERT]` | P2 | non-FIFO or missing `queue.Empty` → drain misbehaves |
+| Handler-owns-init `.storage` read-back | `[ORACLE]` | P3 | different instance → LIQ-03 writes wrong mirror |
+| `EngineContext(sql_engine=None)` / lazy `sql` | `[INERT]` | P1/P3 | Postgres `SqlSettings` at import → inertness fails |
+| `EventHandler` route composition (extra_routes None) | `[ORACLE]` | P7 | base literal drift → routing diff |
+| **UniverseWiring extraction** | `[ORACLE]` | P7 | reorder/split injection → oracle breaks (**highest risk**) |
+| `ErrorPolicy` injection (backtest fail-fast) | `[ORACLE]` | P9 | non-re-raising default → silent state corruption |
+| Venue plugin lazy `build_bundle` | `[INERT]` | P6 | eager `ccxt.pro` import → inertness fails |
+| New stores / live modules not re-exported | `[INERT]` | P5/P7/P8 | barrel re-export → SQL/async on hot path |
+| `test_okx_inertness` forbidden list | `[INERT]` | P5-P12 | new live modules must be added to the probe's `_FORBIDDEN` |
+
+---
 
 ## Sources
 
-- Existing code (HIGH): `portfolio.py`, `portfolio_handler.py`, `cash/cash_manager.py`,
-  `core/portfolio_read_model.py`, `price_handler/feed/{base,bar_feed}.py`,
-  `execution_handler/{matching_engine.py,exchanges/simulated.py}`,
-  `trading_system/{live_trading_system,trading_interface}.py`.
-- Locked design: `docs/superpowers/specs/2026-06-30-live-trading-milestone-design.md` (LX-01..LX-15).
-- [ccxt #21885 — closed/confirm flag for websocket candles](https://github.com/ccxt/ccxt/issues/21885)
-- [ccxt OKX exchange docs](https://docs.ccxt.com/docs/exchanges/okx)
-- [ccxt.pro manual](https://docs.ccxt.com/docs/pro-manual)
+- `docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md` (LR-00..LR-22, CF-1..CF-10, §4/§5/§7/§13/§16) — HIGH (authoritative design)
+- `itrader/trading_system/compose.py`, `backtest_runner.py`, `events_handler/full_event_handler.py`, `portfolio_handler/portfolio_handler.py`, `order_handler/order_handler.py`, `order_handler/storage/storage_factory.py`, `storage/backend.py`, `tests/integration/test_okx_inertness.py` — HIGH (real code traced)
+- `.planning/PROJECT.md` (Current Milestone v1.8) + `CLAUDE.md` (architecture) — HIGH
 
 ---
-*Architecture research for: v1.7 Live Trading Readiness (paper-first OKX)*
-*Researched: 2026-06-30*
+*Architecture research for: v1.8 Live System Refactor integration mapping*
+*Researched: 2026-07-09*

--- a/.planning/research/FEATURES.md
+++ b/.planning/research/FEATURES.md
@@ -1,293 +1,207 @@
-# Feature Research
+# Feature Research — v1.8 Live System Refactor & Live-Readiness Hardening
 
-> ## ⚠ Superseded framing — read `phases/02-okx-connector/02-CONTEXT.md` first
+**Domain:** Live-trading engine internals — composition root, event bus, venue plugin system, runtime-config platform, safety/reconciliation subsystem (single-operator, crypto-first)
+**Researched:** 2026-07-09
+**Confidence:** HIGH (framework grounding verified against Nautilus Trader + QuantConnect LEAN docs); MEDIUM on the trim-boundary judgment calls (P10–P12)
+
+> **What "features" means here.** This is a brownfield architecture refactor, not a user-facing product. The "users" of these features are (1) the single operator running the live engine, (2) the downstream FastAPI app that will consume the seams, and (3) the strategy author. So "table stakes" = what any mature live engine (Nautilus, LEAN) must have to be trusted with real money; "differentiators" = capabilities beyond the LEAN/Nautilus baseline that this engine deliberately adds; "anti-features" = machinery that mature single-operator engines correctly avoid.
 >
-> The Phase-2 discussion (2026-07-01) revised the live architecture; this snapshot
-> predates it and still describes the **two-arm `LiveConnector`** model. **Superseded
-> framings** (the feature set itself remains valid):
-> - Connector is a **session/transport primitive**, not a two-arm venue object; the data/order/account arms are **domain adapters** (`OkxDataProvider` / `OkxExchange` / `VenueAccount`), **injected** with the session, never cross-domain-imported.
-> - The **`OkxExchange` adapter emits `FillEvent`** — the connector owns no operations and emits no domain events.
-> - Paper needs **no connector**: the paper execution adapter implements **`AbstractExchange`** (not `LiveConnector`).
-> - `OkxSettings` reads **plain `OKX_API_*` (no env prefix)** — not `ITRADER_OKX_*`.
->
-> See design-doc LX-05/LX-06 revision notes and `02-CONTEXT.md` D-01..D-10.
-
-**Domain:** Live crypto-trading deployment layer (paper-first, single-venue OKX) over a complete event-driven backtest engine
-**Researched:** 2026-06-30
-**Confidence:** HIGH (locked design + verified venue/lib specifics; LOW flags called out inline)
-
-> Scope guard: this researches the FEATURE-LEVEL behaviors that must work *within* the locked
-> milestone design (`docs/superpowers/specs/2026-06-30-live-trading-milestone-design.md`,
-> LX-01..LX-15). It does NOT re-litigate locked decisions. Where a behavior is fixed by a locked
-> decision it is tagged (e.g. `[LX-13]`) and treated as a constraint, not an open option.
-> "Complexity" is engineering cost *given the existing engine*; "Dependencies" name the existing
-> components a behavior leans on. Phase tags map to the 6 locked phases.
+> **Job of this doc (per the brief):** validate the spec's seven capability areas against how Nautilus/LEAN actually do it, flag any **table-stakes gap** the spec misses, and flag any **over-engineering risk** for a single-operator crypto engine — the ★ P10–P12 feature-adds are the trim-risk zone. The spec already LOCKS the design (LR-NN / CF-NN); each capability below carries an explicit **Spec reconciliation: AGREE / GAP / OVER-ENGINEERING RISK** verdict.
 
 ---
 
-## Verified venue/library facts (the load-bearing ones)
+## How the reference frameworks are built (grounding)
 
-These three facts shape almost every table-stakes behavior below:
+| Concern | Nautilus Trader | QuantConnect LEAN | iTrader v1.8 spec |
+|---|---|---|---|
+| Shared core | `NautilusKernel` shared by backtest + live; `TradingNodeConfig` **inherits** `NautilusKernelConfig` | `LeanEngineSystemHandlers` / `LeanEngineAlgorithmHandlers` swapped per mode | `compose_engine(ctx, spec)` shared seam; `build_live_system` vs `build_backtest_system` factories (LR-10) |
+| Event transport | single `MessageBus`, **single-threaded, strict FIFO**, deterministic | job-packet-driven pipeline | two-tier `PriorityEventBus` (CONTROL > BUSINESS) live; `FifoEventBus` backtest (LR-11) |
+| Execution venue registry | `add_exec_client_factory(name, Factory)` | `IBrokerageFactory` + `IBrokerageModel` via **Composer** | `ExecutionVenueRegistry` + `VenuePlugin` (LR-17) |
+| Data provider registry | `add_data_client_factory(name, Factory)` — **separate** from exec | `IDataQueueHandler` (Composer part) — **separate** from brokerage | `DataProviderRegistry` + `LiveDataProvider` Protocol (LR-17) |
+| Pre-trade safety | `RiskEngine`: `TradingState ∈ {ACTIVE, HALTED, REDUCING}` + submit/modify rate limits + max-notional | brokerage-model order controls | `SafetyController` state latch + CF-1 aggregate circuit breaker |
+| Multi-account | one `Account` **per venue**, aggregated in one `Portfolio` | single algorithm → single portfolio | one `Account` **per `account_id`**, M:N strategy↔portfolio (LR-03/LR-20) |
+| Runtime config mutation | set at node build (immutable at runtime) | set at job packet (immutable at runtime) | durable scoped `ConfigUpdateEvent` platform (LR-04) — **beyond both** |
 
-1. **OKX `candle{tf}` WS channel carries a `confirm` flag** — the candle payload is
-   `[ts, o, h, l, c, vol, volCcy, volCcyQuote, confirm]`; `confirm="1"` = closed/final,
-   `confirm="0"` = still forming. The first message after subscribe may be an incomplete bucket.
-   *(HIGH — OKX v5 docs.)* This is the authoritative bar-close signal (LX-08); wall-clock inference
-   is unnecessary and wrong.
-2. **ccxt.pro `watchOHLCV` returns the still-forming last candle** — it emits the current bucket on
-   every update (and typically the prior formed candle), so a naive "take `[-1]`" leaks an unconfirmed
-   bar into the engine. The LiveBarFeed MUST gate on `confirm` (native field) and only emit on the
-   transition `0→1` (or the arrival of a new bucket that closes the prior one). *(HIGH — ccxt issues +
-   pro manual; this is exactly why LX-12 keeps a native escape hatch for confirm-flag fidelity.)*
-3. **REST `fetch_ohlcv` returns closed bars** and is the correct warmup/backfill/gap-fill source;
-   it is paginated and rate-limited. *(HIGH — ccxt unified method.)*
-
-A fourth, lower-confidence flag carried for plan-time: OKX `orders`/`fills` private channels deliver
-partial fills as incremental `fillSz`/`accFillSz` updates with an order `state`
-(`live`/`partially_filled`/`filled`/`canceled`); fees and funding arrive on their own events. *(MEDIUM
-— consistent across OKX docs + ccxt `watchOrders`/`watchMyTrades`, exact field cadence is the Phase 2/5
-plan-time research item already flagged in the sketch §8.)*
+**Two structural facts that anchor most verdicts below:**
+1. **The two-registry split (exec vs data) is table stakes, not novel.** Both Nautilus (`add_exec_client_factory` / `add_data_client_factory`) and LEAN (`IBrokerageFactory` / `IDataQueueHandler`) ship exactly this separation. The spec's LR-17 is the proven pattern, not an invention.
+2. **Nautilus/LEAN both freeze config at construction.** Neither ships a durable runtime-config-override-via-events platform. That makes iTrader's P10 a genuine *differentiator* — and simultaneously the single biggest over-engineering risk for a one-operator engine.
 
 ---
 
 ## Feature Landscape
 
-The 7 question areas are grouped under each category. Each row notes complexity and the existing
-component it depends on.
+### Table Stakes (any trusted live engine has these)
 
-### Table Stakes (Required to be Correct/Safe)
+| # | Capability | Why expected (framework precedent) | Complexity | Spec phase / reconciliation |
+|---|---|---|---|---|
+| TS-1 | **God-object → composition root + shared engine seam + run-driver + thin facade** | Nautilus `NautilusKernel` shared, `TradingNode` thin over it; LEAN system/algorithm handler split. A 2,171-line God object is the anti-pattern both avoid. | HIGH | P1–P7. **AGREE** — LR-10 mirrors the Nautilus kernel/node split precisely. |
+| TS-2 | **Venue parametrization (zero `if exchange==...`)** | Nautilus/LEAN both dispatch venues through a factory registry; hardcoded venue branches are the smell being removed. | HIGH | P6. **AGREE** — `VenueLifecycle` None-guards + registry kills every branch (LR-17). |
+| TS-3 | **Separate execution-venue + data-provider registries** | Nautilus `add_exec_client_factory` vs `add_data_client_factory`; LEAN `IBrokerageFactory` vs `IDataQueueHandler`. The decoupling (paper-exec + real-data) is why both keep them separate. | MEDIUM | P6. **AGREE** — LR-17 two registries, directly matches both frameworks. |
+| TS-4 | **Connector sharing / memoization per venue** | Nautilus shares one client per venue across data+exec; opening N duplicate authenticated sessions is wasteful and rate-limit-hostile. | MEDIUM | P6. **AGREE** — `dict[(venue, account_id)]` memoization (LR-17/LR-20). |
+| TS-5 | **Halt / kill-switch state machine** | Nautilus `RiskEngine.TradingState=HALTED` (new orders denied, cancels pass). A live engine with no hard-stop is untrustworthy. | MEDIUM | P8. **AGREE** — `SafetyController` latch, `VALID_STATUS_TRANSITIONS`, `HALTED` no-exit-except-operator. |
+| TS-6 | **Durable halt record + startup refusal** | A crashed-while-halted engine that silently resumes RUNNING is a money-loss bug. | MEDIUM | P8. **AGREE** — `check_durable_halt_on_start()` runs first, re-latches from persisted reason (LR-22 `halt_records`). |
+| TS-7 | **Startup reconciliation (venue truth vs local intent)** | Every restart-safe live engine reconciles broker state on boot; drift-then-trade is catastrophic. Nautilus reconciles execution state on connect. | HIGH | P8. **AGREE** — `ReconciliationCoordinator` rehydrate→reconcile→baseline guard, per-portfolio. |
+| TS-8 | **Stream reconnect + gap recovery + resume gate** | ccxt.pro / any WS feed drops; catch-up + snapshot + health-gate before resuming submission is standard. | HIGH | P8. **AGREE** — `StreamRecoveryHandler` (CF-2 backfill-on-resume, loop-native). |
+| TS-9 | **Injected error policy (fail-fast backtest / publish-and-continue live)** | A single handler failure must not abort a live session nor false-green a backtest. Nautilus isolates component faults. | MEDIUM | P9. **AGREE** — `ErrorPolicy` injected (removes the monkeypatch), per-handler granularity, WR-06 guards. |
+| TS-10 | **Aggregate error-rate circuit breaker** | Nautilus `RiskEngine` submit/modify **rate limits**; a money route failing every event while "publish-and-continue" runs infinitely green is the exact hole CF-1 closes. | MEDIUM | P9 (CF-1). **AGREE — and this is the one table-stakes safety item that is a genuine *add*, not just a refactor.** Route-classified ring (SETTLEMENT halt-on-first, ORDER-IO N=3/60s, etc.). |
+| TS-11 | **Handler-owns storage init (uniform backtest/live)** | Storage wiring living in the composition God object is the smell; the `PortfolioHandler` pattern already proves the shape. | MEDIUM | P3. **AGREE** — LR-13, `(environment, sql_engine)` + `storage=` override. |
+| TS-12 | **Centralized, import-safe config** | One config surface, not scattered module constants; import must not do credential I/O (inertness gate). | MEDIUM | P1. **AGREE** — `SystemConfig` eager/lazy split; lazy `sql`, per-venue creds never global. |
 
-| # | Feature | Why Required | Complexity | Phase / Depends on |
-|---|---------|--------------|------------|--------------------|
-| **Live data engine** |
-| 1 | **Bar-close detection via OKX `confirm` flag** — emit a `BarEvent` only on a *completed* bar; never on the forming bucket | Strategies/indicators are built on closed-bar semantics (bar-feed rule 2); a forming bar = look-ahead + indicator corruption. ccxt streams the forming candle, so this gate is mandatory, not optional | MEDIUM | P3. `BarFeed` ABC; 7-rule contract in `bar_feed.py`; OKX connector data arm (P2) |
-| 2 | **Warmup/backfill at live-start through the *identical* `update(bar)` path** [LX-09] | Stateful O(1) indicators (SMA/EMA/MACD/RSI) need K prior bars to be "ready"; a second bulk-warm path diverges and re-opens the parity audit. REST `fetch_ohlcv` last-K, replayed one-by-one | MEDIUM | P3. Stateful indicators (v1.5); `cache_capacity()` derivation; REST data arm |
-| 3 | **Monotonic-forward-only delivery** [LX-10] — gap→backfill-and-replay; duplicate→drop; out-of-order/stale→reject; reconnect→gap-fill interim | Stateful indicators have **no rewind**; feeding state backward silently corrupts every downstream decision. This is the single hardest correctness property of the live feed | HIGH | P3. Ring-buffer feed; stateful indicators; connector reconnect (P2) |
-| 4 | **Ring-buffer `BarFeed` impl serving `window()`/`newest_bar()`/`current_bars()`** [LX-07] | The engine above the feed speaks one contract; only the backing store changes (precompute→stream). Bounded deque per `(symbol, tf)` sized by the same wiring-time capacity as backtest | MEDIUM | P3. `BarFeed` ABC (the seam already exists) |
-| 5 | **Event-driven time source replacing `TimeGenerator`** — closed-bar arrival drives the cycle | Backtest iterates a pinned grid; live has no grid — the closed bar *is* the clock tick | MEDIUM | P3. `EventHandler` TIME/BAR routes; `generate_bar_event` factory |
-| **Live execution loop** |
-| 6 | **Order submit→ack→fill-stream lifecycle** (market/limit/stop on OKX) | A live venue is async and authoritative: you submit, get an order-id ack, then fills arrive asynchronously on a stream — unlike backtest where `on_bar` returns fills synchronously | HIGH | P2/P5. `LiveConnector` interface; order mirror (v1.6); async/sync bridge |
-| 7 | **Partial-fill handling** — accumulate `accFillSz`, weighted-avg fill price, terminalize only at full fill/cancel | Real venues fill in pieces; the engine's `MatchingEngine` is full-quantity-only (D-06). The *live* path must reconcile partials the matching engine never produces | HIGH | P5. Order mirror reconcile (`on_fill`); `VenueAccount` |
-| 8 | **Order-status reconciliation from venue truth** — map OKX `state` → mirror status (`live`→PENDING, `partially_filled`/`filled`→FILLED, `canceled`→CANCELLED, rejected→REJECTED) | The venue, not the engine, is the source of truth live. Mirror must follow venue state transitions, same shape as today's `OrderHandler.on_fill` reconcile | MEDIUM | P5. Order mirror; `VALID_ORDER_TRANSITIONS`; SQL order store (v1.6) |
-| 9 | **Idempotent client order IDs** (`clOrdId`) on every submit | Resend after a timeout/reconnect must not double-submit; the venue dedupes on client id. The engine already has a single UUIDv7 scheme to source these | LOW | P2. `idgen` (UUIDv7); `LiveConnector` |
-| **Paper trading** |
-| 10 | **Local paper reuses the pure `MatchingEngine` + fee/slippage, bar-based fills only** [LX-06/LX-13] | This is the milestone DoD's correctness anchor: same matching core → deterministic → paper-parity holds. A `PaperConnector` composes the I/O-free engine (`submit`/`on_bar→decisions`) | MEDIUM | P4. `MatchingEngine`; fee/slippage models; `SimulatedAccount` (P1) |
-| 11 | **Paper-parity gate vs the backtest oracle on a fixed dataset** [LX-11] | Live has no golden-master; paper-parity-vs-backtest is the closest equivalent. Replaying a fixed dataset through the live path offline must reproduce `134 / 46189.87730727451` | HIGH | P4. Oracle harness; `SimulatedAccount`; `LiveBarFeed` |
-| 12 | **`SimulatedAccount` computes balance/margin locally (paper + backtest)** [LX-03] | Paper shares the *backtest's* computation column — that shared math is exactly what preserves parity. Same spot/margin code, verbatim | MEDIUM | P1. `Portfolio`/`cash` managers; margin model (v1.4) |
-| **Account abstraction** |
-| 13 | **`Account` ABC owning balance/margin truth; `Simulated*` vs `Venue*` leaves; cash-vs-margin axis** [LX-03] | Margin/liq logic currently mis-housed in `PortfolioHandler` is an *account* concept; extracting it cleanly is the oracle-gated Phase 1 refactor that everything live depends on | HIGH | P1. `Portfolio`, `PortfolioHandler` (margin/liq methods); v1.4 margin model. **Must stay byte-exact** |
-| 14 | **`VenueAccount` caches venue balance/margin/position streams** [LX-03] | Live cannot compute truth locally (fees, funding, venue rounding diverge); it caches what the venue reports and reconciles | MEDIUM | P5. `LiveConnector` balances/positions stream; `Account` ABC (P1) |
-| 15 | **1 account : 1 portfolio** [LX-04] — one OKX subaccount per strategy-portfolio | Dissolves venue-aggregate→per-portfolio *attribution* at the source; reconciliation collapses to per-symbol drift. Assumes exclusive control of the (sub)account | LOW (constraint, not code) | P1/P5. `Portfolio`; `Account` |
-| **Venue reconciliation** |
-| 16 | **Per-symbol drift detection** (partial fills, fees, funding, liquidations) under 1:1 | Without it, cached `VenueAccount` silently diverges from reality and the engine trades on a phantom balance — the core live-safety property | HIGH | P5. `VenueAccount`; SQL portfolio-state store (v1.6); connector streams |
-| 17 | **Repair policy: halt-and-alert on unexplained drift** (auto-correct only within a defined tolerance) | Trading through an unreconciled discrepancy is how live systems blow up. Default-safe = stop and surface; auto-correct is the *narrow* exception, not the rule | MEDIUM | P5. `LiveTradingSystem` publish-and-continue error seam; `ErrorEvent` |
-| **Persistence live-drive** |
-| 18 | **Drive the v1.6 operational store with the real feed** (orders / portfolio-state / signals write-through) | The store was built + testcontainer-verified but never driven by a live feed; live is where write-through/purge-on-terminalize actually run | MEDIUM | P5. SqlOrderStorage, SqlPortfolioStateStorage, SqlSignalStorage (v1.6) |
-| 19 | **Restart rehydration against a live venue** — reconstruct working set from store *and* reconcile vs venue | v1.6 rehydration was store-only; the broker side needs the live adapter so a restart doesn't resurrect a stale position the venue already closed | HIGH | P5. v1.6 open-only restart rehydration; `VenueAccount`; reconciliation (#16) |
-| **Resilience / operational** |
-| 20 | **WebSocket reconnect with gap recovery** — connector owns transport reconnect; feed owns bar-gap fill | Streams drop; a silent reconnect that skips bars corrupts indicators. Reconnect must trigger the gap-fill path (#3) | HIGH | P2 (transport) + P3 (gap-fill). Connector; ring-buffer feed |
-| 21 | **Rate-limit handling** shared across ccxt + native paths | OKX throttles REST + WS subscribe; uncoordinated calls across the two paths get the connection banned | MEDIUM | P2. `OkxConnector` (ccxt.pro + native escape hatch) |
-| 22 | **Secrets management** — real OKX key/secret out of code; sandbox vs live key separation tied to the single `sandbox` flag | Live adds real credentials; leaking them = direct financial loss | LOW | P2/cross-cutting. `pydantic-settings` `Settings` (`ITRADER_` prefix), `SecretStr` |
-| 23 | **Single `sandbox: bool` routing both ccxt (`set_sandbox_mode`) and native (`x-simulated-trading` header)** [LX-05] | A split-brain live/demo state (one path live, one demo) is a catastrophic foot-gun; one flag, both paths | LOW | P2. `OkxConnector`; `Settings` |
-| 24 | **FL-13: test coverage on the live surface** (`LiveTradingSystem`/`TradingInterface`) | The live composition root is currently uncovered; build coverage as each phase lands, not after | MEDIUM | All live phases. `LiveTradingSystem`; LX-14 `TradingInterface` decision |
-| **Dynamic universe** |
-| 25 | **Warmup-on-add** — a newly added symbol replays history through the same `update(bar)` path | Adding a symbol mid-run with cold indicators = garbage signals; reuses Phase 3's backfill machinery | MEDIUM | P6. Phase 3 backfill-through-update; `universe/membership.py` (D-20) |
-| 26 | **Open-position-handling-on-remove** | Dropping a symbol that holds an open position silently orphans risk; must have a defined policy (force-close vs orphan-and-track) | MEDIUM | P6. `Portfolio` position manager; order submit path |
+### Differentiators (beyond the LEAN/Nautilus single-operator baseline)
 
-### Differentiators (Beyond Correct-and-Safe)
+| # | Capability | Value proposition | Complexity | Spec phase / reconciliation |
+|---|---|---|---|---|
+| DF-1 | **Two-tier priority event bus (CONTROL > BUSINESS)** | Nautilus is strict single-tier FIFO; a kill-switch or config command queues *behind* a market-data backlog. Priority-lifting only operational/safety/config events (never trading intents) lets the kill switch preempt without breaking causal trading FIFO. | MEDIUM–HIGH | P2. **AGREE, with a caveat.** Genuinely beyond Nautilus and solves a real latency problem. Risk is subtle: any event mis-classified into CONTROL that participates in trading causality corrupts state — the spec correctly pins `SIGNAL` to BUSINESS. Keep `_CONTROL_EVENT_TYPES` a tiny, reviewed frozenset. Unbounded-but-monitored is fine at single-operator volume; a real depth cap/backpressure is correctly deferred. |
+| DF-2 | **Durable runtime-config platform (scoped, allowlisted, survives restart)** | Neither Nautilus nor LEAN can mutate config at runtime — both freeze at construction. A FastAPI-controllable engine that changes fee params / poll cadence / risk limits / strategy enablement live, durably, and re-applies on restart is a real operator win. | HIGH | P10 ★. **AGREE that it's valuable; OVER-ENGINEERING RISK on scope — see below.** |
+| DF-3 | **Durable strategies registry (which strategies trade survives restart; runtime enable/disable)** | Nautilus adds strategies at node config (static); LEAN is one-algorithm-per-deploy. A registry where the active set is durable and toggle-able at runtime via `STRATEGY_COMMAND` is an operator capability neither ships out of the box. | MEDIUM | P11 ★. **AGREE.** Split value: *durable-resume* is near-table-stakes once multi-strategy is real; *runtime toggle mid-session* is the differentiator slice (and the trimmable one). |
+| DF-4 | **Multi-strategy / multi-portfolio-live, per-`account_id` keying (M:N)** | LEAN is single-portfolio; Nautilus is account-per-venue aggregated into one portfolio. iTrader's signal-fan-out to N portfolios, each sizing independently against its own `account_id` venue account, is a superset — one strategy trading across multiple accounts at once. | HIGH | P12 ★. **AGREE.** Aligned with Nautilus's account-per-venue truth model, generalized to account-per-portfolio. The hard-but-right part is `client_order_id` correlation + per-portfolio reconcile. |
+| DF-5 | **Stats/state snapshot as a store-backed UI read-model** | Exposing `state.*` / `stats.*` from a key-value store the UI reads without touching hot-path locks is a clean seam for the downstream FastAPI app. | LOW–MEDIUM | P10 ★ (`system_store`). **AGREE** — cheap, and it's the read-side the FastAPI milestone needs. |
+| DF-6 | **First-class `paper` venue plugin (simulated fills + real live data)** | Paper-trading against a *live* feed as a production venue (not a test hack) is how you validate a strategy pre-real-money. LEAN/Nautilus support paper accounts; making it a registry plugin (aliasing `SimulatedExchange`) is the clean expression. | LOW–MEDIUM | P6/P13. **AGREE** — `paper` = production plugin; `replay` = test-only fixture (clean split, LR test-migration). |
 
-| Feature | Value Proposition | Complexity | Phase / Depends on |
-|---------|-------------------|------------|--------------------|
-| **Connector abstraction is ours, not ccxt's** [LX-05] — `LiveConnector` shaped on OKX reality, ccxt.pro default + native escape hatch hidden behind it | Keeps OKX fidelity (confirm flag, order-status nuance) *and* a cheap 2nd-venue path; most frameworks either marry ccxt or hand-roll one venue. This is the structural bet | HIGH | P2. New interface; reuse `ccxt_provider.py`/`binance_stream.py` plumbing |
-| **Trade-aggregation-capable bar source seam** [LX-12] — klines now, trades behind the same bar-close interface later | Future optionality (slippage research, tick-backtester) without paying for it now; justified by optionality, NOT by paper fills | LOW (seam only) | P3. Ingestion seam in `LiveBarFeed` |
-| **Separate-worker / process-per-portfolio runtime** [LX-15] — engine as its own service, FastAPI controls lifecycle via the Postgres system-of-record | Crash isolation, independent scaling, thin web layer. This is *precisely* what v1.6's durable store + restart rehydration were built to enable | HIGH | Cross-cutting (decide before P4 wiring). v1.6 store-as-truth; restart rehydration |
-| **Deterministic offline parity harness** — replay a recorded/fixed dataset through the live thread | Turns "did live break?" from a guess into a regression test; reuses the byte-exact oracle | MEDIUM | P4. Oracle; determinism seams (seeded RNG, injected clock) |
-| **OKX sandbox-validated real order arm** | A real I/O path proven against demo before any capital — de-risks the eventual real-money stretch | MEDIUM | P5. `OkxConnector` order arm; `x-simulated-trading` |
+### Anti-Features (correctly avoided — do NOT build for a single-operator crypto engine)
 
-### Anti-Features (Out of Scope — Do NOT Build)
+| Feature | Why it gets requested | Why problematic here | Spec status / verdict |
+|---|---|---|---|
+| **Config audit-trail table** (`system_config_audit`) | "Track who changed what config when." | Single operator, no compliance driver; a full audit table + write path is machinery for a governance need that doesn't exist yet. | Spec **defers** (§14). **AGREE — keep deferred.** |
+| **Errors-history table** | "Persist every error for forensics." | The ERROR route already logs (structured) + persists `state.last_error`; a full history table contends with hot-path writes for no single-operator payoff. | Spec **defers** (§14). **AGREE — keep deferred.** Latest-error-in-`system_store` is the right minimum. |
+| **Multi-provider feed-router** (crypto aggregator + forex concurrently) | "Trade multiple asset classes at once." | Needs `set_provider` → a symbol/asset-class-keyed router; premature for a crypto-first single-venue operator. The two-registry decoupling *enables* it later without building it now. | Spec **defers** (§14). **AGREE.** |
+| **Shared-`account_id` risk allocator** (N portfolios pooling one venue account) | "Split one account's buying power across strategies." | The venue can't partition pooled buying power back out — needs a whole risk-allocation subsystem. Express "many strategies, shared account" as many strategies on *one* portfolio instead. | Spec **defers, fail-loud** (§10a). **AGREE — the distinct-`account_id` invariant is the right guardrail.** |
+| **Single-connector-multi-`account_id` optimization** (OKX master key routing) | "One session for all accounts." | Micro-optimization; one connector per `account_id` is simpler and correct. Only worth it at many-accounts scale. | Spec **defers** (§14). **AGREE.** |
+| **Plugin auto-discovery** (entry-points / Composer-style dynamic class loading) | "Drop a venue in and it's found." | LEAN's Composer exists because it's a hosted multi-tenant platform. A single-operator engine registering venues explicitly in a factory is simpler, inertness-safe, and grep-able. Dynamic loading would fight the lazy-import inertness gate. | Not in spec. **AGREE with the omission — explicit factory registration is correct; do not add discovery.** |
+| **N-tier priority bus (>2 tiers) / per-event priority** | "Fine-grained scheduling." | Two tiers (CONTROL/BUSINESS) already exceed Nautilus. More tiers multiply the risk of causal reordering bugs for zero single-operator benefit. | Spec = exactly 2 tiers. **AGREE — hold the line at 2.** |
+| **General dynamic config-mutation framework** (arbitrary key mutation, type registry, schema DSL) | "Make everything runtime-tunable." | The over-engineering trap inside P10 — see risk note. Only a small allowlist of keys actually needs runtime mutation. | Spec has an **allowlist** (§6e). **AGREE — the allowlist IS the anti-over-engineering guard; enforce it narrowly.** |
 
-| Feature | Why It Seems Appealing | Why Problematic Here | Instead (locked) |
-|---------|------------------------|----------------------|------------------|
-| **Tick-level local-paper fills** | "More realistic" sub-bar fills | Breaks determinism + the paper-parity gate (the whole DoD); explodes complexity; sub-bar realism is what OKX *sandbox* is for | Bar-based local paper via reused `MatchingEngine` [LX-13]; sub-bar realism lives in OKX sandbox |
-| **Full production screener** | Mature frameworks have rich universe selection | Massive scope; not needed to deploy one strategy live | Lean poll seam only — `UniverseSelectionModel` growing `membership.py` [sketch §1, P6] |
-| **Multi-venue / multi-asset** | "Trade everywhere" | Each venue is months of fidelity work; dilutes the OKX correctness focus | Crypto-first, OKX-only; `LiveConnector` *shaped* for a 2nd venue but only OKX implemented [LX-05] |
-| **Perp realism "Phase B" (funding accrual, mark-price liq trigger, funding pipeline, freqtrade 4th oracle)** | Perps are the dominant crypto product | Additive on the v1.4 Phase-A core; its own future milestone; would derail the paper-parity gate | Deferred (FUND-01..04) [sketch §1] |
-| **Cross-margin pooling** | Capital efficiency across positions | A backtest-accounting driver, distinct from live reconciliation; conflicts with 1:1 | Deferred beyond N+2 Phase B; isolated-margin under 1:1 [sketch §1, LX-04] |
-| **Bulk `warmup_from(series)` fast-path** | Faster live-start than one-by-one replay | A second state-building path diverges from the live `update(bar)` path and re-opens the parity audit | Replay K bars one-by-one through the identical `update(bar)` path [LX-09] |
-| **Wall-clock bar-close inference** | Works when a venue has no confirm flag | OKX *has* a confirm flag; wall-clock guessing mis-fires on venue latency/clock skew and emits a forming bar | Drive "closed" off OKX `confirm`, never wall-clock [LX-08] |
-| **In-process engine inside the FastAPI process** | Simplest to wire | Couples engine + web lifecycles, mixes 3 event loops in one process, one crash kills both | Separate worker / process-per-portfolio via Postgres SoR [LX-15 b/c] |
-| **Async engine core** | The venue is async | Would rewrite the whole synchronous event engine; the async boundary belongs only at the connector edge | Async bottled in the connector thread; engine stays synchronous [sketch P2] |
-| **Auto-correct-everything reconciliation** | "Self-healing" | Trading through unexplained drift hides real bugs/loss | Halt-and-alert default; auto-correct only within a defined tolerance (#17) |
+---
+
+## Table-stakes GAP check (does the spec miss anything mature frameworks have?)
+
+Only one candidate gap surfaced against the Nautilus/LEAN baseline, plus two minor notes:
+
+- **GAP (MEDIUM): pre-trade order-rate / max-notional throttle, distinct from the post-error circuit breaker.** Nautilus `RiskEngine` enforces **submit/modify rate limits** and **max-notional-per-order** *before* an order reaches the venue (`OrderDenied`). iTrader has `EnhancedOrderValidator` + cash-reservation admission (pre-trade sizing/cash gates) and CF-1 (a *post-hoc* error-rate breaker), but **no pre-trade throttle on order submission velocity**. A runaway strategy spamming valid orders is caught by neither the validator (each order is individually valid) nor CF-1 (no errors are raised). For a live crypto engine this is a real safety surface. **Recommendation:** flag as a candidate requirement in P8/P9 (`SafetyController` or admission) — a simple submit-rate ceiling + max-notional-per-order guard. It is *not* in the spec's 26 concerns or CF list. Low-cost to add (a counter + threshold on the admission path); high safety value. Rank it against P9's CF-1 work since they share the "runaway protection" theme.
+- **Minor note (REDUCING state):** Nautilus has a third trading state, `REDUCING` (accept only exposure-reducing orders). iTrader has `halt` (freeze) + `pause_submission` (reversible quiesce). `pause_submission` with deferred-protective-order replay covers most of the operational need; a full `REDUCING` mode (let stops/exits through, block entries) is a *nice-to-have*, not a gap — the deferred-protective queue already prioritizes protective orders on resume. Do not build `REDUCING` now; note it as a future safety refinement.
+- **Minor note (no gap):** Nautilus's `RiskEngine` is a *first-class engine on the submit path*; iTrader spreads the equivalent across `AdmissionManager` + `SafetyController` + CF-1. That's a topology choice, not a missing capability — coverage is equivalent once the pre-trade throttle above is added.
+
+---
+
+## Over-engineering risk zone (the ★ P10–P12 trim boundary)
+
+The brief asks specifically to flag over-engineering for a single-operator crypto engine. Assessment per ★ phase:
+
+| Phase | Verdict | Reasoning |
+|---|---|---|
+| **P10 ★ Runtime-config platform** | **HIGHEST trim/scope risk.** Keep — but scope hard. | Value is real (FastAPI-controllable engine), but the failure mode is building a *general* config-mutation framework when **~5–8 keys** actually need runtime mutation (fee/slippage params, poll cadence, `universe_remove_policy`, risk limits, strategy enable/disable). The **allowlist is the discipline** — if the allowlist stays small and the "framework" is just `event → route-to-owner → persist → overlay`, it's proportionate. The risk is the allowlist quietly growing and a schema/validation DSL accreting. **Guidance for requirements:** cap the initial allowlist explicitly; treat "add a runtime-mutable key" as a deliberate decision, not a default. Stats-snapshot + `system_store` read-model (DF-5) is cheap and should stay even if the mutation path is trimmed. |
+| **P11 ★ Strategies registry** | **Keep the durable half; the runtime-toggle half is the trimmable slice.** | *Durable resume* (restart re-registers the active set) is near-table-stakes the moment multi-strategy live is real — without it a restart silently drops strategies. *Runtime enable/disable mid-session via `STRATEGY_COMMAND`* is the differentiator and the part that could defer to the FastAPI milestone if P11 needs trimming. Complexity is moderate (mirror `HaltRecordStore`). Low over-engineering risk as long as it stays a store + rehydrate + one command route. |
+| **P12 ★ Multi-portfolio-live** | **Keep — it's the LR-03 reason this milestone exists; not over-engineered.** | Deleting the single-portfolio guard + `client_order_id` correlation + per-portfolio reconcile is the correct generalization of Nautilus's account-per-venue model. The genuinely-hard parts (per-`account_id` reconcile, attribution) are inherent to multi-account live, not gold-plating. The **deferred shared-`account_id` risk allocator is the right cut** — that one *would* be over-engineering. Distinct-`account_id` fail-loud invariant is the correct guardrail. |
+
+**Net:** the spec's own trim boundary (P1–P9+P13 core; P10–P12 ★) is well-drawn. If schedule pressure hits, trim in this order: **(1)** P10's runtime-*mutation* path (keep the read-model), **(2)** P11's runtime-*toggle* (keep durable-resume), **(3)** never trim P12 (it's the milestone's LR-03 mandate) and never trim P8/P9 safety.
 
 ---
 
 ## Feature Dependencies
 
 ```
-Phase 1: Account abstraction (Account ABC, Simulated* leaves, Venue* interface-only)
-    ├──gates──> SimulatedAccount math (#12)        ──required-by──> Paper parity (#11)
-    └──gates──> VenueAccount interface (#14)        ──required-by──> Reconciliation (#16)
+P1 Config centralization ──┐
+                           ├──> P3 EngineContext + storage-in-handler ──> P4 SqlEngine rename ──> P5 New stores
+P2 Event bus ──────────────┘                                                                        │
+                                                                                                    ├──> P6 Venue registry + bundle
+P2 ─────────────────────────────────────────────────────────────────────────────────────────────┘        │
+P5 + P6 ──> P7 LiveRunner + factory + facade shrink (SessionInitializer / UniverseWiring — ORACLE-SENSITIVE)
+P7 ──> P8 Safety + reconciliation + stream recovery ──┐
+P7 ──> P9 Error subsystem (CF-1 circuit breaker)      │
+                                                       ├──> P10 ★ Runtime-config platform  (needs P5 stores + P8 CONTROL routes)
+P5 + P7 ──> P11 ★ Strategies registry                 │
+P6 + P8 ──> P12 ★ Multi-portfolio-live                │
+P7 + P12 ──> P13 Test migration (replay→fixture, gates)
 
-Phase 2: OKX connector (LiveConnector + OkxConnector, data arm + order arm)
-    ├── data arm ──required-by──> LiveBarFeed (#1,#4) [Phase 3]
-    └── order arm ──required-by──> Live real path (#6,#7,#8) [Phase 5]
-
-Phase 3: LiveBarFeed
-    ├── bar-close detection (#1) ──requires──> connector data arm + OKX confirm flag
-    ├── warmup-through-update (#2) ──requires──> stateful indicators (v1.5)
-    ├── monotonic-forward-only (#3) ──requires──> ring buffer (#4) + reconnect (#20)
-    └── backfill machinery ──reused-by──> warmup-on-add (#25) [Phase 6]
-
-Phase 4: Paper path (DoD)
-    └──requires──> Phase 1 (SimulatedAccount) + Phase 3 (LiveBarFeed) + connector DATA arm
-        (NOT the order arm) ──validated-by──> paper-parity gate (#11)
-
-Phase 5: Live real path
-    └──requires──> Phase 2 order arm + Phase 1 VenueAccount + v1.6 SQL store
-        ├── reconciliation (#16) ──required-by──> restart rehydration vs venue (#19)
-        └── partial fills (#7) ──feeds──> order-status reconcile (#8) ──writes──> SQL order store
-
-Phase 6: Dynamic universe
-    └──pairs-with──> Phase 3 (reuses backfill-through-update for warmup-on-add #25)
-
-Cross-cutting (Phases 2–5): runtime topology [LX-15] ──decide-before──> Phase 4 wiring
-                            reconnect/rate-limit/secrets/FL-13 ──woven-through──> each phase
+CONTROL-plane routes (P8) ──enable──> P10 ConfigUpdateEvent + P11 STRATEGY_COMMAND
+PriorityEventBus (P2) ──enables──> CONTROL > BUSINESS preemption for all of the above
+Venue registry (P6) ──enables──> P12 connector memoization by (venue, account_id)
 ```
 
-### Dependency Notes
+### Dependency notes (framework-grounded)
 
-- **Paper parity (#11) requires SimulatedAccount (#12) sharing the backtest computation column.**
-  Paper sits in the middle column of the parity spine but borrows the *left* (backtest) column's math —
-  that shared computation is the only thing that makes parity hold. If paper computed anything its own
-  way, the gate is meaningless.
-- **LiveBarFeed monotonic-forward-only (#3) requires reconnect (#20) to route into gap-fill, not
-  re-subscribe-fresh.** A reconnect that just resubscribes silently skips the interim bars; it must
-  detect the gap and REST-backfill-and-replay through `update(bar)`.
-- **Restart rehydration vs venue (#19) requires reconciliation (#16).** Rehydrating the working set
-  from the store alone (v1.6 behavior) can resurrect a position the venue closed while the worker was
-  down; the broker-side reconcile is the new live half.
-- **Phase 1 is the universal gate** — it is behavior-preserving and oracle-gated; *no live code may
-  depend on the Account abstraction until backtest is re-confirmed byte-exact* (`134 / 46189.87730727451`).
-- **Warmup-on-add (#25) reuses Phase 3 backfill (#2)** — same `update(bar)` replay path, so Phase 6 is
-  cheap *only if* Phase 3 built the seam generically (per-symbol, not start-only).
+- **Everything routes through P2 (the bus) and P6 (the registry).** These are the two structural seams the rest hang off — exactly the `MessageBus` + client-factory-registry pair that anchor a Nautilus `TradingNode`. Sequence them early (spec does: P2 foundation, P6 first live-decomposition phase).
+- **P10/P11 depend on the CONTROL plane (P8) *and* the durable stores (P5).** Runtime config and strategy toggles are only meaningful once (a) a CONTROL event can preempt the business flow and (b) a store makes them survive restart. This is why they're correctly last.
+- **P12 depends on the venue registry (P6) for per-`account_id` connector keying and on safety (P8) for per-portfolio reconcile.** Multi-account without reconciliation is the drift-then-trade hazard.
+- **P7 is the oracle-sensitive chokepoint.** `UniverseWiring` is *shared* with backtest — the refactor may only extract it if the backtest path stays byte-identical (LR-02). This is the one live-decomposition phase with real oracle risk; the priority bus and stores carry *zero* oracle risk (backtest uses `FifoEventBus` + `sql_engine=None`).
 
 ---
 
-## Paper-Parity Requirements (concrete + testable — the DoD anchor)
+## MVP Definition (the trim boundary, restated for requirements)
 
-For the paper-parity gate [LX-11] to be meaningful and pass, ALL must hold:
+### Core refactor — must ship this milestone (P1–P9 + P13)
 
-1. **Same matching core.** Local paper composes the *same* `MatchingEngine` instance class the backtest
-   uses (full-quantity fills, next-bar-open, OCO, STOP-beats-LIMIT, trailing ratchet) — no
-   paper-specific fill logic. [LX-06]
-2. **Same account math.** `SimulatedAccount` runs the verbatim spot/margin/carry/liquidation code
-   extracted in Phase 1 — Decimal end-to-end, same quantization boundaries. [LX-03]
-3. **Same closed bars, same order.** The fixed dataset replayed through `LiveBarFeed` must deliver the
-   identical sequence of closed `Bar`s (same timestamps, same Decimal OHLCV) the `BacktestBarFeed`
-   produces — proving bar-close detection + warmup-through-update introduce no drift.
-4. **Same determinism seams.** The seeded `random.Random` (`performance.rng_seed=42`) and injected
-   clock must thread into the paper path; fills must not consume wall-clock time or unsourced RNG.
-5. **Byte-exact equality, not tolerance.** The parity assertion reuses the oracle's exact-diff
-   discipline: `134` trades and `final_equity == 46189.87730727451` — `check_exact=True`, no float
-   tolerance.
-6. **Inertness on the backtest hot path.** The live machinery must be provably inert when not running
-   live — no W1/W2 regression vs the v1.5 baseline (15.7 s / 152.8 MB), same as the v1.6 import-quarantine
-   discipline.
+- [ ] TS-1 God-object decomposition (factory + `compose_engine` + `LiveRunner` + ~200-line facade) — the milestone's north star (LR-00)
+- [ ] TS-2/TS-3/TS-4 Venue parametrization + two registries + connector memoization — kills every `if exchange==` (P6)
+- [ ] TS-5/TS-6/TS-7/TS-8 Safety state machine + durable halt + reconciliation + stream recovery (P8)
+- [ ] TS-9/TS-10 Injected `ErrorPolicy` + **CF-1 aggregate circuit breaker** (P9) — the one HIGH-priority safety add
+- [ ] TS-11/TS-12 Handler-owns storage + centralized import-safe config (P1/P3/P4/P5)
+- [ ] DF-1 Two-tier priority bus (P2) — foundational, everything else preempts through it
+- [ ] DF-6 `paper` production venue plugin; `replay`→test fixture (P6/P13)
+- [ ] **CANDIDATE GAP:** pre-trade order-rate / max-notional throttle (evaluate into P8/P9)
 
-**Testable harness shape (open item, sketch §4):** prefer *replay a fixed dataset through the live path
-offline* (deterministic, CI-runnable) over *record-a-live-session-then-replay* (non-deterministic,
-network-bound). The offline replay feeds a recorded/fixed bar stream into `LiveBarFeed` and asserts the
-oracle numbers — this is also the differentiator "deterministic offline parity harness."
+### ★ Feature-adds — in scope this milestone, but the trim boundary if pressure hits (P10–P12)
 
----
+- [ ] DF-4 Multi-portfolio-live (P12) — **do not trim** (LR-03 mandate)
+- [ ] DF-3 Strategies registry, durable-resume half (P11) — near-table-stakes once multi-strategy is real
+- [ ] DF-5 Stats/state store-backed read-model (P10) — cheap; the FastAPI seam
+- [ ] DF-2 Runtime-config mutation path (P10) — **scope hard via a small allowlist; first trim candidate**
+- [ ] DF-3 runtime enable/disable-mid-session (P11) — second trim candidate
 
-## MVP Definition (maps to the locked phases)
+### Future / deferred (correctly out of scope — the anti-features above)
 
-### Launch With (the milestone DoD)
-
-- [ ] **Phase 1 — Account abstraction** (#13, #12, #14-interface, #15) — gates everything; backtest stays byte-exact
-- [ ] **Phase 2 — OKX connector data + order arm** (#6, #9, #21, #23) — feeds Phases 3/5
-- [ ] **Phase 3 — LiveBarFeed** (#1, #2, #3, #4, #5, #20) — the real-time data engine
-- [ ] **Phase 4 — Paper path + parity gate** (#10, #11, #12) — *this is the DoD* (LX-01)
-- [ ] **Phase 5 — Real/sandbox path** (#7, #8, #14, #16, #17, #18, #19) — sandbox-validated
-- [ ] **Phase 6 — Dynamic universe** (#25, #26) — lean poll seam
-- [ ] **Cross-cutting** — secrets (#22), FL-13 (#24), runtime topology decision (LX-15)
-
-### Add After Validation (gated stretch / next milestones)
-
-- [ ] **Real-capital execution** — gated stretch beyond sandbox validation [LX-01]; trigger = sandbox path proven + owner sign-off
-- [ ] **Async/buffered write-through** — keep-only-measured; build only if the live loop profiles a stall [sketch P5]
-- [ ] **Trade-aggregation bar source** — slot behind the LX-12 seam; trigger = slippage-research or tick-backtester need
-
-### Future Consideration (explicitly deferred)
-
-- [ ] **Perp realism Phase B** (FUND-01..04) — own milestone
-- [ ] **Full production screener** — beyond the lean poll seam
-- [ ] **Multi-venue / multi-asset** — 2nd connector against the shaped interface
-- [ ] **Cross-margin pooling** — backtest-accounting driver, distinct concern
+- [ ] Config audit-trail table, errors-history table, multi-provider feed-router, shared-`account_id` risk allocator, single-connector-multi-account optimization, `REDUCING` trading state, plugin auto-discovery
 
 ---
 
 ## Feature Prioritization Matrix
 
-| Feature | Safety/Value | Implementation Cost | Priority |
-|---------|--------------|---------------------|----------|
-| Account abstraction (oracle-gated) (#13) | HIGH (gates all) | HIGH | P1 |
-| Bar-close via confirm flag (#1) | HIGH | MEDIUM | P1 |
-| Monotonic-forward-only delivery (#3) | HIGH | HIGH | P1 |
-| Warmup-through-update (#2) | HIGH | MEDIUM | P1 |
-| Paper-parity gate (#11) | HIGH (the DoD) | HIGH | P1 |
-| Local paper via reused MatchingEngine (#10) | HIGH | MEDIUM | P1 |
-| Submit→ack→fill lifecycle (#6) | HIGH | HIGH | P1 |
-| Partial-fill handling (#7) | HIGH | HIGH | P1 |
-| Per-symbol drift reconciliation (#16) | HIGH | HIGH | P1 |
-| Halt-and-alert repair policy (#17) | HIGH | MEDIUM | P1 |
-| WS reconnect + gap recovery (#20) | HIGH | HIGH | P1 |
-| Restart rehydration vs venue (#19) | HIGH | HIGH | P1 |
-| Secrets + single sandbox flag (#22, #23) | HIGH | LOW | P1 |
-| Idempotent client order IDs (#9) | MEDIUM | LOW | P1 |
-| Rate-limit handling (#21) | MEDIUM | MEDIUM | P2 |
-| Persistence live-drive (#18) | MEDIUM | MEDIUM | P2 |
-| Dynamic universe add/remove (#25, #26) | MEDIUM | MEDIUM | P2 |
-| Separate-worker runtime (LX-15) | MEDIUM | HIGH | P2 |
-| Trade-aggregation seam (LX-12) | LOW | LOW | P3 |
+| Capability | Operator/Live value | Impl cost | Priority | Note |
+|---|---|---|---|---|
+| God-object decomposition (TS-1) | HIGH | HIGH | P1 | The milestone reason |
+| Venue registry + two registries (TS-2/3) | HIGH | MEDIUM | P1 | Proven pattern (Nautilus/LEAN) |
+| Safety state machine + durable halt (TS-5/6) | HIGH | MEDIUM | P1 | Real-money trust floor |
+| Reconciliation + stream recovery (TS-7/8) | HIGH | HIGH | P1 | Restart-safety |
+| CF-1 circuit breaker (TS-10) | HIGH | MEDIUM | P1 | Only table-stakes *add* |
+| Pre-trade rate/notional throttle (GAP) | HIGH | LOW | P1–P2 | **Missing from spec — evaluate in** |
+| Two-tier priority bus (DF-1) | MEDIUM–HIGH | MEDIUM | P1 | Beyond Nautilus; hold at 2 tiers |
+| Injected ErrorPolicy (TS-9) | HIGH | MEDIUM | P1 | Removes monkeypatch |
+| Multi-portfolio-live (DF-4) | HIGH | HIGH | P1 (★) | LR-03 mandate — don't trim |
+| Strategies registry, durable-resume (DF-3a) | MEDIUM–HIGH | MEDIUM | P2 (★) | Near-table-stakes |
+| Stats/state read-model (DF-5) | MEDIUM | LOW | P2 (★) | FastAPI seam; keep even if P10 trims |
+| Runtime-config mutation (DF-2) | MEDIUM | HIGH | P2/P3 (★) | Scope via allowlist; first trim candidate |
+| Runtime strategy toggle (DF-3b) | MEDIUM | LOW | P3 (★) | Second trim candidate |
 
-**Priority key:** P1 = required for the DoD; P2 = should-have in-milestone; P3 = seam-only/future.
+**Priority key:** P1 = ship this milestone, core; P2 = ship this milestone, ★ feature-add; P3 = ★ trim-first-if-pressure.
 
 ---
 
-## Competitor Feature Analysis (how mature frameworks handle these)
+## Competitor Feature Analysis
 
-| Feature | Nautilus Trader | freqtrade | Hummingbot | QuantConnect LEAN | iTrader approach |
-|---------|-----------------|-----------|------------|-------------------|------------------|
-| Bar-close detection | Bar aggregator emits on close; venue confirm where available | Polls closed candles; treats last as incomplete | Real-time order-book/trade driven; candles secondary | Consolidators emit on bar close; data feed-driven | OKX `confirm` flag, never wall-clock [LX-08] |
-| Warmup/backfill | History request → same handler path; "warmup range" | `startup_candle_count` REST prefetch | N/A (order-book first) | Warm-up period replays through algorithm | One-by-one replay through identical `update(bar)` [LX-09] |
-| Gap/reconnect | Reconnect + subscription resync; data-quality checks | Re-fetch on each loop (poll model masks gaps) | Auto-reconnect; order-book resync | Brokerage reconnect + data resync | Gap→REST-backfill-replay; forward-only [LX-10] |
-| Account truth | `Account` per venue; cached from venue, reconciled | Wallet object synced from exchange | Per-connector budget checker | `SecurityHolding`/cash synced from brokerage | `Simulated*` computes / `Venue*` caches [LX-03] |
-| Paper trading | `BacktestEngine` reuse + sandbox adapters | dry-run mode (simulated wallet, live data) | paper_trade mode (simulated balances) | Paper brokerage on live data | Reused pure `MatchingEngine`, bar-based [LX-06/13] |
-| Reconciliation | Built-in venue reconciliation on start/stream | Re-sync open trades vs exchange | Status polling per order | Brokerage reconcile of holdings/orders | Per-symbol drift under 1:1, halt-and-alert [LX-04] |
-| Connector model | Native per-venue adapters | ccxt-based | Native per-connector | Native brokerage plugins | Ours over ccxt.pro + native escape hatch [LX-05] |
-| Universe | Full instrument provider / discovery | pairlists (rich) | Fixed config markets | Universe selection framework | Lean poll seam only (anti: full screener) |
-| Runtime | Standalone node/process | Single process + (optional) API | Standalone | Cloud/standalone engine | Separate worker via Postgres SoR [LX-15] |
-
-**Takeaway:** every behavior in the table-stakes list is something *all four* mature frameworks
-implement — confirming they are genuine table-stakes, not gold-plating. iTrader's distinctive choices
-(reused pure matching engine for paper, ours-over-ccxt connector, Postgres-as-system-of-record runtime)
-are deliberate differentiators that fall out of the existing engine's structure (the parity spine, v1.6
-durable store). The deferred items (full screener, multi-venue, perps) are exactly where the mature
-frameworks have spent years — correctly out of scope for "minimum surface to deploy live."
+| Capability | Nautilus Trader | QuantConnect LEAN | iTrader v1.8 (our approach) |
+|---|---|---|---|
+| Composition root | `NautilusKernel` shared; `TradingNodeConfig ⊃ NautilusKernelConfig` | System/Algorithm handler split per mode | `compose_engine` shared + mode factories (LR-10) — **same shape as Nautilus** |
+| Event transport | Single-threaded FIFO `MessageBus`, no priority | Job-packet pipeline | Two-tier `PriorityEventBus` live / `FifoEventBus` backtest — **exceeds both** |
+| Exec venue registry | `add_exec_client_factory` | `IBrokerageFactory` + Composer | `ExecutionVenueRegistry` + `VenuePlugin` — **matches** |
+| Data provider registry | `add_data_client_factory` (separate) | `IDataQueueHandler` (separate) | `DataProviderRegistry` (separate) — **matches** |
+| Venue bundle members | client + exec + instrument provider | `IBrokerage`+`IBrokerageModel`+`IDataQueueHandler`+factory | connector + exchange + account-factory + provider (4-collaborator) — **matches LEAN's separation** |
+| Pre-trade safety | `RiskEngine`: states + rate + notional limits | brokerage-model controls | `SafetyController` + admission + CF-1 — **equivalent, minus a submit-rate throttle (GAP)** |
+| Runtime config mutation | frozen at build | frozen at job packet | durable scoped `ConfigUpdateEvent` — **differentiator, neither has it** |
+| Multi-account | Account per venue → one Portfolio | single portfolio | Account per `account_id`, M:N — **superset of Nautilus** |
+| Paper trading | paper account mode | paper brokerage | first-class `paper` venue plugin — **cleaner registry expression** |
 
 ---
 
 ## Sources
 
-- OKX v5 WebSocket candle channel `confirm` flag — [OKX API guide](https://www.okx.com/docs-v5/en/) (HIGH)
-- ccxt.pro `watchOHLCV` returns forming last candle — [CCXT Pro Manual](https://docs.ccxt.com/docs/pro-manual), [ccxt #24107](https://github.com/ccxt/ccxt/issues/24107) (HIGH)
-- Locked milestone design — `docs/superpowers/specs/2026-06-30-live-trading-milestone-design.md` (LX-01..LX-15) (HIGH)
-- Existing engine seams — `itrader/price_handler/feed/bar_feed.py` (7-rule contract), `itrader/execution_handler/matching_engine.py` (pure I/O-free engine), `CLAUDE.md` architecture (HIGH)
-- Project state — `.planning/PROJECT.md` (v1.7 section, validated requirements) (HIGH)
-- Framework patterns (Nautilus/freqtrade/Hummingbot/LEAN) — training-data + design-sketch references; the per-cell behaviors are MEDIUM (well-established, not freshly re-verified per framework this session)
+- [NautilusTrader — Architecture](https://nautilustrader.io/docs/latest/concepts/architecture/) (NautilusKernel shared core; single-threaded MessageBus; ports-and-adapters modularity) — HIGH confidence (official docs)
+- [NautilusTrader — Live Trading](https://nautilustrader.io/docs/latest/concepts/live/) (TradingNode, TradingNodeConfig ⊃ NautilusKernelConfig, research-to-live parity) — HIGH
+- [NautilusTrader — Risk API / Execution](https://nautilustrader.io/docs/latest/api_reference/risk/) (RiskEngine `TradingState` ACTIVE/HALTED/REDUCING, submit/modify rate limits, max-notional, OrderDenied) — HIGH
+- [NautilusTrader — Live API](https://nautilustrader.io/docs/latest/api_reference/live/) (`add_data_client_factory` / `add_exec_client_factory`, TradingNodeBuilder) — HIGH
+- [QuantConnect LEAN — Contributing Brokerages / Laying the Foundation](https://www.quantconnect.com/docs/v2/lean-engine/contributions/brokerages/laying-the-foundation) (IBrokerageFactory, IBrokerage, IBrokerageModel, IDataQueueHandler, Composer `AddPart`) — HIGH
+- iTrader v1.8 design spec `docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md` (LR-00..LR-22, CF-1..CF-10) — authoritative locked design
+- iTrader `.planning/PROJECT.md`, `CLAUDE.md` — existing architecture (v1.7 live path, Account abstraction, OkxConnector, VenueReconciler)
 
 ---
-*Feature research for: live crypto-trading deployment layer (paper-first OKX) over an event-driven backtest engine*
-*Researched: 2026-06-30*
+*Feature research for: live-trading engine internals / operational control surface (single-operator, crypto-first)*
+*Researched: 2026-07-09*

--- a/.planning/research/PITFALLS.md
+++ b/.planning/research/PITFALLS.md
@@ -1,684 +1,513 @@
 # Pitfalls Research
 
-> ## ⚠ Superseded framing — read `phases/02-okx-connector/02-CONTEXT.md` first
->
-> The Phase-2 discussion (2026-07-01) revised the live architecture; this snapshot
-> predates it and still describes the **two-arm `LiveConnector`** model. The pitfalls
-> themselves remain valid — only the connector-shape wording is stale. **Superseded framings:**
-> - Connector is a **session/transport primitive**, not a two-arm venue object; the data/order/account arms are **domain adapters** (`OkxDataProvider` / `OkxExchange` / `VenueAccount`), **injected** with the session.
-> - The **`OkxExchange` adapter emits `FillEvent`** — the connector emits no domain events.
-> - Paper needs **no connector**: the paper execution adapter implements **`AbstractExchange`** (not `LiveConnector`).
-> - `OkxSettings` reads **plain `OKX_API_*` (no env prefix)** — not `ITRADER_OKX_*`.
->
-> See design-doc LX-05/LX-06 revision notes and `02-CONTEXT.md` D-01..D-10.
+**Domain:** Live-trading God-object decomposition + live-readiness hardening (brownfield, event-driven Python 3.13)
+**Researched:** 2026-07-09
+**Confidence:** HIGH (grounded in the authoritative v1.8 design spec §4/§15/§18, the v1.7 carry-forward TODO, and CLAUDE.md-locked constraints; general refactor/concurrency/Alembic knowledge cross-checked)
 
-**Domain:** Adding live crypto (OKX) trading to an event-driven, Decimal-exact, deterministic backtest engine — paper-first, oracle-gated (iTrader v1.7)
-**Researched:** 2026-06-30
-**Confidence:** HIGH on engine-internal pitfalls (read from source + locked sketch); MEDIUM-HIGH on OKX/ccxt integration facts (verified against ccxt issues + OKX v5 docs; firm up at plan-time)
-
-> Scope note: these are pitfalls specific to grafting a live OKX arm onto **this** engine — the
-> byte-exact SMA_MACD oracle (`134 / 46189.87730727451`), Decimal-end-to-end money, single-writer
-> `global_queue`, stateful no-rewind indicators, `filterwarnings=["error"]`, and the paper-parity
-> gate (LX-11). Generic "trading is hard" advice is omitted. Each pitfall names the v1.7 phase
-> (1-6) that should own its prevention.
-
----
+> These pitfalls are specific to **this** refactor. The two blocking gates — the byte-exact backtest
+> oracle (`134 / 46189.87730727451`, `check_exact=True`) and the OKX import-inertness gate
+> (`tests/integration/test_okx_inertness.py`) — are the epicenters; behavior-drift, inertness-regression,
+> and threading-contract pitfalls are covered in depth because a single mistake there silently invalidates
+> the whole milestone.
 
 ## Critical Pitfalls
 
-### Pitfall 1: Acting on a forming (unconfirmed) bar — wall-clock close inference
+### Pitfall 1: Behavior-drift smuggled into "pure code-motion"
 
 **What goes wrong:**
-The live feed emits a `BarEvent` for a candle that has not actually closed, so strategies compute
-indicators on a partial bar and fire signals the backtest would never produce. Paper-parity fails
-immediately and silently (the live run trades on data the oracle never saw).
+Extracting `UniverseWiring`, storage-init, or config values from `LiveTradingSystem`/`compose_engine`
+into shared helpers *looks* like moving code, but silently changes a value that feeds the backtest run —
+membership derivation order, an instrument-scale default, an rng-seed resolution path, a dict-iteration
+order that a `searchsorted`/reserve loop depends on — and the oracle drifts off `46189.87730727451`.
+The most dangerous case: `SessionInitializer` + shared `UniverseWiring` is **explicitly oracle-sensitive**
+(spec §13a/§15) because `BacktestRunner._initialise_backtest_session` calls the *same* helper. If the
+extracted helper reorders `derive_membership → derive_instruments → build Universe → inject → feed.bind`
+or changes a default, backtest results move.
 
 **Why it happens:**
-Two compounding traps. (a) ccxt's unified `watchOHLCV` does **not** expose a `closed`/`confirm`
-boolean — it streams the in-progress candle and you can only distinguish finalized bars by watching
-the timestamp roll over (ccxt issue #21885). (b) The naive fix — "the bar is closed when
-wall-clock ≥ open + timeframe" — is wrong under clock skew, late venue ticks, and the engine's own
-bar-stamping contract (rule 2: the tick at `T` means "the bar stamped `T` just closed", whose
-wall-clock semantics are `T + tf_base`). Inferring close from local time re-introduces exactly the
-look-ahead the 7-rule contract (`bar_feed.py`) was built to forbid.
+"It's just moving code" lowers vigilance; reviewers don't diff *values*, they diff *structure*. Extraction
+tempts small "harmless" normalizations (a default argument, a `dict` → `OrderedDict`, a re-sorted list, a
+`Decimal` default folded from a module constant into a config field). Any of these can change money math or
+iteration order. The P1 config-centralization pass is the highest-risk because relocating a scattered
+constant into `SystemConfig` changes *where the value comes from*, and a typo or unit mismatch is invisible
+until the run.
 
 **How to avoid:**
-Drive "closed" off OKX's native `confirm` field (the last element of the WS candle array:
-`0`=forming, `1`=closed), never wall-clock (LX-08). Because ccxt drops this field, the OKX
-`confirm` read is precisely the "proven gap" that justifies the **native escape hatch** (LX-05) —
-the `OkxConnector` must reach the native OKX candle channel (or its own ccxt subclass) to recover
-`confirm`, and `LiveBarFeed` must emit `BarEvent` **only** on `confirm == 1`. Encode the bar-timing
-contract's rule 2 into the feed: the emitted `BarEvent.time` must be the bar's **open** stamp `T`,
-identical to backtest, so downstream `window()` cutoff math is unchanged.
+- **Hold invariant, not just green:** every P1–P4 and P7-UniverseWiring plan must run the oracle with
+  `check_exact=True` AND the determinism double-run (two runs byte-identical) as a per-plan gate, not a
+  per-phase gate. The equity string `46189.87730727451` and trade count `134` are the invariants.
+- **Extract by reference-preservation:** move the code *verbatim* (byte-for-byte, same indentation family —
+  see Pitfall 9), then wire it back; do NOT "improve" during the move. Mirror the proven v1.2 Phase-6
+  OrderManager decomposition discipline (pure code-motion, `on_fill` moved as one intact unit).
+- **Value-diff, not structure-diff:** when relocating a constant into config, assert the new config value
+  `==` the old module constant in a test before deleting the constant.
+- **Re-baseline is never silent (LR-02):** if a change legitimately must move results, it is gated on
+  external cross-validation (backtesting.py + backtrader) + owner sign-off, documented in a REFREEZE note.
+  The default target is byte-exact.
 
 **Warning signs:**
-More signals live than in the oracle backtest on the same dates; a `BarEvent` whose timestamp equals
-the current wall-clock minute/day; indicator values that change between two events carrying the same
-bar timestamp (the tell-tale of a forming bar being re-delivered).
+Oracle diff shows *any* delta (even in a trailing digit); determinism double-run diverges; a P1–P4 plan
+touches a `Decimal` default or a membership/instrument path; a code-motion diff contains a `sorted(...)`,
+`OrderedDict`, changed default arg, or a `Decimal(float)` that wasn't there before.
 
-**Phase to address:** Phase 3 (LiveBarFeed, LX-08); the native-`confirm` plumbing is Phase 2 (connector).
+**Phase to address:**
+P1 (config constants), P3/P4 (storage-init + SqlEngine rename), **P7 (`UniverseWiring` — the oracle-sensitive
+extraction).** Gate: byte-exact oracle + determinism double-run on every plan in these phases.
 
 ---
 
-### Pitfall 2: Off-by-one between backtest next-bar-open fills and live closed-bar arrival
+### Pitfall 2: Inertness regression — an eager import sneaks onto the backtest path
 
 **What goes wrong:**
-The backtest decides at tick `T` and fills the market order at the **open of `T + tf_base`** through
-the resting book (bar-timing rule 5, `FillEvent.time = T + tf_base`). A live/paper path that fills
-"now" on the same bar `T` (or fills on the close of `T`) shifts every fill by one bar. Equity curves
-diverge cumulatively; paper-parity never holds even with identical signals.
+The backtest import path must stay async/`ccxt.pro`/SQL-free (`test_okx_inertness.py`). A refactor
+re-introduces heaviness four classic ways: (a) a **barrel re-export** — adding the live stack to an
+`__init__.py` so `from itrader.trading_system import ...` transitively imports `ccxt.pro`; (b) a
+**non-lazy `SqlSettings`** — `SystemConfig` constructing the Postgres arm at import (which *raises* without
+a credential and definitely pulls SQL); (c) a **registry that imports concretions at registration** — the
+`ExecutionVenueRegistry`/`DataProviderRegistry` importing `OkxExchange`/`OkxConnector` when `'okx'` is
+*registered* rather than when a venue is *built*; (d) `FifoEventBus` or `EngineContext(sql_engine=None)`
+pulling something heavy on construction.
 
 **Why it happens:**
-In live, the decision and the next bar's arrival are separated by real time, so it feels natural to
-fill against the bar you just received. The backtest's "rest now, fill at next open" semantics are an
-engine invariant, not an obvious default — easy to lose when re-implementing fills in `PaperConnector`.
+Python import side-effects are transitive and invisible — one new top-level `import` in a module that's on
+the backtest path drags its whole dependency subtree. Registries feel like the natural place to `import`
+the thing you're registering. Config aggregation (P1) tempts eagerly constructing every settings block.
 
 **How to avoid:**
-`PaperConnector` must reuse the **pure `MatchingEngine`** (LX-06), not re-implement matching: the
-matching core already rests the market order and fills it on the *next* `on_bar` at that bar's open,
-preserving rule 5 by construction. Local paper stays strictly **bar-based** (LX-13) — no sub-bar /
-tick fills. The parity harness must replay the *same* dataset bar-stream so the "next bar" the paper
-path fills against is byte-identical to the oracle's.
+- **Lazy-import concretions inside `build_bundle`/method bodies, never at module top or registration**
+  (spec §8a). Registering `'okx'` registers a *plugin object/factory*, not the exchange class. The plugin
+  imports `ccxt.pro` only inside `build_bundle`, i.e. only when a venue is actually built.
+- **`sql` is a cached-property/method accessor on `SystemConfig`, resolved on first access, never at import**
+  (spec §6a). Eager fields (`performance`, `monitoring`, `runtime`, templates) are plain safe-default
+  `BaseModel`s with no env I/O. `OkxSettings`/venue creds stay out of `SystemConfig` entirely.
+- **Never re-export the live stack from package barrels.** `EngineContext`, `FifoEventBus`,
+  `PriorityEventBus` must be importable without pulling live backends; keep live-only modules out of
+  `__init__.py` re-exports (the v1.7 proven pattern).
+- **Treat `test_okx_inertness.py` as a per-plan gate for P1, P2, P5, P6** — the phases that add config
+  aggregation, the bus, SQL stores, and the venue registry. Extend the inertness test to assert
+  *registering* a venue imports no `ccxt.pro` (spec §15).
 
 **Warning signs:**
-Paper trade count matches the oracle but fill prices are shifted to the previous/next bar's open;
-first divergence appears at the first trade and compounds; `FillEvent.time` in paper equals the
-deciding `BarEvent.time` instead of the following bar's.
+`test_okx_inertness.py` red; import time of the backtest path grows; a new top-level `import ccxt`/`import
+sqlalchemy`/`import asyncio`-heavy module appears in a backtest-path file; a registry `.register()` call
+takes a class rather than a factory/plugin; `SystemConfig.default()` touches env vars or raises on a
+missing DB credential at import.
 
-**Phase to address:** Phase 4 (paper path / `PaperConnector` reuse of `MatchingEngine`, LX-06/LX-13).
+**Phase to address:**
+P2 (bus — assert `FifoEventBus`/`EngineContext(sql_engine=None)` inert), P5 (stores — lazy), **P6 (venue
+registry — the highest-risk: lazy plugins, register-vs-build).** P1 owns the lazy-`sql` split. Gate:
+inertness test green on every plan in P1/P2/P5/P6.
 
 ---
 
-### Pitfall 3: Live wall-clock leaking into business `time`
+### Pitfall 3: Priority-queue pathologies (starvation, non-orderable fall-through, lost causal FIFO)
 
 **What goes wrong:**
-A live component stamps an event, order, transaction, or metrics row with `datetime.now(UTC)`
-instead of the bar's business `time`. This corrupts determinism, breaks the paper-parity replay
-(records carry replay-time wall-clocks, not dataset times), and pollutes the persisted system of
-record with non-reproducible timestamps.
+The two-tier `PriorityEventBus` (`(tier, seq, event)`) introduces four failure modes:
+1. **BUSINESS-tier starvation** — a flood of CONTROL events (e.g. rapid `STREAM_STATE` flap, or a
+   `CONFIG_UPDATE` storm) monopolizes the single consumer so `BAR`/`SIGNAL`/`ORDER`/`FILL` never drain,
+   stalling the trading flow indefinitely.
+2. **Tuple-comparison fall-through** — if two entries compare equal on `(tier, seq)`, `PriorityQueue` falls
+   through to comparing the **frozen event dataclass**, which is not orderable → `TypeError` crash mid-drain.
+3. **Lost strict causal FIFO within BUSINESS** — if `seq` isn't a single monotonic thread-safe counter, two
+   events at the same tier can reorder, breaking the causal `BAR→SIGNAL→ORDER→FILL` chain and corrupting
+   position state.
+4. **Mis-tiering a trading intent** — putting externally-injected `SIGNAL` on CONTROL would let an operator
+   signal jump ahead of a bar/fill it must interleave *after*, desyncing position state.
 
 **Why it happens:**
-The existing `LiveTradingSystem` already does this in several non-event-critical spots
-(`_stats['last_event_time'] = datetime.now(UTC)`, idle detection, `ErrorEvent` fallback
-`getattr(event, 'time', datetime.now(UTC))`), and the pattern is contagious. In live, "what time is
-it?" genuinely has two answers (the bar's business time vs. the wall clock for transport/heartbeat),
-and the wrong one is the convenient one.
+`queue.PriorityQueue` compares the *whole tuple* and only stops at the first differing element — a well-known
+Python footgun. Developers reach for `(priority, event)` and get bitten when priorities tie. Starvation is
+invisible in low-volume tests and only appears under a real CONTROL flood.
 
 **How to avoid:**
-Hold the line from CLAUDE.md: business `time` is **always** the bar's stamp, never wall clock.
-Wall-clock is permitted **only** for transport/observability concerns that never enter accounting or
-event causality (heartbeat, reconnect backoff, idle-warning, log lines) — and those must never be
-written into a `FillEvent`/`OrderEvent`/transaction/metrics row. Introduce a live "session clock"
-seam that mirrors the injected `BacktestClock` (core/clock.py): the connector translates each
-confirmed bar into a `TimeEvent`/`BarEvent` whose `time` is the venue bar-open stamp, and that stamp
-is the only time the engine sees. Audit every `datetime.now` on the live path for "is this allowed to
-touch money/events?".
+- **Unique monotonic `seq` from a single `itertools.count()`** (thread-safe) as the second tuple element
+  guarantees the tuple *never* falls through to the event (spec §4a) AND preserves strict FIFO within a tier.
+  This is the load-bearing invariant — test it explicitly: two same-tier events dequeue in put-order; a
+  same-`(tier)` pair never triggers event comparison.
+- **Bound the starvation risk with monitoring, not just priority:** the bus is "unbounded-but-watched" via
+  `depth_by_tier`. Add a guard/alert if BUSINESS depth grows while CONTROL is being serviced, or cap
+  CONTROL drain (e.g. drain at most N CONTROL between BUSINESS items) if a real flood source emerges.
+  CONTROL is *designed* low-volume (safety/operator/config) — enforce that assumption with a monitor.
+- **Freeze the tier assignment in P2** via the declarative `_CONTROL_EVENT_TYPES` frozenset; keep
+  externally-injected `SIGNAL` on **BUSINESS** (spec §4a) — control priority is for *operational* commands,
+  not trading intents. Review the frozenset in code review as a security/correctness-sensitive list.
+- **Determinism is a non-issue by construction — but verify the reasoning:** the priority bus is *live-only*.
+  Backtest uses `FifoEventBus` over `queue.Queue` and its synchronous `process_events()` drain, which never
+  touches the priority bus (spec §4a "Determinism note"). Live events already arrive in non-deterministic
+  wall-clock order, so priority ordering adds **zero oracle risk**. Verify: `compose_engine` selects
+  `FifoEventBus` for backtest, and no backtest-path test constructs a `PriorityEventBus`.
 
 **Warning signs:**
-Determinism double-run is no longer byte-identical on the paper path; persisted order/fill rows carry
-timestamps near real time rather than dataset dates; the parity harness output differs run-to-run.
+A `TypeError: '<' not supported between instances of ...Event` in the drain (fall-through hit); BUSINESS
+`depth_by_tier` climbing under load; an integration test where an operator `SIGNAL` fills before an
+in-flight bar; any `PriorityQueue.put((tier, event))` **without** a `seq` between them.
 
-**Phase to address:** Phase 4 (determinism seam in the live runtime; the "how the live thread/clock
-interacts with determinism seams" open item is named in the sketch §4 Phase 4).
+**Phase to address:**
+P2 (bus design + `seq` uniqueness test + tier frozenset). Starvation-monitor lives with P2's `depth_by_tier`;
+CONTROL-flood backstop coordinates with P9's LOOP-BACKSTOP breaker.
 
 ---
 
-### Pitfall 4: Stateful-indicator divergence from a backfill fast-path (LX-09 violation)
+### Pitfall 4: Threading-contract violations (blocking the connector loop / second ring writer / external direct calls)
 
 **What goes wrong:**
-Warmup/backfill builds indicator state via a bulk `warmup_from(series)` shortcut while live streaming
-uses per-bar `update(bar)`. The two code paths compute the same EMA/MACD/RSI recurrences slightly
-differently (seeding, first-value handling, order of operations), so the live indicator state diverges
-from what the oracle's per-bar path produced. Signals diverge; paper-parity fails in a way that is
-maddening to debug because both paths "look correct" in isolation.
+The single-writer engine-thread contract (LR-12) has three violation modes, each corrupting state or
+deadlocking:
+1. **Blocking venue I/O on the connector asyncio loop** — doing a resume snapshot, reconcile, or durable
+   halt write inside a stream callback on the connector loop. This blocks `ccxt.pro` streaming (bars/fills
+   stop arriving) and can deadlock. All such I/O must run on the **engine thread** inside the CONTROL-event
+   handler (spec §4b.4).
+2. **A second concurrent ring-buffer writer** — the CF-2 `backfill_on_resume` wiring is the trap: if it runs
+   on the **engine thread**, it races the connector-loop `update()` on the ring/`_replaying_backfill` guard
+   state (two writers, one buffer). It MUST land **loop-native** (connector loop, via the reconnect
+   callback), which is only safe now that V17-15 `spawn_gap_backfill` landed.
+3. **External/web threads calling handler methods directly** — a caller mutating handler state off-thread
+   instead of going through `bus.put()` (trading intents/config/commands) or a thin thread-safe status-latch
+   facade method (`halt/pause/reset/get_status/start/stop`).
 
 **Why it happens:**
-Bulk warmup is faster and feels harmless ("it's just the same data"). But the v1.5 stateful
-indicators (hand-written O(1) recurrences) have **no rewind** and are sensitive to seeding — a second
-state-building path is a second source of truth that re-opens the parity audit.
+The "just do the I/O where the event arrives" instinct puts blocking work on the loop. The connector loop
+*already* has the fill/bar data, so it's tempting to also write it. `backfill_on_resume` naturally reads like
+engine-thread work ("resume the engine") when it's actually a ring-writer op. External callers see public
+handler methods and call them.
 
 **How to avoid:**
-LX-09 is absolute: warmup/backfill replays the last K bars **one-by-one through the identical
-`update(bar)` path** live streaming uses. **No bulk fast-path exists.** Both warmups (cache hydration
-and indicator readiness, §10.D-2 of the stateful-indicator spec) go through the same entry. Make this
-structurally impossible to violate: do not add a `warmup_from`/`seed`/`prime` method to the indicator
-or feed API at all. Add a test that asserts replaying K bars through `update()` yields byte-identical
-indicator state to the backtest feed at the same asof.
+- **The queue is the bulkhead (spec §4c):** the connector loop does *only* venue I/O + `bus.put()` — fills/
+  bars → BUSINESS, stream-up/down + connector-fatal → CONTROL. It **never** touches handler state, never
+  blocks. Any blocking work triggered by a stream event runs on the engine thread inside the CONTROL handler
+  (`StreamRecoveryHandler.on_reconnect` does `catch_up_missed_fills()`/`account.snapshot()` on the engine
+  thread).
+- **CF-2 lands loop-native, asserted:** wire `LiveBarFeed.backfill_on_resume` on the connector loop via the
+  reconnect callback (P8), and add a test/assertion that no engine-thread path invokes it (would be a second
+  writer). This is a hard acceptance criterion for CF-2 in P8.
+- **External ingress is fail-closed and event-only:** `LiveTradingSystem.add_event` admits only externally-
+  originated `SIGNAL`/`STRATEGY_COMMAND` (D-10 default-deny, preserved); everything else is a thin thread-safe
+  facade delegating to `SafetyController`'s status latch. No external caller reaches a handler method.
+- **Add the CF-3 connector-contract docstrings** (`connectors/base.py` `call`/`spawn`/`disconnect`) so the
+  next connector author can't re-introduce a call-from-loop-thread or timeout-≠-didn't-happen bug — the
+  Protocol is where implementers read the rules.
 
 **Warning signs:**
-Any method named `warmup_from`, `bulk_update`, `seed`, `prime`, `from_series` appears on an indicator
-or feed; paper-parity passes only after the warmup window and diverges in the first post-warmup bars;
-indicator state after backfill differs from `BacktestBarFeed` at the same timestamp.
+Bars/fills stall after a reconnect (loop blocked); a `snapshot()`/`reconcile()`/durable-write call inside a
+connector callback; `backfill_on_resume` reachable from the `LiveRunner`/engine-thread drain; two writers
+touching `_replaying_backfill`/ring state; a web/test thread calling `portfolio_handler.on_fill` or similar
+directly; intermittent ring-buffer corruption or non-monotonic bar delivery only under reconnect.
 
-**Phase to address:** Phase 3 (LiveBarFeed backfill-through-update, LX-09); reused in Phase 6
-(warmup-on-add).
+**Phase to address:**
+P8 (SafetyController + StreamRecoveryHandler + CONTROL routes + **CF-2 loop-native backfill** + CF-7
+reconciler guard). P6 owns CF-3 connector-contract docstrings. The single-writer contract itself is
+established in P7's `LiveRunner`.
 
 ---
 
-### Pitfall 5: Feeding indicator state backward on a gap / duplicate / out-of-order bar
+### Pitfall 5: Alembic migration-chain hazards (relocation, multi-head, create_all divergence)
 
 **What goes wrong:**
-The feed delivers a bar with a timestamp ≤ the last delivered bar (duplicate, stale re-send,
-out-of-order WS frame, or a venue correction). The stateful indicators have no rewind, so feeding an
-older bar corrupts state irreversibly — every subsequent signal is wrong, and there is no clean
-recovery short of re-warming.
+P4 relocates `itrader/storage/migrations/` → project-root `migrations/`, and P5 chains **three new stores**
+(`d10_halt_records → system_store → venue_config → strategy_registry`). Classic breakages:
+1. **Relocation breaks `script_location`** — `alembic.ini` still points at the old package path, or `env.py`
+   loses its import of the `build_*_table` registrars + `NAMING_CONVENTION` from `itrader.storage`, so
+   migrations run against an empty/wrong metadata.
+2. **Multi-head / branched revision tree** — three new stores authored in parallel (or across plans) each
+   set `down_revision` to the same parent → Alembic reports multiple heads and `upgrade head` becomes
+   ambiguous or errors.
+3. **`create_all` vs migration divergence** — tests use `create_all()` (from the registrars) while
+   production uses the Alembic chain; if a new column/index is added to a registrar but not to a migration
+   (or vice-versa), tests pass green while production migrations produce a *different* schema.
+4. **Packaging leak** — `migrations/` accidentally shipped in the wheel, or conversely `env.py` can no longer
+   import the registrars because the relocation broke the package boundary.
 
 **Why it happens:**
-Crypto WS streams routinely re-send, reorder, or correct candles, especially around reconnects. The
-backtest never sees this (its `TimeGenerator` is a pinned monotonic grid), so the engine has no
-existing guard — the guard must be invented in `LiveBarFeed`.
+Relocation is "just moving a folder" (see Pitfall 1's mindset). Parallel store authorship naturally forks the
+revision chain. `create_all` in tests is convenient and hides schema drift because nobody runs migrations in
+CI unless forced.
 
 **How to avoid:**
-Enforce monotonic-forward-only delivery (LX-10): **duplicate → drop; out-of-order/stale → reject
-(never feed state backward); gap → REST-backfill the missing bars and replay through the same
-`update(bar)` path; reconnect → gap-fill the interim**. For after-the-fact corrections, do **not**
-patch in place — either re-warm from the ring buffer or forward-only-and-log (decide at plan time;
-the sketch leaves this open). The ring-buffer `LiveBarFeed` is the natural enforcement point (mirror
-the backtest cursor's "non-monotonic cutoff → safe rebuild" discipline in `window()`).
+- **Relocation is mechanical + verified (spec §7e):** update `alembic.ini` `script_location` to the new
+  `migrations/`; keep `env.py` importing the `build_*_table` registrars + `NAMING_CONVENTION` from
+  `itrader.storage`; confirm `migrations/` is excluded from the shipped wheel; confirm test-path `create_all`
+  is unaffected. Run `alembic upgrade head` against a clean DB as a P4 gate.
+- **Linear chain, one head, enforced:** each new store's migration sets `down_revision` to the *previous*
+  store in the declared order (`d10_halt_records → system_store → venue_config → strategy_registry`). Add an
+  `alembic heads` check (must report exactly one head) to the P5 gate. Author the chain sequentially, not in
+  parallel, or reconcile heads before merge.
+- **Migration/registrar parity test:** a test that builds the schema via `create_all` (registrars) AND via
+  `alembic upgrade head` and asserts identical table/column/index sets. This catches the silent divergence.
+- **Each new store follows the `HaltRecordStore` template** (composes `sql_engine`, own `build_*_table`
+  registrar, chained migration) — don't invent a new pattern per store.
 
 **Warning signs:**
-Indicator values jump non-physically after a reconnect; a `BarEvent` timestamp ≤ `newest_bar`'s;
-duplicate timestamps reaching strategies; parity holds on a clean session but breaks on any session
-with a disconnect.
+`alembic heads` reports >1 head; `alembic upgrade head` errors or no-ops against a clean DB; a store's table
+exists in tests but not after a real migration; `alembic.ini` still references `itrader/storage/migrations`;
+CI never runs `upgrade head`; the wheel build includes `migrations/`.
 
-**Phase to address:** Phase 3 (LiveBarFeed monotonic-forward delivery + reconnect gap-fill, LX-10).
+**Phase to address:**
+P4 (relocation — `script_location`/`env.py`/wheel-exclusion + `upgrade head` gate). P5 (three-store chain —
+single-head check + create_all/migration parity test). Uses the `SqlEngine` rename from P4.
 
 ---
 
-### Pitfall 6: ccxt float money leaking into the Decimal accounting core
+### Pitfall 6: Runtime-config platform footguns (mutating immutables / snapshot-write races / persisting secrets)
 
 **What goes wrong:**
-ccxt returns **floats** for every price, amount, fee, and balance (and `amount_to_precision` /
-`price_to_precision` historically return floats too). If any of those floats reach the engine via
-`Decimal(float)` — or are compared/arithmetic'd before conversion — the binary-float repr artifact
-(`Decimal(10.1) == 10.0999999...`) poisons the ledger. This is the locked correctness defect
-(money is Decimal end-to-end), now arriving from outside the engine for the first time.
+The runtime-config platform (P10) introduces mutation-at-runtime, which threatens correctness three ways:
+1. **Mutating an immutable-at-runtime key** — a `ConfigUpdateEvent` that changes `rng_seed`, money precision,
+   SQL credentials, `environment`, or IDs would break determinism/money/identity mid-run. These are declared
+   immutable (spec §6e) but an over-broad allowlist or a missing validation lets them through.
+2. **Snapshot-read vs engine-thread-write race on the `RuntimeConfig` overlay** — handlers read the overlay
+   (snapshot-read); the config-update handler writes it (engine-thread-write). If a handler reads a
+   half-applied multi-field update, or if a write happens off the engine thread, it observes torn state.
+3. **Persisting secrets** — writing venue credentials (`OkxSettings`) into `SystemStore`/`VenueStore` when
+   applying/persisting a config override. Secrets must stay env-sourced, per `account_id`, **never** in any
+   store.
 
 **Why it happens:**
-The whole codebase has so far controlled its own data ingress (`Bar.from_row` uses `Decimal(str(x))`).
-ccxt is the first money source the engine does not own, and its floats look like ordinary numbers.
-`Decimal(some_ccxt_float)` is a one-character mistake away everywhere.
+A generic "config is mutable" platform doesn't distinguish immutable keys unless forced. The overlay pattern
+(defaults ← YAML ← env ← persisted) invites "just set the field" without an engine-thread hop. When persisting
+a venue config, credentials sit adjacent to the config fields and get serialized together by accident.
 
 **How to avoid:**
-Bottle **all** ccxt→Decimal conversion at the connector edge through the existing `to_money(x)`
-(which is `Decimal(str(x))`, D-04) — never `Decimal(float)`, never float arithmetic before
-conversion. Treat the connector boundary like `Bar.from_row`: the moment a value crosses into the
-engine it is Decimal. For order submission *out* to OKX, convert with ccxt's **string** precision
-helpers (`decimal_to_precision` with `TRUNCATE`/`DECIMAL_PLACES`, or the string variants), not the
-float-returning `amount_to_precision`, so the venue sees a correctly-rounded string and the engine
-keeps its Decimal. Add a mypy/lint guard or a focused test that no `Decimal(` wraps a float on the
-live path.
+- **Allowlist of runtime-mutable keys + type/range check (spec §6e), rejecting immutables loudly.** The
+  allowlist is a closed set (fee/slippage params, poll cadence, `universe_remove_policy`, idle/timeout knobs,
+  risk limits, strategy enable/disable). `rng_seed`, precision, SQL creds, `environment`, IDs are hard-rejected.
+  Test that each immutable key raises on a mutation attempt.
+- **Engine-thread-write, snapshot-read (spec §6c):** `ConfigUpdateEvent` routes through the **CONTROL plane**
+  to an engine-thread handler that applies the whole update atomically to the overlay + relevant
+  `handler.update_config(...)` + persists. Handlers only ever *read* a consistent snapshot. No off-thread
+  overlay writes (this is a direct consequence of the LR-12 single-writer contract).
+- **Secrets never persisted (spec §6a/§15):** `VenueStore` holds per-venue config but **never** credentials;
+  the persist path must be structurally incapable of writing `OkxSettings`. Add a test asserting no store
+  round-trip contains a secret; the alert sink binds only declared `ErrorEvent` fields.
 
 **Warning signs:**
-Any `Decimal(` call on the connector path whose argument is not a `str`; balances/fees with 15+ trailing
-digits in the ledger; `InvalidOperation` from OKX `create_order` (ccxt issue #7415, a classic
-float-precision symptom); reconciliation drift that is always tiny and always present.
+An allowlist entry for `rng_seed`/precision/creds; a config write path reachable off the engine thread; a
+handler reading a config field that another thread is writing; a `VenueStore`/`SystemStore` row containing an
+API key/secret; a multi-field config update visible half-applied.
 
-**Phase to address:** Phase 2 (connector edge conversion) and Phase 5 (`VenueAccount` balance/fee ingest).
+**Phase to address:**
+P10 (runtime-config platform — allowlist, engine-thread-write CONTROL route, no-secret persistence). P1 owns
+declaring the immutable-vs-mutable split in centralized config. CF-8's typed `HaltReason` enum (P1) is the
+model for closed-vocabulary config values.
 
 ---
 
-### Pitfall 7: Rounding to the wrong OKX tick/lot/contract size
+### Pitfall 7: Multi-portfolio keying errors (shared account_id / attribution confusion / mis-routed fills)
 
 **What goes wrong:**
-The engine sizes an order with its own per-instrument Decimal scales (8dp BTC), but OKX enforces its
-own `price` tick, `amount` lot step, **and contract-size multiple** — and rejects (or silently adjusts)
-anything off-grid. OKX amount must be a multiple of the lot/contract size; sending `0.123456` when the
-step is `0.0001` fails with "amount must be greater than minimum amount precision" (ccxt issue #17710).
-A silently-adjusted fill then mismatches the engine's intended quantity → reconciliation drift.
+Multi-portfolio-live (P12) makes `account_id` and `portfolio_id` load-bearing keys, with three failure modes:
+1. **Two portfolios sharing one venue `account_id`** — pooled buying power the venue can't split back out.
+   This is explicitly **not supported** (deferred, needs a risk-allocator) and MUST fail loud. If it slips
+   through silently, two portfolios' positions/cash entangle on one venue account and reconciliation is
+   ambiguous.
+2. **`client_order_id` vs `portfolio_id` confusion** — `client_order_id` (LR-19, was `clOrdId`) does
+   venue↔engine *correlation*; `portfolio_id` does *attribution*. Conflating them (e.g. deriving attribution
+   from the venue order id, or keying the account by `client_order_id`) mis-attributes fills.
+3. **Fills routed to the wrong `Portfolio.on_fill`** — a fill for account A's order settles against
+   portfolio B, corrupting both cash ledgers.
 
 **Why it happens:**
-The engine's `Instrument` scales (v1.4) were authored for the backtest and may not match OKX's live
-filters. The two precision systems (engine `quantize` vs. OKX market `precision`/`limits`) are easy to
-conflate.
+The old model was 1 account : 1 portfolio (LX-04) with a `RuntimeError(>1)` guard, so keying was implicit.
+Removing that guard and fanning a signal out to N portfolios makes every attribution path explicit for the
+first time — easy to miss a hop. `client_order_id` and `portfolio_id` are both "order-ish ids" and blur.
 
 **How to avoid:**
-At connector init, load OKX market metadata (`load_markets`) and reconcile each traded symbol's
-OKX `precision`/`limits`/contract size into the engine `Instrument` (or a connector-side filter that
-runs after engine sizing). Round outbound quantities to OKX's lot step using ccxt's **string**
-precision helper, then re-quantize the resulting Decimal back into the engine so the engine's intended
-quantity equals what the venue will actually accept. Validate against `limits.amount.min` /
-`limits.cost.min` before submit; reject loud, never silently truncate to zero.
+- **Distinct-`account_id` invariant, fail-loud (spec §10b):** replace the deleted
+  `_link_venue_account_to_portfolios` + `RuntimeError(>1)` guard with per-portfolio account minting via the
+  plugin's mandatory `new_account(portfolio_ref, config)` **plus** an explicit invariant that no two
+  portfolios share an `account_id`. Test that a shared-`account_id` spec raises at composition, not at runtime.
+- **Two-key discipline, tested end-to-end (spec §10c):** every submitted order is tagged with its
+  `portfolio_id`; fills route `client_order_id`/`venue_order_id` → engine order → `FillEvent(portfolio_id)` →
+  the correct `Portfolio.on_fill`. Add a multi-portfolio gate (P13) that submits from two portfolios on two
+  `account_id`s and asserts each fill lands in the right ledger.
+- **Per-portfolio reconciliation:** `ReconciliationCoordinator` iterates active portfolios, reconciling each
+  against *its own* `VenueAccount`/`account_id` — never a pooled reconcile.
+- **Connector memoized by `(venue, account_id)`** (LR-17) so per-account credentials/sessions don't cross.
 
 **Warning signs:**
-OKX order rejections citing precision/min-amount; a fill quantity that differs from the submitted
-quantity; per-symbol drift that correlates with the least-significant digits of order size.
+No composition-time error when two `PortfolioSpec`s share an `account_id`; attribution derived from
+`client_order_id`; a fill's `portfolio_id` computed from venue order id; reconciliation that sums across
+portfolios; a multi-portfolio test where ledgers cross.
 
-**Phase to address:** Phase 2 (connector market-metadata load + outbound rounding); validated Phase 5 (sandbox).
+**Phase to address:**
+P12 (multi-portfolio-live — per-`account_id` factory, distinct-`account_id` invariant, `client_order_id`
+rename, per-portfolio reconcile, `(venue, account_id)` connector keying). P13 adds the multi-portfolio
+attribution gate. P6 lays the account-factory + connector-memoization foundation.
 
 ---
 
-### Pitfall 8: Races translating async ccxt.pro messages onto the synchronous single-writer queue
+### Pitfall 8: Error-subsystem circuit-breaker failures (CF-1 — livelock, false-green, broken fail-fast)
 
 **What goes wrong:**
-The connector's asyncio loop receives fills/balances/bars concurrently and pushes them onto
-`global_queue` from a thread/loop that is **not** the engine's single writer. The engine's
-single-writer contract (D-19, on which the backtest dropped all portfolio locks) is violated: two
-producers interleave, ordering guarantees the FIFO queue assumed are broken, and Portfolio/Account
-state mutated from the dispatch thread can race the connector thread.
+CF-1 is the **one HIGH-priority safety fold** and the only one that *adds an acceptance criterion* to P9.
+Four ways it goes wrong:
+1. **Error→error livelock (WR-06)** — a failing `ErrorEvent` consumer republishes a fresh `ErrorEvent` (no
+   type guard) → unbounded error→error recursion. This already bit the codebase (memory WR-06): the fix is a
+   **source guard** (don't republish an `ErrorEvent` if the failing event was itself `ERROR`) *plus* a
+   **consumer guard** (the `ErrorHandler` swallows its own failures, never re-raises) — two-guard terminal
+   safety.
+2. **A breaker that false-greens a money route** — the exact gap CF-1 exists to close: `_publish_and_continue`
+   increments a counter and emits one `ErrorEvent` per failure then continues **forever**, so a money route
+   (settlement/FILL) failing on *every* event produces an infinite green-looking run (the "V17-01 ran an
+   entire e2e suite green with zero settlements" bug). Without the aggregate tripwire, the breaker doesn't
+   exist.
+3. **Breaking backtest fail-fast** — implementing the breaker as a per-event policy change that softens
+   backtest's fail-fast (re-raise) would let the parity gate false-green. The breaker is an **aggregate
+   tripwire on top of** the live publish-and-continue policy — backtest fail-fast stays untouched.
+4. **Wrong route classification** — treating a settlement failure as retryable. SETTLEMENT (FILL →
+   portfolio/order handler) must **halt on first** failure; ORDER-IO N=3/60s; ADMISSION N=3/300s;
+   LOOP-BACKSTOP N=5/60s; FILL-TRANSLATION (`okx.py` per-trade swallow) must first emit a *counted*
+   `ErrorEvent` then treat as SETTLEMENT.
 
 **Why it happens:**
-ccxt.pro is async-native; the engine is synchronous. Bridging them invites "just call
-`global_queue.put()` from the websocket callback" — which works until two callbacks fire close
-together or until the order-status stream races the bar stream.
+Publish-and-continue is the correct *live* resilience policy — but "continue" with no aggregate bound is
+silently unsafe on a money route. The livelock is a subtle recursion that only manifests when the error route
+*itself* fails. Injecting the policy vs monkeypatching (`event_handler._on_handler_error = ...  # type: ignore`)
+tempts a global override that erases per-handler granularity or the backtest arm.
 
 **How to avoid:**
-Bottle the async boundary **entirely at the connector edge** (Phase 2 design). The connector runs its
-own asyncio loop in its own thread and is the **only** producer that translates venue messages into
-domain events; the engine keeps its single dispatch thread as the **only** consumer/mutator.
-`queue.Queue.put()` is itself thread-safe (the FIFO crossing is fine); the danger is *state mutation*
-and *event ordering*, not the put. So: never let the connector thread touch Portfolio/Account/order
-state directly (queue-only contract — emit an event); preserve event causality by emitting in venue
-order; and keep the live `Portfolio`/`Account` `RLock`s where any read crosses threads (status/metrics
-queries from the API thread vs. the dispatch thread). Decide the LX-15 process topology early — a
-separate worker process (option b/c) sidesteps much of this by isolating the engine.
+- **Ship the route-classified ring breaker (CF-1, spec §18 + `v17_audit_results.md §3b` — ready-to-paste):**
+  SETTLEMENT halt-on-first, ORDER-IO N=3/60s, ADMISSION N=3/300s, LOOP-BACKSTOP N=5/60s; guard with
+  `_stats_lock`; trip via the existing idempotent `halt(reason)`; surface counters + last-trip reason in
+  status. This is a hard P9 acceptance criterion, not merely "refactor the error seam."
+- **Two-guard terminal safety (WR-06), tested:** source guard in the publish path + consumer swallow in the
+  `ErrorHandler`. Test: an `ErrorEvent` whose consumer raises does NOT produce a second `ErrorEvent` (no
+  livelock).
+- **`ErrorPolicy` injected at construction, not monkeypatched (spec §12a):** backtest/replay → fail-fast
+  (re-raise; parity gate can't false-green); live → publish-and-continue. Keep per-handler granularity (a
+  route is a list — one failing handler doesn't skip the rest). Assert backtest fail-fast is byte-for-byte
+  unchanged (oracle green).
+- **Unblocked dependency check:** the breaker's `halt()` no longer gets clobbered back to RUNNING because the
+  ARCH-4 HALTED latch (V17-03) landed — verify the latch is in place before wiring the breaker.
 
 **Warning signs:**
-`global_queue.put` called from anywhere other than the connector translator or an event handler;
-Portfolio/Account fields mutated off the dispatch thread; intermittent, unreproducible state
-corruption under load; events arriving out of causal order (fill before its order ack).
-
-**Phase to address:** Phase 2 (async/sync bridge at connector edge); topology decision is cross-cutting
-LX-15 (before Phase 4 wiring); thread-safety hardening Phase 4/5 (FL-13).
-
----
-
-### Pitfall 9: Blocking the asyncio loop with engine/DB/sync work
-
-**What goes wrong:**
-A synchronous call (engine dispatch, a Postgres write-through, a `time.sleep`, a heavy pandas
-resample) runs inside the connector's asyncio loop coroutine, stalling all websocket I/O. Heartbeats
-miss, OKX drops the connection, and a reconnect storm follows — during which bars are missed and the
-gap-fill machinery (Pitfall 5) is stressed exactly when it matters most.
-
-**Why it happens:**
-The connector lives next to async code; it's tempting to "just await the engine" or do the DB write
-inline. The engine and DB are synchronous, so they block the loop.
-
-**How to avoid:**
-Strict separation: the asyncio loop does **only** network I/O and message translation, then hands off
-to the synchronous engine via the queue (a non-blocking `put`). No engine logic, no DB writes, no
-`sleep`, no pandas in a coroutine. Persistence write-through stays **keep-only-measured** (build async
-buffering only if the live loop profiles a stall, sketch Phase 5) — and even then it runs on the
-engine/storage side, never in the connector's loop. Run blocking work via `run_in_executor` only if
-unavoidable.
-
-**Warning signs:**
-Websocket reconnects correlate with order submissions or metrics writes; OKX "connection idle/timeout"
-disconnects under normal load; the asyncio loop's iteration latency spikes; `time.sleep` or a
-synchronous DB call inside any `async def`.
-
-**Phase to address:** Phase 2 (connector loop discipline); Phase 5 (persistence write-through must not stall).
-
----
-
-### Pitfall 10: Treating the engine (not the venue) as source of truth in live
-
-**What goes wrong:**
-On the real path, the engine assumes its computed position/balance is correct and ignores or
-overwrites the venue's actual state. Partial fills, fees, funding, and venue-side liquidations make
-the venue the only authority; an engine that trusts its own books drifts from reality and can place
-orders against positions it doesn't actually hold.
-
-**Why it happens:**
-In backtest **and paper**, the `SimulatedAccount` legitimately *computes* truth — that's the parity
-spine (sketch §3). The instinct carries over to the real path, where it's wrong: `VenueAccount` must
-*cache and reconcile*, not compute (LX-03).
-
-**How to avoid:**
-Keep the two account leaves honest to their roles (LX-03): `SimulatedAccount` computes (backtest +
-paper, preserving parity); `VenueAccount` mirrors the connector's balance/position/fill streams and
-**reconciles** against them. Under 1 account : 1 portfolio (LX-04), reconciliation reduces to
-**per-symbol drift detection** (no cross-portfolio attribution) — assuming the portfolio has exclusive
-control of its OKX subaccount. Define a drift policy explicitly: auto-correct small drift vs.
-halt-and-alert (sketch Phase 5 open item) — never silently continue on unexplained drift.
-
-**Warning signs:**
-The real path has no code reading venue balances/positions after submit; engine position ≠ venue
-position after a partial fill; no drift threshold/alert; manual venue trades (or another process)
-silently desync the engine.
-
-**Phase to address:** Phase 5 (`VenueAccount` reconciliation, LX-04); interface shaped Phase 1.
-
----
-
-### Pitfall 11: Partial / duplicate / mis-sequenced fill handling
-
-**What goes wrong:**
-OKX fills a large order in pieces, re-sends a fill on reconnect, or delivers a fill before the order
-ack. The order handler's mirror reconciliation (EXECUTED→FILLED etc.) — built for clean simulated
-fills — double-counts a duplicate, marks an order FILLED on the first partial, or chokes on a fill it
-has no order for. Position/cash diverge from the venue.
-
-**Why it happens:**
-The `SimulatedExchange`/`MatchingEngine` produces one clean terminal fill per order; partials and
-duplicates are a live-only reality the order mirror has never had to be idempotent against.
-
-**How to avoid:**
-Make fill ingestion idempotent and partial-aware at the connector/order-handler seam: key fills by the
-venue's fill/trade id (dedupe duplicates), accumulate partials against the order's filled-quantity
-(only terminalize when cumulative filled == order quantity or the venue reports the order closed), and
-tolerate fill-before-ack by buffering an orphan fill until its order appears (or reconciling from venue
-order status). The order mirror stays a **mirror** — the venue order-status stream, not the engine, is
-authoritative on the real path. Persist the cumulative-filled state so a restart can resume mid-partial
-(Pitfall 13).
-
-**Warning signs:**
-Order marked FILLED while venue shows it partially open; cash/position double-debited after a
-reconnect; a `FillEvent` with no matching order in the mirror; cumulative filled quantity exceeding
-order quantity.
-
-**Phase to address:** Phase 5 (order/fill reconciliation on the real path); connector fill stream Phase 2.
-
----
-
-### Pitfall 12: Fees and funding drift the ledger silently
-
-**What goes wrong:**
-OKX charges maker/taker fees (and, on perps, funding) that differ from the engine's fee model. The
-engine's computed cash diverges from the venue balance by an accumulating fee/funding delta that looks
-like "small constant drift" and is easy to dismiss — until it isn't.
-
-**Why it happens:**
-Paper uses the engine's own fee/slippage models (correct for parity); the real path must instead ingest
-the venue's *actual* charged fees. Funding is explicitly out of scope (perp Phase B / FUND-01..04) but
-will be a visible drift source the moment anyone trades a perp.
-
-**How to avoid:**
-On the real path, ingest the venue's reported fee per fill (Decimal via `to_money`) into the ledger
-rather than recomputing — the engine fee model is for paper/backtest only. Make fee drift a *named,
-explained* component of reconciliation, not noise. Keep spot-only in v1.7 (funding out of scope); if a
-perp is ever traded, treat funding drift as expected-and-unmodeled and **halt rather than silently
-absorb** until Phase B lands.
-
-**Warning signs:**
-Reconciliation drift that grows linearly with trade count; engine cash consistently above venue cash by
-~the fee rate; any funding line item on a perp position the engine doesn't account for.
-
-**Phase to address:** Phase 5 (venue-fee ingest in reconciliation); funding deferred (out of scope, named).
-
----
-
-### Pitfall 13: Restart rehydration reconciling store-only, ignoring the live venue (the v1.6 broker-side gap)
-
-**What goes wrong:**
-On restart, the engine rehydrates its working set from the v1.6 Postgres store and resumes — but the
-store is stale relative to the venue (fills landed while the engine was down, an order was canceled
-venue-side, a position was liquidated). The engine resumes on a false picture and acts on it.
-
-**Why it happens:**
-v1.6's restart-rehydration tests were **store-only** — they proved cache↔store consistency, never
-cache↔**broker** consistency, because there was no live adapter. The broker side is an explicit carried
-gap (sketch Phase 5).
-
-**How to avoid:**
-Restart reconciliation must be two-sided: rehydrate from the store **and** reconcile against the live
-venue (fetch open orders, positions, balances; replay any fills that landed during downtime through the
-idempotent fill path; cancel/expire orders the venue no longer holds). Bracket parents need special
-care: a parent that filled during downtime must have its children correctly activated/cancelled on
-restart (the engine's two-pass bracket gate must be re-established from venue truth, not assumed).
-Define the drift-on-restart policy (auto-reconcile vs. halt-and-alert) the same as steady-state
-(Pitfall 10).
-
-**Warning signs:**
-Restart path reads only the store, never the connector; open orders on OKX that the engine doesn't know
-about post-restart; a bracket child resting with no live parent (or vice versa); positions on the venue
-absent from the rehydrated portfolio.
-
-**Phase to address:** Phase 5 (cache↔broker restart reconciliation; persistence live-drive).
-
----
-
-### Pitfall 14: Crash-safe write ordering / write-through stalling the live loop
-
-**What goes wrong:**
-Either (a) the engine acts (submits an order, applies a fill) before durably persisting the intent, so
-a crash between act-and-persist loses the record and breaks restart reconciliation; or (b) the
-write-through runs synchronously on the dispatch thread and stalls the live loop, backing up the queue
-and missing bars/fills.
-
-**Why it happens:**
-The two goals pull opposite ways — crash-safety wants write-before-act; latency wants act-then-write.
-The v1.6 store was built and tested on testcontainers but never *driven by a live feed* (its
-transaction-boundary design is an explicit carried research flag).
-
-**How to avoid:**
-Decide the transaction boundary per operation (sketch Phase 5 / v1.6 carried flag): **create and
-terminalize sync** (durable before the irreversible venue action), append-heavy/metrics writes can be
-async/buffered. Keep write-through **keep-only-measured** — only build async buffering if the live loop
-profiles a stall (don't pre-optimize). Persist the *intent* (order to be sent) before submit so a crash
-mid-submit is recoverable by reconciliation. Never run a Postgres write inside the connector asyncio
-loop (Pitfall 9).
-
-**Warning signs:**
-Queue depth grows during DB-heavy moments; orders submitted to OKX with no prior store row; restart
-finds a venue order with no engine record; p99 dispatch latency tracks DB write latency.
-
-**Phase to address:** Phase 5 (persistence live-drive, write ordering); profile-gated per keep-only-measured.
-
----
-
-### Pitfall 15: Sandbox vs. live key split-brain
-
-**What goes wrong:**
-Part of the system talks to OKX demo and part to OKX live — e.g. ccxt is put in sandbox mode but a
-native escape-hatch call (Pitfall 1's `confirm` reader) hits production, or the data feed is live while
-the order arm is demo (or vice versa). Result: phantom fills, orders against the wrong book, or
-real-money trades when "paper" was intended. Catastrophic.
-
-**Why it happens:**
-OKX routes demo via two different mechanisms — ccxt's `set_sandbox_mode(True)` **and** the native
-`x-simulated-trading: 1` header — and the connector has two paths (ccxt.pro default + native escape
-hatch). Two switches → split-brain if only one is flipped.
-
-**How to avoid:**
-A **single `sandbox: bool`** (LX-05) routes *both* arms: it must call ccxt `set_sandbox_mode` **and**
-set the native `x-simulated-trading` header, with no second toggle anywhere. Pair sandbox/live with
-**separate key sets** keyed off the same flag (sandbox keys can't reach live, by construction). Add a
-startup assertion that both ccxt and native paths report the same environment before any order arm goes
-live. Paper-first (LX-01) means the order arm is sandbox-only until a deliberate gated promotion.
-
-**Warning signs:**
-Two independent sandbox/demo toggles in the codebase; the data feed and order arm configured
-separately; no startup check that ccxt and native agree on environment; live API keys present in a
-paper/sandbox config.
-
-**Phase to address:** Phase 2 (single-flag routing of both arms); secrets split cross-cutting (LX-05).
-
----
-
-### Pitfall 16: Secrets leakage in logs / structured events
-
-**What goes wrong:**
-API key/secret/passphrase (OKX requires a passphrase) end up in logs, error events, or the persisted
-store — via a connector exception that logs the request, a `repr()` of a config object, or an
-`ErrorEvent.error_message` that includes the offending payload. The structlog setup logs liberally and
-`filterwarnings` won't catch a leaked secret.
-
-**Why it happens:**
-ccxt errors often include the request context; the engine's publish-and-continue policy logs every
-handler failure (`_publish_and_continue` logs `str(exc)` and emits an `ErrorEvent`); credentials in a
-config object get logged on init.
-
-**How to avoid:**
-Keys never in code (already the WR-10 posture — no hardcoded fallback). Load from env/secret store as
-Pydantic `SecretStr` (the codebase already uses `SecretStr database_url`) so `repr`/log renders
-`**********`. Scrub connector exceptions before logging/emitting (strip auth headers, redact request
-bodies). Never persist raw credentials in the store or `ErrorEvent`. Add a log/event scrubber on the
-live path and a test asserting no key material appears in emitted `ErrorEvent`s or log capture.
-
-**Warning signs:**
-API secret visible in any log line or `ErrorEvent`; config object logged without `SecretStr`
-wrapping; ccxt request context logged on error; secrets in the Postgres store.
-
-**Phase to address:** Phase 2 (secret loading via SecretStr); cross-cutting secrets hardening (Phases 2-5).
-
----
-
-### Pitfall 17: Over-building beyond the trimmed scope
-
-**What goes wrong:**
-The team builds explicitly out-of-scope machinery — **tick-level local paper fills** (rejected by
-LX-13), a **full production screener** (only a lean poll seam is in scope, Phase 6), a
-**multi-venue abstraction** beyond shaping the interface (crypto/OKX-first, locked), or **perp Phase B
-funding realism** (FUND-01..04, its own future milestone). Each balloons the surface, delays the
-paper-parity DoD, and risks destabilizing the byte-exact oracle.
-
-**Why it happens:**
-The connector interface invites generalization ("while I'm here, let me support N venues");
-sub-bar realism feels more "real" than bar fills; the screener seam looks half-built. The pull toward
-completeness fights the trimmed-N+4 posture.
-
-**How to avoid:**
-Hold the sketch's explicit out-of-scope list (sketch §1). Local paper stays **bar-based** (LX-13) —
-sub-bar realism lives in OKX sandbox, not local paper. The connector is **shaped** for a 2nd venue but
-only `OkxConnector` is implemented (LX-05). Phase 6 ships only the lean membership poll seam, not the
-production screener. Funding/perp realism is deferred. Treat every "while I'm here" as scope creep to
-defer with a note, not absorb.
-
-**Warning signs:**
-A `TickPaperConnector` or sub-bar fill logic; a second connector implementation; screener filter
-chains beyond add/remove polling; funding-rate accrual code; the milestone slipping while "foundations"
-grow.
-
-**Phase to address:** All phases (scope discipline); Phase 4 (resist tick fills); Phase 6 (resist full screener).
-
----
-
-### Pitfall 18: asyncio/websocket warnings failing the strict suite (`filterwarnings=["error"]`)
-
-**What goes wrong:**
-Live tests pull in ccxt.pro/aiohttp/websockets, which emit `ResourceWarning` (unclosed session/
-transport), `DeprecationWarning` (asyncio loop/`get_event_loop`), and "coroutine was never awaited"
-warnings. Under `filterwarnings=["error"]` **any** of these fails the test — so the live surface is
-hard to test at all, and the temptation is to weaken the strict gate globally (which would also weaken
-the backtest's correctness net).
-
-**Why it happens:**
-The strict suite was tuned for a synchronous, dependency-light engine. Async test teardown reliably
-leaks warnings unless sessions/loops are explicitly closed; ccxt.pro holds connections open by design.
-
-**How to avoid:**
-Never relax `filterwarnings` globally. Instead: ensure deterministic async teardown (close ccxt
-connections, await `exchange.close()`, close the loop) so no `ResourceWarning` escapes; use
-`pytest-asyncio` with explicit loop/fixture scoping; and where a third-party warning is genuinely
-unavoidable, scope a **narrow** per-test `filterwarnings` marker (or `pytest.warns`/`recwarn`)
-targeting that exact warning class+module — never a blanket ignore. Prefer testing the live surface
-against a **mocked/recorded connector** (replay fixtures) so most FL-13 coverage needs no live socket
-at all; reserve real-socket tests for a small sandbox-gated integration set.
-
-**Warning signs:**
-Live tests pass only with a broadened global `filterwarnings`; `ResourceWarning: unclosed`
-transport/session in test output; "coroutine never awaited"; pressure to mark the whole live suite
-`-W ignore`.
-
-**Phase to address:** Phase 2 onward (every live phase adds FL-13 coverage as it lands, sketch §5).
+A live run stays green while a money route fails every event; an `ErrorEvent` consumer failure spawns another
+`ErrorEvent`; a monkeypatched `_on_handler_error`; a settlement failure retried instead of halting; backtest
+oracle drifts after the P9 error-policy change; no `last-trip reason`/counters in status; `_stats_lock`
+missing around breaker counters.
+
+**Phase to address:**
+**P9 (error subsystem — CF-1 aggregate breaker is a hard acceptance criterion, `ErrorPolicy` injected,
+two-guard terminal safety, CF-5 pluggable alert-sink seam).** Depends on P7 (`LiveRunner` owns the drain +
+injected policy). The breaker's LOOP-BACKSTOP coordinates with P2's CONTROL-flood monitor.
 
 ---
 
 ## Technical Debt Patterns
 
+Shortcuts that seem reasonable but create long-term problems.
+
 | Shortcut | Immediate Benefit | Long-term Cost | When Acceptable |
 |----------|-------------------|----------------|-----------------|
-| Use ccxt unified `watchOHLCV`, infer close from timestamp roll-over | No native escape hatch needed | Forming-bar bugs, parity failure, fragile to stream quirks | Never for fills — `confirm` flag is mandatory (LX-08) |
-| Bulk `warmup_from(series)` for fast backfill | Faster start | Second state path diverges, re-opens parity audit (LX-09) | Never — forbidden by LX-09 |
-| `Decimal(ccxt_float)` directly | One line | Binary-float poison in the ledger | Never — route through `to_money` |
-| Synchronous write-through on dispatch thread | Simple, crash-safe | Stalls live loop, backs up queue | MVP only if profiled clean; keep-only-measured |
-| `VenueAccount` computes instead of caches | Reuse `SimulatedAccount` math | Engine drifts from venue truth (LX-03) | Never on real path; fine for paper (it IS `SimulatedAccount`) |
-| Run engine in-process with FastAPI | Simplest wiring | Couples lifecycles, mixes 3 concurrency models, one crash kills both | Throwaway demo only; sketch leans worker/process-per-portfolio (LX-15) |
-| Global `-W ignore` to pass live tests | Green suite fast | Destroys the backtest correctness net too | Never — scope warnings per-test |
-| Two sandbox toggles (ccxt + native separately) | Quick | Split-brain → real-money risk | Never — single `sandbox: bool` (LX-05) |
+| "Improve" code while extracting it (normalize sort/defaults/indentation) | Cleaner-looking diff | Silent oracle drift; broken tab file; hard-to-bisect regression | **Never** on oracle-gated (P1–P4, P7-UniverseWiring) or tab files |
+| Import venue concretions at registration for "simplicity" | Registry is one-liner | Kills inertness gate; drags `ccxt.pro`/SQL onto backtest path | **Never** — lazy-import in `build_bundle` |
+| `create_all` in tests, skip running Alembic in CI | Fast test setup | Schema drift between tests and production migrations | Only if a create_all/migration parity test exists |
+| Monkeypatch `_on_handler_error` for the live policy | No constructor change | Erases per-handler granularity; risks softening backtest fail-fast | **Never** — inject `ErrorPolicy` (spec §12a) |
+| Wire `backfill_on_resume` on the engine thread ("it resumes the engine") | Simpler call site | Second concurrent ring writer racing the connector loop → corruption | **Never** — loop-native only (CF-2) |
+| Broad config allowlist ("make everything mutable") | Flexible runtime | Mutable `rng_seed`/precision/creds breaks determinism/money/identity | **Never** — closed allowlist, hard-reject immutables |
+| Defer the CF-1 aggregate tripwire to "later" | P9 ships faster | A money route can fail every event, run infinitely green | **Never** — CF-1 is a P9 acceptance criterion |
+| Free-string `halt('baseline-residual')` reasons | Quick to write | Unclassified halts; FastAPI control-plane can't reason about them | **Never** — typed `HaltReason` enum (CF-8, P1) |
 
 ## Integration Gotchas
 
+Common mistakes when connecting to external services.
+
 | Integration | Common Mistake | Correct Approach |
 |-------------|----------------|------------------|
-| OKX kline WS | Trusting ccxt `watchOHLCV` to tell you a bar closed | Read native `confirm` field (last array element, 0/1); ccxt drops it (issue #21885) → native escape hatch (LX-05) |
-| ccxt money | `Decimal(float)` on prices/amounts/fees/balances | `to_money(str)` at connector edge; string precision helpers outbound |
-| OKX order size | Engine 8dp quantity sent as-is | Round to OKX lot/contract step via ccxt string precision; validate `limits.amount.min` (issue #17710) |
-| OKX demo | `set_sandbox_mode` only, native calls hit live | Single flag sets BOTH ccxt sandbox + native `x-simulated-trading` header (LX-05) |
-| ccxt.pro async | `global_queue.put` / state mutation from WS callback thread | Connector translator is sole producer; queue-only; no cross-thread state mutation |
-| OKX auth | Forgetting the passphrase; logging the request | Passphrase required; `SecretStr`; scrub connector exceptions before log/emit |
-| ccxt.pro sessions | Tests leak unclosed sessions → `ResourceWarning` fails strict suite | `await exchange.close()` in teardown; mock/replay connector for most FL-13 |
+| OKX (`ccxt.pro`) | Blocking venue I/O (snapshot/reconcile) on the connector asyncio loop | Loop does only I/O + `bus.put()`; blocking work on engine thread inside CONTROL handler (§4b) |
+| OKX markets map | Stale markets map → a delisted symbol trades on; or adding a parallel drop in the retry loop | Keep markets map fresh (CF-9, P6) so delisting exits via existing `validate_symbol → delta.removed`; close the fail-open-before-load window |
+| OKX candle stream | Trusting an in-progress candle snapshot pushed on every WS subscribe (defeats payload-gated reconnect budgets — memory WR-03) | Confirm-gated `ClosedBar` only; don't reset reconnect budget on snapshot payloads |
+| `LiveConnector` (any future venue) | Re-introducing call-from-loop-thread / timeout-≠-didn't-happen bugs | Add CF-3 CONTRACT docstrings to `connectors/base.py` (`call`/`spawn`/`disconnect`) — the Protocol is where implementers read the rules |
+| Venue credentials | Persisting `OkxSettings` into `VenueStore`/`SystemStore` alongside config | Creds stay env-sourced per `account_id`, never in any store (§6a/§15) |
+| Venue reconciliation | Bare `str(matched["id"])` KeyError on a fallback-matched resting order with no `id` (CF-7) | Fail-loud typed error at `venue_reconciler.py:411` (P8) |
 
 ## Performance Traps
 
+Patterns that work at small scale but fail as usage grows.
+
 | Trap | Symptoms | Prevention | When It Breaks |
 |------|----------|------------|----------------|
-| Blocking the asyncio loop with DB/engine/sleep | Reconnect storms under load; bars missed | Loop does only I/O + translate; sync work off-loop | First DB-heavy live session |
-| Sync write-through on dispatch thread | Queue depth tracks DB latency | Sync only create/terminalize; rest buffered, profile-gated | High trade rate / slow DB |
-| Live machinery imported on the backtest hot path | W1/W2 regression vs v1.5 (15.7s/152.8MB) | Lazy-import the live arm (mirror the existing SQL lazy-import); inertness test | Any backtest run after live code lands |
-| Per-bar REST gap-fill on a flaky connection | Latency spikes, rate-limit bans during reconnect | Bounded backfill window; ring buffer; reconnect debounce | Unstable network / frequent disconnects |
+| CONTROL-tier flood starving BUSINESS | Bars/fills stop draining; BUSINESS `depth_by_tier` climbs | Monitor `depth_by_tier`; CONTROL is designed low-volume; add a drain backstop if a flood source appears | A stream-flap or config storm generating high CONTROL volume |
+| Unbounded event bus | Memory growth; no backpressure signal | "Unbounded-but-watched" via `depth_by_tier` monitoring + alerts | Sustained producer > consumer (e.g. a wedged engine thread) |
+| Stats-snapshot upserts contending with config writes on `SystemStore` | Lock contention / slow config apply | Marked seam: split stats-history table if periodic snapshot upserts contend (§14 deferred) | High-frequency `stats.snapshot` upserts |
+| Per-portfolio reconcile iterating many accounts serially | Slow startup with N portfolios | Acceptable at current N; watch startup time; parallelize only if measured | Large N portfolios on slow venue snapshot I/O |
 
 ## Security Mistakes
 
+Domain-specific security issues beyond general web security.
+
 | Mistake | Risk | Prevention |
 |---------|------|------------|
-| API key/secret/passphrase in logs or `ErrorEvent` | Account takeover | `SecretStr`; scrub connector exceptions; no raw creds in store/events |
-| Hardcoded credential fallback | Leaked key in repo | Already WR-10 (no fallback); keep it; env/secret-store only |
-| Sandbox/live key split-brain | Unintended real-money trades | Single `sandbox` flag routes both arms + key set; startup environment assertion |
-| Persisting credentials in the system-of-record | DB compromise = key compromise | Never persist creds; store references, not secrets |
+| Persisting venue API secrets to a durable store | Credential leak from DB dump/backup | Secrets stay in env-sourced `OkxSettings` per `account_id`, never written to any store (§6a/§15) |
+| Alert sink binding undeclared event fields | Leaking internal/sensitive state to an external alert channel | Alert sink binds **only** declared `ErrorEvent` fields (§15) |
+| Runtime config mutating `environment`/creds/IDs | Privilege/identity/determinism escape at runtime | Closed allowlist; `environment`, SQL creds, IDs, `rng_seed`, precision are immutable-at-runtime (§6e) |
+| External thread reaching handler methods directly | Off-thread state mutation bypassing validation/admission | Fail-closed `add_event` (D-10, SIGNAL/STRATEGY_COMMAND only); thin thread-safe facade otherwise (§4b.3) |
+
+## UX Pitfalls
+
+(Operator-facing, not end-user — the "user" here is the operator running/monitoring the live engine.)
+
+| Pitfall | Operator Impact | Better Approach |
+|---------|-----------------|-----------------|
+| Unclassified free-string halt reasons | Operator/control-plane can't categorize *why* the engine halted | Typed `HaltReason` vocabulary (CF-8, P1/P8) |
+| Alert egress log-only | A 3am halt reaches nobody | Thread the pluggable alert-sink seam so CRITICAL can reach a real sink (CF-5, P9); substantive egress is the FastAPI milestone |
+| No breaker counters/last-trip reason in status | Operator can't see *why* a breaker tripped | Surface counters + last-trip reason in `get_status()` (CF-1, P9) |
+| Status read touching hot-path locks | UI/status polling contends with the engine thread | `state.*`/`stats.*` in `SystemStore` double as the UI read model (§6d) — read without hot-path locks |
 
 ## "Looks Done But Isn't" Checklist
 
-- [ ] **Bar-close detection:** Often missing the `confirm`-flag read — verify `BarEvent` emits only on `confirm == 1`, never wall-clock
-- [ ] **Backfill:** Often missing the through-`update()` guarantee — verify no `warmup_from`/bulk path exists; state byte-matches backtest at same asof
-- [ ] **Paper fills:** Often missing next-bar-open semantics — verify `FillEvent.time == T + tf_base` via reused `MatchingEngine`
-- [ ] **Determinism:** Often missing the business-time discipline — verify paper double-run byte-identical; no wall-clock in events/ledger
-- [ ] **Reconciliation:** Often missing the broker side — verify restart reconciles store AND live venue, not store-only
-- [ ] **Partial fills:** Often missing idempotency — verify duplicate fills deduped, partials accumulated, fill-before-ack tolerated
-- [ ] **Money:** Often missing the ccxt-float boundary — verify no `Decimal(float)` on the live path; venue fees ingested (not recomputed)
-- [ ] **Sandbox:** Often missing dual-arm routing — verify single flag sets ccxt sandbox AND native header; startup env assertion
-- [ ] **Secrets:** Often missing exception scrubbing — verify no key material in any log/`ErrorEvent`
-- [ ] **Strict suite:** Often missing async teardown — verify live tests pass under `filterwarnings=["error"]` without global relaxation
-- [ ] **Backtest inertness:** Often missing the regression check — verify oracle byte-exact + no W1/W2 regression after live code lands
+Things that appear complete but are missing critical pieces.
+
+- [ ] **Config centralization (P1):** looks done — but `sql` must be lazy-accessed (not constructed at import), and every relocated constant must value-equal its old module constant. Verify: inertness gate green + a constant-equality test.
+- [ ] **Priority bus (P2):** looks done — but verify the unique `seq` prevents tuple fall-through (no event comparison) AND preserves within-tier FIFO. Verify: same-tier order test + a same-`(tier)` non-comparison test.
+- [ ] **SqlEngine rename + migration relocation (P4):** looks done — but run `alembic upgrade head` against a clean DB and confirm `migrations/` is excluded from the wheel. Verify: `upgrade head` succeeds; `alembic heads` == 1.
+- [ ] **New stores (P5):** looks done — but the three-store chain is one linear head, and `create_all` == `upgrade head` schema. Verify: single-head check + create_all/migration parity test.
+- [ ] **Venue registry (P6):** looks done — but registering `'okx'` imports no `ccxt.pro` until *built*. Verify: extend inertness test to registration.
+- [ ] **UniverseWiring (P7):** looks done — but backtest oracle byte-exact AND determinism double-run identical, because the helper is shared with `BacktestRunner`. Verify: oracle + double-run per plan.
+- [ ] **StreamRecovery / CF-2 (P8):** looks done — but `backfill_on_resume` runs loop-native, NOT engine-thread. Verify: no engine-thread path invokes it.
+- [ ] **Error subsystem (P9):** looks done as a refactor — but CF-1 aggregate breaker actually trips (SETTLEMENT halt-on-first), two-guard livelock safety holds, backtest fail-fast unchanged. Verify: a money-route-fails-every-event test halts; an ErrorEvent-consumer-fails test spawns no second ErrorEvent; oracle green.
+- [ ] **Multi-portfolio (P12):** looks done — but two portfolios sharing an `account_id` fails LOUD at composition, and fills route by `portfolio_id` to the right ledger. Verify: shared-`account_id` raises; two-portfolio attribution gate.
 
 ## Recovery Strategies
 
+When pitfalls occur despite prevention, how to recover.
+
 | Pitfall | Recovery Cost | Recovery Steps |
 |---------|---------------|----------------|
-| Forming-bar acted on / parity broken | MEDIUM | Switch to `confirm` flag; replay parity harness from clean dataset; re-validate gate |
-| Indicator state corrupted (backward feed / bad backfill) | MEDIUM | Re-warm from ring buffer through `update()`; no in-place patch; re-assert state vs backtest |
-| ccxt-float in ledger | HIGH | Audit all `Decimal(` on live path; re-route through `to_money`; reconcile/rebuild affected balances from venue |
-| Engine/venue drift undetected | HIGH | Add per-symbol drift detection; reconcile from venue truth; halt-and-alert policy; rebuild from venue + store |
-| Restart on stale store (broker gap) | MEDIUM | Add broker-side reconciliation; replay downtime fills idempotently; re-establish bracket parent/child from venue |
-| Sandbox/live split-brain | HIGH (if real money) | Halt; single-flag refactor; key-set separation; startup env assertion before any future run |
-| Secret leaked to log/store | HIGH | Rotate keys immediately; scrub logs/store; add scrubber + test |
+| Oracle drift in a code-motion phase | LOW–MEDIUM | `git bisect` the plan commits (per-plan gate makes this cheap); revert the offending value change; re-extract verbatim |
+| Inertness regression | LOW | Read the inertness-test import trace; move the offending `import` into a method body / out of a barrel; re-run gate |
+| Priority-queue fall-through crash | LOW | Add/repair the `seq` element so the tuple never compares events; add the regression test |
+| Second-ring-writer corruption (CF-2 on wrong thread) | MEDIUM | Move `backfill_on_resume` to the connector loop (reconnect callback); add the no-engine-thread assertion |
+| Multi-head Alembic tree | LOW–MEDIUM | Author a merge revision OR re-chain `down_revision`s linearly; add the single-head gate |
+| Error→error livelock | MEDIUM | Restore the two-guard (source + consumer) terminal safety; add the consumer-fails-no-second-error test |
+| Shared-`account_id` slipped through | MEDIUM–HIGH | Add the composition-time distinct-`account_id` invariant; audit reconciliation for cross-portfolio sums; re-reconcile affected portfolios |
+| Persisted secret | HIGH | Rotate the leaked credential; purge the store row; make the persist path structurally unable to write secrets; add the no-secret round-trip test |
 
 ## Pitfall-to-Phase Mapping
 
+How roadmap phases should address these pitfalls.
+
 | Pitfall | Prevention Phase | Verification |
 |---------|------------------|--------------|
-| 1. Forming-bar / wall-clock close | Phase 3 (flag plumb Phase 2) | `BarEvent` emitted only on `confirm==1`; parity holds |
-| 2. Next-bar-open fill off-by-one | Phase 4 | `FillEvent.time == T+tf_base`; reused `MatchingEngine` |
-| 3. Wall-clock in business time | Phase 4 | Paper double-run byte-identical; no `now()` in events/ledger |
-| 4. Backfill fast-path divergence | Phase 3 (reused Phase 6) | No `warmup_from`; state == backtest at asof |
-| 5. Backward indicator feed | Phase 3 | Dup dropped / stale rejected / gap backfilled; reconnect parity |
-| 6. ccxt float in ledger | Phase 2 + 5 | No `Decimal(float)`; balances Decimal-clean |
-| 7. OKX tick/lot rounding | Phase 2 (sandbox Phase 5) | Outbound qty multiple of lot; no precision rejects |
-| 8. Async→queue races | Phase 2 (+ LX-15 topology) | Single producer; no off-thread state mutation |
-| 9. Blocking the asyncio loop | Phase 2 (+ Phase 5 write-through) | No sync/DB/sleep in coroutine; stable reconnects |
-| 10. Venue not source of truth | Phase 5 (interface Phase 1) | `VenueAccount` caches+reconciles; drift policy defined |
-| 11. Partial/duplicate fills | Phase 5 (stream Phase 2) | Idempotent fill ingest; partial accumulation |
-| 12. Fee/funding drift | Phase 5 | Venue fees ingested; drift named/explained; funding halts |
-| 13. Restart broker-side gap | Phase 5 | Restart reconciles store AND venue; bracket parents safe |
-| 14. Write ordering / loop stall | Phase 5 (profile-gated) | Create/terminalize durable pre-act; no loop stall |
-| 15. Sandbox/live split-brain | Phase 2 (LX-05) | Single flag both arms; startup env assertion |
-| 16. Secrets leakage | Phase 2 (cross-cutting) | No creds in logs/events/store |
-| 17. Over-build out of scope | All (Phase 4/6 esp.) | No tick fills / full screener / multi-venue / funding |
-| 18. Strict-suite async warnings | Phase 2 onward (FL-13) | Live tests green under `filterwarnings=["error"]`, no global relax |
+| Behavior-drift in pure code-motion | P1, P3, P4, **P7 (UniverseWiring)** | Byte-exact oracle (`134 / 46189.87730727451`, `check_exact=True`) + determinism double-run, **per plan** |
+| Inertness regression | P1 (lazy `sql`), P2, P5, **P6 (registry)** | `test_okx_inertness.py` green per plan; extended to assert register-vs-build |
+| Priority-queue pathologies | P2 | Unique-`seq` no-fall-through test; within-tier FIFO test; backtest selects `FifoEventBus` |
+| Threading-contract violations | P7 (single-writer), **P8 (CF-2 loop-native, CF-7)**, P6 (CF-3 docstrings) | No blocking I/O on connector loop; `backfill_on_resume` unreachable from engine thread; fail-closed `add_event` |
+| Alembic migration-chain hazards | P4 (relocation), P5 (chain) | `alembic upgrade head` on clean DB; `alembic heads` == 1; create_all/migration parity test |
+| Runtime-config footguns | P10 (allowlist/CONTROL-route/no-secret), P1 (immutable split) | Immutable-key mutation raises; no off-thread overlay write; no-secret store round-trip |
+| Multi-portfolio keying errors | **P12**, P13 (gate), P6 (account factory) | Shared-`account_id` raises at composition; two-portfolio fill-attribution gate |
+| Error-subsystem circuit-breaker (**CF-1**) | **P9** | Money-route-fails-every-event **halts**; ErrorEvent-consumer-fails spawns no second ErrorEvent; backtest fail-fast/oracle unchanged; counters + last-trip in status |
+| Indentation hazard (cross-cutting) | Every phase | Match the file's indentation family (tabs: handlers; 4-space: `config/`/`core/`/`feed/`/`events/`); never normalize; mixed-indentation diff review |
 
 ## Sources
 
-- [iTrader locked sketch — `docs/superpowers/specs/2026-06-30-live-trading-milestone-design.md`](file) — LX-01..LX-15, parity spine, carried research flags (HIGH)
-- iTrader source: `itrader/price_handler/feed/bar_feed.py` (7-rule bar-timing contract), `itrader/core/money.py` (D-04 string entry), `itrader/trading_system/live_trading_system.py` (daemon thread, publish-and-continue, wall-clock usage) (HIGH)
-- [ccxt issue #21885 — request for `closed`/`confirm` flag in watchOHLCV](https://github.com/ccxt/ccxt/issues/21885) — confirms unified ccxt does NOT expose candle-closed; native read needed (MEDIUM-HIGH)
-- [ccxt issue #17710 — OKX amount precision / contract-size multiple rejection](https://github.com/ccxt/ccxt/issues/17710) (MEDIUM)
-- [ccxt issue #7415 — OKX create_order InvalidOperation (float precision)](https://github.com/ccxt/ccxt/issues/7415) (MEDIUM)
-- [ccxt decimal_to_precision source](https://github.com/ccxt/ccxt/blob/master/python/ccxt/base/decimal_to_precision.py) — string TRUNCATE/DECIMAL_PLACES helpers (MEDIUM)
-- [OKX v5 WebSocket candlesticks channel docs](https://www.okx.com/docs-v5/en/) — candle array `[ts,o,h,l,c,vol,...,confirm]`, confirm 0/1 (MEDIUM-HIGH)
-- [ccxt OKX exchange docs](https://docs.ccxt.com/docs/exchanges/okx), [ccxt.pro manual](https://docs.ccxt.com/docs/pro-manual) (MEDIUM)
+- `docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md` — §4 (event bus & threading model), §6 (config platform), §7 (storage/migrations), §8 (venue registry), §10 (multi-portfolio), §11 (safety), §12 (error handling), §13 (session init), **§15 (constraints & risks)**, **§16 (phasing P1–P13)**, **§18 (folded-in CF-1..CF-10)** — HIGH confidence (authoritative locked design)
+- `.planning/todos/pending/v17-residual-carryforward.md` — CF-1 (ERROR-route circuit breaker spec), CF-2 (loop-native backfill), CF-3 (connector contract docstrings), CF-4 (stream supervisor DRY), CF-5 (alert egress), CF-7 (reconciler guard) — HIGH
+- `.planning/PROJECT.md` (Current Milestone v1.8) — phase list, blocking-gate framing — HIGH
+- `CLAUDE.md` — indentation hazard, money=Decimal, determinism, inertness conventions; D-10 fail-closed `add_event` — HIGH
+- User memory: WR-06 (error→error two-guard terminal safety), WR-03 (OKX candle snapshot-on-subscribe), OKX markets/EEA constraints — MEDIUM–HIGH (prior in-repo findings)
+- General knowledge: `queue.PriorityQueue` tuple-comparison fall-through footgun; Alembic multi-head/`script_location`/`create_all`-divergence hazards — HIGH (well-established Python/Alembic gotchas)
 
 ---
-*Pitfalls research for: adding live OKX (paper-first) trading to the iTrader event-driven/Decimal/deterministic backtest engine*
-*Researched: 2026-06-30*
+*Pitfalls research for: v1.8 Live System Refactor & Live-Readiness Hardening*
+*Researched: 2026-07-09*

--- a/.planning/research/STACK.md
+++ b/.planning/research/STACK.md
@@ -1,180 +1,320 @@
 # Stack Research
 
-> ## ⚠ Superseded framing — read `phases/02-okx-connector/02-CONTEXT.md` first
->
-> The Phase-2 discussion (2026-07-01) revised the live architecture; this snapshot
-> predates it and still describes the **two-arm `LiveConnector`** model. **Superseded
-> framings** (everything else here remains valid):
-> - Connector is a **session/transport primitive**, not a two-arm venue object; the data/order/account arms are **domain adapters** (`OkxDataProvider` / `OkxExchange` / `VenueAccount`), **injected** with the session, never cross-domain-imported.
-> - The **`OkxExchange` adapter emits `FillEvent`** — the connector owns no operations and emits no domain events.
-> - Paper needs **no connector**: the paper execution adapter implements **`AbstractExchange`** (not `LiveConnector`).
-> - `OkxSettings` reads **plain `OKX_API_*` (no env prefix)** — not `ITRADER_OKX_*`; secret manager deferred post-milestone.
->
-> See design-doc LX-05/LX-06 revision notes and `02-CONTEXT.md` D-01..D-10.
+**Domain:** Brownfield structural refactor of an event-driven algo-trading engine (v1.8 — Live System Refactor & Live-Readiness Hardening)
+**Researched:** 2026-07-09
+**Confidence:** HIGH
 
-**Domain:** Live crypto trading (OKX, paper-first) — additions to an event-driven backtest engine
-**Researched:** 2026-06-30
-**Confidence:** HIGH (ccxt packaging/versions, OKX demo mechanics, asyncio bridge verified against current sources; MEDIUM on native-escape-hatch choice — a plan-time gap-list decision)
+## Headline
 
-> Scope: **only the NEW stack surface for v1.7 live OKX paper-first trading.** The existing
-> validated stack (Python 3.13, Poetry, `ccxt ^4.5.56` read-only providers, `websocket-client`,
-> `sqlalchemy`+`psycopg2-binary`+Postgres, `msgspec`, `structlog`, `pydantic`+`pydantic-settings`,
-> `uuid-utils`, Decimal money) is NOT re-researched. The headline: **almost nothing new is
-> strictly required** — the live capability is mostly *activating async ccxt that you already ship*
-> plus stdlib asyncio glue. Resist scope creep (libSQL-rejection precedent applies).
+**v1.8 needs ZERO new third-party dependencies.** Every mechanic the refactor introduces —
+the two-tier priority `EventBus`, the three new durable stores + Alembic chain, the venue
+registry/plugin system, and the runtime-config platform — is satisfied by (a) Python
+**stdlib** constructs (`queue.PriorityQueue`, `itertools.count`, `typing.Protocol`,
+`dataclasses`, `functools`) and (b) libraries **already pinned and validated** in the
+codebase (SQLAlchemy 2.0, Alembic, pydantic 2 / pydantic-settings, msgspec, structlog,
+uuid-utils). Adding a dependency for any of these would *actively regress* the inertness gate,
+which is the opposite of the milestone's intent.
+
+The rest of this document is the evidence for that verdict, item by item, plus the concrete
+stdlib construct for each and the inertness impact.
 
 ---
 
 ## Recommended Stack
 
-### Core Technologies
+### Core Technologies (all EXISTING — no version change forced)
 
-| Technology | Version | Purpose | Why Recommended |
-|------------|---------|---------|-----------------|
-| `ccxt` (already pinned) | bump `^4.5.56` → `^4.5.62` (latest 4.5.62, Feb–Mar 2026) | **Live data arm + order arm** via its built-in WebSocket layer (ccxt.pro) and async REST | **ccxt.pro is already inside the free `ccxt` package** (merged at v1.95, 2022) — no separate license, no separate install, no new dependency. You already depend on ccxt for read-only providers; v1.7 just *uses its async + watch\* surface*. OKX is a first-class ccxt venue. This is the LX-05 default. |
-| Python stdlib `asyncio` | stdlib (3.13) | **Async/sync bridge** — run the connector's event loop on its own daemon thread; marshal across the boundary | `asyncio.run_coroutine_threadsafe()` (sync→async commands) + `loop.call_soon_threadsafe()` (loop control) is the canonical, dependency-free pattern. Outbound (async→sync `global_queue`) is just `queue.Queue.put()` — already thread-safe. **No new library needed for the bridge.** |
-| `aiohttp` | transitive via ccxt async (verify resolved ≥ 3.10) | HTTP transport for `ccxt.async_support` / `ccxt.pro` | Ships as a ccxt dependency for the async layer; confirm it resolves in `poetry.lock` rather than adding it explicitly. No direct use in our code. |
+| Technology | Installed | Latest | Purpose in v1.8 | Verdict |
+|------------|-----------|--------|-----------------|---------|
+| Python stdlib `queue` / `itertools` / `typing` / `dataclasses` | 3.13 | 3.13 | `PriorityEventBus`, monotonic seq, `EventBus`/`VenuePlugin` Protocols, `EngineContext`/`VenueBundle` frozen dataclasses | **Use — no dependency** |
+| SQLAlchemy | 2.0.50 | 2.0.51 | SQLAlchemy **Core** `Table`/`insert`/`select`/`update` for the 3 new stores (same pattern as `HaltRecordStore`) | **Keep** (2.0.50 is current-minus-one patch; no upgrade required for v1.8) |
+| Alembic | 1.18.5 | 1.18.5 | Chain 3 new migrations after `d10_halt_records`; relocate `script_location` to project-root `migrations/` | **Keep — already latest** |
+| pydantic + pydantic-settings | 2.13.4 / 2.14 | 2.13.x / 2.14 | Extend `SystemConfig` (eager/lazy/template split), `RuntimeConfig` overlay, per-store config models | **Keep** |
+| msgspec | 0.21.1 | 0.21.x | Existing `Bar`/event structs — the priority-tuple wraps these unchanged | **Keep** |
+| structlog | 24.4.0 | 24.x | `ErrorHandler` severity-mapped logging (existing) | **Keep** |
+| uuid-utils | 0.16.0 | 0.16.x | UUIDv7 PKs for new store rows (via `idgen` singleton) | **Keep** |
 
-### Supporting Libraries
+### Supporting stdlib constructs (the actual "additions")
 
-| Library | Version | Purpose | When to Use |
-|---------|---------|---------|-------------|
-| `pytest-asyncio` | `^1.4.0` (requires py ≥3.10 ✓) | Test `async def` connector coroutines (watch-loop parsing, ack handling, reconnect) | **Add to dev group.** Needed the moment you unit-test the connector's async edge in isolation. Configure explicitly (see "Version Compatibility" — interacts with `filterwarnings=["error"]`). |
-| `python-okx` (native escape hatch candidate) | `0.4.1` (okxapi/python-okx, last upload 2026-01-08, py ≥3.7) | LX-05 native OKX v5 escape hatch for *proven* ccxt gaps only | **Do NOT add up front.** Candidate only if a concrete gap is found at Phase 2/3 plan time. Version `0.4.1` is low and the wrapper is community-maintained — treat with the **libSQL-beta caution**. Preferred escape hatch is raw `aiohttp`/`websockets` against OKX v5 (see below). |
-| `janus` | `2.0.0` (py ≥3.9) | Purpose-built mixed sync↔async queue | **Probably NOT needed.** Only reach for it if you discover you need *async-side consumption* of a queue that the *sync side produces into* (the rare reverse direction). The forward path (`queue.Queue` out, `run_coroutine_threadsafe` in) covers the connector design in the sketch. Flag, don't add. |
-| `redis` (py client) | `^5.x` if chosen | LX-15 inter-process command/status channel (option) | Only if the topology decision picks Redis over Postgres LISTEN/NOTIFY. **Topology is an architecture decision (out of scope here)** — inventoried below, not selected. |
+| Construct | Module | Where it lands | Why stdlib suffices |
+|-----------|--------|----------------|---------------------|
+| `queue.PriorityQueue` | `queue` | `events_handler/bus.py::PriorityEventBus` | Thread-safe priority heap with the same `.get/.put` surface as the existing `queue.Queue`; already the substrate the live engine thread expects |
+| `itertools.count()` | `itertools` | `PriorityEventBus` seq generator | Thread-safe monotonic counter (the `__next__` increment is atomic under CPython's GIL); the unique tiebreaker that stops tuple comparison at `seq` |
+| `typing.Protocol` | `typing` | `EventBus`, `ExecutionVenuePlugin`, `LiveDataProvider`, `PortfolioReadModel` (existing pattern) | Structural typing = zero-import registration; the codebase already uses this idiom (`PortfolioReadModel`, `_AlertSinkLike`) |
+| `@dataclass(frozen=True)` | `dataclasses` | `EngineContext`, `VenueBundle`, tier enum carriers | Matches every existing event/value object; frozen = the single-writer/snapshot-read contract |
+| `functools.cached_property` | `functools` | `SystemConfig.sql` lazy accessor | First-access resolution keeps Postgres `SqlSettings` off the import path (inertness) |
+| `dict[(venue, account_id), LiveConnector]` | builtin | connector memoization at the composition root | A plain dict *is* the registry; entry-points/plugin libs would break lazy-import inertness |
 
-### Development Tools
+### Development Tools (unchanged)
 
 | Tool | Purpose | Notes |
 |------|---------|-------|
-| `pytest-asyncio` | Async test driver | Set `asyncio_mode = "auto"` (or `"strict"`) AND `asyncio_default_fixture_loop_scope = "function"` in `[tool.pytest.ini_options]` — otherwise it emits a `PytestDeprecationWarning` that the `error` filter can escalate. Do NOT redefine the `event_loop` fixture (deprecated → future error). |
-| ccxt verbose / `exchange.verbose = True` | Inspect raw OKX WS frames during connector bring-up | Use to confirm the kline **confirm flag** payload shape (LX-08) and demo-header routing without writing throwaway scripts. |
+| pytest + strict config | Test gate | `filterwarnings=["error"]`, strict markers — new `PriorityEventBus`/store tests must be warning-clean |
+| mypy `--strict` | Type gate | New collaborators (bus, registries, stores) must be strict-clean; live subsystems may keep their `[[tool.mypy.overrides]]` |
+| testcontainers (existing) | Postgres round-trip tests | New stores follow the `HaltRecordStore` test pattern (in-process SQLite `create_all` + Postgres testcontainer) |
 
 ## Installation
 
 ```bash
-# Core: bump the existing ccxt pin (NO new runtime dependency — ccxt.pro is in-package)
-poetry add "ccxt@^4.5.62"
-
-# Dev: async test driver
-poetry add --group dev "pytest-asyncio@^1.4.0"
-
-# DO NOT add up front (evaluate at plan time only):
-#   poetry add "python-okx@0.4.1"     # native escape hatch — only on a proven gap
-#   poetry add "janus@^2.0.0"         # only if reverse sync->async queue consumption is needed
-#   poetry add "redis@^5"             # only if LX-15 topology picks Redis
+# NOTHING to install. All v1.8 mechanics are stdlib or already-pinned deps.
+# Explicitly: do NOT add pypubsub / blinker / pluggy / stevedore / dynaconf /
+# python-configuration / an entry-points plugin loader. Each would regress the
+# inertness gate and duplicate a stdlib capability.
 ```
-
-`aiohttp` is pulled transitively by ccxt's async layer — verify it lands in `poetry.lock`; do not pin it directly.
 
 ---
 
-## The six questions, answered
+## Point-by-point evaluation (the five questions)
 
-### 1. ccxt.pro packaging + OKX surface (LX-05)
-- **Packaging: definitively merged.** ccxt.pro is a **free part of the unified `ccxt` package** since v1.95 (2022). There is **no separate package, no separate install, no license key.** Confirmed against ccxt issue #15171 and the PyPI/docs current pages. The CLAUDE.md note that ccxt is "used today only as read-only providers" is an *internal usage* fact, not a packaging limit — the async + WS surface is already shipped in the wheel you have.
-- **Import structure (Python):**
-  - `import ccxt.pro as ccxtpro` — the **WebSocket** layer (`watch_*` streaming methods).
-  - `import ccxt.async_support as ccxt` — **async REST** (awaitable `create_order`, `fetch_ohlcv`, `fetch_balance`).
-  - `import ccxt` — the legacy **sync REST** layer (what `ccxt_provider.py` uses today).
-- **OKX WS method support (LX-05 data + order arms):** OKX supports `watch_ohlcv` (data arm), and the private streams `watch_orders`, `watch_balance`, `watch_my_trades`, `watch_positions`. Order placement: `create_order` (async REST) and `create_order_ws` (`createOrderWs`, same signature, over WS). `create_order_ws` is an optional optimization — start with async-REST `create_order` + `watch_orders` for the fill stream.
-- **Native escape hatch (LX-05):** the leanest escape hatch is **raw `aiohttp` (REST) + `websockets`/the ccxt-bundled WS client against the OKX v5 API directly** — both transports already ride in via ccxt, so no new dep. The packaged `python-okx 0.4.1` SDK is a *candidate* but is low-version + community-maintained (libSQL-caution); `okx-sdk` (burakoner, 5.5.812) is more complete but is a second third-party surface. **Recommendation: keep the escape hatch as thin hand-rolled v5 calls behind `LiveConnector`, add a native SDK only if a concrete, proven gap justifies it** at Phase 2/3 plan time.
+### 1. Two-tier priority `EventBus` — stdlib `queue.PriorityQueue` + `itertools.count()` ✅
 
-### 2. asyncio bridge
-- **Best practice (verified, dependency-free):** connector owns a `loop = asyncio.new_event_loop()` on a **daemon thread**; `run_coroutine_threadsafe(coro, loop)` to submit work *into* the loop from the sync engine; `loop.call_soon_threadsafe(loop.stop)` for graceful shutdown, then `thread.join()`. Outbound async→sync is `global_queue.put(event)` (stdlib `queue.Queue` is thread-safe). This keeps the async boundary "bottled at the connector edge" exactly as the sketch requires.
-- **No version-pinned dep required.** `janus 2.0.0` exists for the harder sync↔async-queue case but is **not needed** for this topology — flag it, don't add it.
+**Verdict: stdlib, no new dependency.** `queue.PriorityQueue` (a thread-safe binary-heap
+wrapper over `heapq`) is the correct substrate. No third-party bus (pypubsub, blinker,
+zmq, an actor framework) is warranted: they add async/serialization/transport machinery the
+single-consumer engine-thread model does not need, and every one of them would be a heavy
+import that must NOT touch the backtest path.
 
-### 3. OKX sandbox/demo (single `sandbox: bool`)
-- **ccxt path:** `exchange.set_sandbox_mode(True)` routes OKX to demo endpoints. For OKX, demo also requires the **`x-simulated-trading: 1` HTTP header**; modern ccxt sets this for OKX when sandbox mode is on, but the header is the underlying mechanism — confirm it is applied on **both REST and WS** during bring-up (historical ccxt issues show drift here).
-- **Native path:** set `headers = {"x-simulated-trading": "1"}` and use the demo base URLs / WS URLs.
-- **Demo requires demo-specific API keys** (created in OKX → Demo Trading), distinct from live keys.
-- **Single-flag routing (LX-05):** one `sandbox: bool` on the connector config should (a) call `set_sandbox_mode(sandbox)` on the ccxt instance AND (b) inject the `x-simulated-trading` header on any native call AND (c) select the sandbox-vs-live **key set**. No split-brain — one flag, three effects.
+**The tuple-ordering correctness point (addressed concretely):**
 
-### 4. Secrets (OKX needs THREE)
-- **OKX auth = apiKey + secret + passphrase** (the "password" in ccxt's config is the OKX **passphrase**). Confirmed. This is unlike key+secret-only venues — the passphrase is mandatory.
-- **Best practice: env-only via the existing `pydantic-settings` `ITRADER_` pattern.** Add a dedicated `OkxSettings(BaseSettings)` mirroring `SqlSettings` (`itrader/config/sql.py`): `env_prefix="ITRADER_OKX_"`, all three credentials as `SecretStr | None`, a `sandbox: bool` field, and a `model_validator` that **fails loud** when live (sandbox=False) is selected without all three creds — the exact "no working secret defaults" discipline already proven in `sql.py`. Keys never in code; sandbox vs live keys separated by the single `sandbox` flag (LX-05 cross-cutting §5).
+The heap orders `(tier, seq, event)` tuples by lexicographic comparison. Tuple comparison is
+short-circuit: it compares `tier` first; on a tie it compares `seq`; only on a `seq` tie
+would it reach `event`. Because frozen event dataclasses/`msgspec.Struct`s define **no
+`__lt__`**, reaching `event` would raise `TypeError: '<' not supported`. The fix is that
+`seq` is drawn from a single process-wide `itertools.count()`, so **`seq` is globally unique
+by construction** — two entries can never tie on `seq`, so the comparison provably terminates
+at `seq` and never dereferences `event`. This also gives strict FIFO *within* a tier (lower
+`seq` = earlier `put`, dequeued first) and strict CONTROL-before-BUSINESS preemption *across*
+tiers.
 
-### 5. Runtime topology IPC channels (LX-15) — INVENTORY ONLY (do not pick)
-| Channel | New dep? | Pros | Cons |
-|---------|----------|------|------|
-| **Postgres `LISTEN/NOTIFY`** (via existing `psycopg2`) | **None** — you already ship `psycopg2-binary` + Postgres (v1.6 store) | Reuses the v1.6 system-of-record as the shared truth; zero new infra; transactional with the state writes; "exactly what v1.6's durable store was built to enable" | NOTIFY payload ≤ 8 KB; not a durable queue (missed while disconnected unless paired with a polled table); LISTEN needs a dedicated connection/poll loop |
-| **Redis** (pub/sub or streams) | `redis` py client + a Redis server | Low-latency; mature pub/sub + durable Streams; natural fit for fan-out | New infra component + new dep + new ops surface; second source of truth alongside Postgres |
-| **Message broker** (RabbitMQ / NATS) | heavy client + broker | Strong delivery semantics, routing | Heaviest ops/dep footprint; overkill for a single-venue, few-process deployment |
-- **Lean read:** the Postgres LISTEN/NOTIFY option adds **zero dependencies** and reuses v1.6 — it is the obvious low-cost default *if* a separate-process topology (LX-15 option b/c) is chosen. **But the topology choice itself is an architecture decision and is out of scope here.**
+```python
+# events_handler/bus.py  (4-space file — matches events_handler/events/ package)
+import itertools, queue
+from typing import Any, Protocol
 
-### 6. Testing libs + `filterwarnings=["error"]` interaction
-- **`pytest-asyncio ^1.4.0`** (py ≥3.10 ✓ for 3.13) is the standard async test driver.
-- **Strictness interaction (the gotcha):** the existing `[tool.pytest.ini_options]` has `filterwarnings = ["error", "ignore::UserWarning", "ignore::DeprecationWarning"]`. pytest-asyncio emits a `PytestDeprecationWarning` if `asyncio_default_fixture_loop_scope` is unset. `PytestDeprecationWarning` subclasses `pytest.PytestWarning` (→ `UserWarning`) **and** `DeprecationWarning` — your current ignores *may* absorb it, but **do not rely on that.** Set both config knobs explicitly:
-  ```toml
-  asyncio_mode = "auto"                          # or "strict"
-  asyncio_default_fixture_loop_scope = "function"
-  ```
-- **Do NOT redefine the `event_loop` fixture** — that override path is deprecated and slated to become a hard error; use the `scope=` arg on the asyncio marker or the `event_loop_policy` fixture instead.
-- Async network code tends to leak `ResourceWarning`/unclosed-session warnings; under `error` these fail the suite. Ensure connector teardown `await exchange.close()` in fixtures, and prefer **mocked transports** for unit tests (real OKX sandbox I/O belongs in `integration`/`e2e`, not unit).
+_CONTROL = 0
+_BUSINESS = 1
+_CONTROL_EVENT_TYPES: frozenset = frozenset({...})  # STREAM_STATE, CONNECTOR_FATAL, CONFIG_UPDATE, STRATEGY_COMMAND
+
+class PriorityEventBus:
+    def __init__(self) -> None:
+        self._q: "queue.PriorityQueue[tuple[int, int, Any]]" = queue.PriorityQueue()
+        self._seq = itertools.count()          # thread-safe monotonic tiebreaker
+    def put(self, event: Any) -> None:
+        tier = _CONTROL if event.type in _CONTROL_EVENT_TYPES else _BUSINESS
+        self._q.put((tier, next(self._seq), event))   # next(count) is atomic under GIL
+```
+
+Notes for the planner:
+- `next(itertools.count())` is atomic under CPython (a single bytecode into C) — no extra
+  lock needed for the counter. If the project ever targets a free-threaded (PEP 703) build,
+  wrap `next(self._seq)` in a `threading.Lock`; document the assumption either way.
+- The `FifoEventBus` (backtest) is a thin `queue.Queue` wrapper — it never constructs a
+  `PriorityQueue`, so the priority path carries **zero oracle risk** (design §4a confirms).
+- Keep the shared `.put/.get/.get_nowait/.qsize/.empty` surface so `compose_engine` is
+  bus-agnostic; add `depth_by_tier()` for monitoring (unbounded-but-watched).
+
+### 2. Alembic chain for 3 new stores + `migrations/` relocation ✅
+
+**Verdict: no new dependency; a handful of concrete Alembic 2.0/1.18 gotchas to respect.**
+
+**Current chain head (verified):**
+`2cbf0bf6b0b6` (baseline) → `47f2b41f3ffe` → `p05_venue_order_id` →
+`hl5_transaction_venue_trade_id` → **`d10_halt_records` (HEAD)**. The design's
+"chained after `d10_halt_records`" is correct — `d10_halt_records` **is** the single head,
+so the new linear chain is:
+
+```
+d10_halt_records → system_store → venue_config → strategy_registry
+```
+
+Concrete hazards to encode in the P4/P5 plans:
+
+1. **Verify the head at plan time, don't assume.** Add `poetry run alembic heads` as a
+   pre-flight; it must return exactly one head (`d10_halt_records` today). If P4's rename
+   lands a data-migration or anyone branches, a second head silently breaks `upgrade head`.
+2. **`down_revision` chains by revision *id*, not by file path.** Relocating the entire
+   `migrations/` directory (including `versions/`) preserves the chain with **zero revision
+   edits** — the id pointers are path-independent. Do NOT renumber or rewrite existing
+   revisions during the move.
+3. **`script_location` relocation is a one-line `alembic.ini` edit.** `alembic.ini` already
+   sits at the project root and already uses the modern `%(here)s` token model +
+   `path_separator = os` (Alembic ≥1.16 style). Change `script_location =
+   itrader/storage/migrations` → `script_location = migrations`. Because `%(here)s` = the
+   ini's directory (= project root), this resolves to `<root>/migrations`. `prepend_sys_path
+   = .` stays, so `env.py`'s `from itrader.storage... import build_*_table` /
+   `NAMING_CONVENTION` imports keep resolving against the installed package. (Alembic 1.16+
+   also allows moving this into `[tool.alembic]` in `pyproject.toml` — **do not** adopt that
+   here; keep the working `alembic.ini` to minimize the relocation blast radius.)
+4. **`env.py` must gain three `build_*_table(target_metadata)` calls** (mirroring the existing
+   `build_order_tables`/`build_portfolio_tables`/`build_signal_tables`/`build_halt_records_table`
+   registrar pattern) so `--autogenerate` sees the new tables and never emits a spurious DROP.
+   Each new store owns its own `build_*_table` registrar as the single source of truth shared
+   by its `create_all(checkfirst=True)` test path and the Alembic autogen path.
+5. **`NAMING_CONVENTION` stays the single source of truth** — new tables inherit it via the
+   shared `MetaData`, so autogenerate emits deterministic, byte-stable constraint/index names
+   (no churn across regenerations).
+6. **`render_as_batch=True` is already set** in both `env.py` configure paths — the new
+   migrations get portable (move-and-copy) ALTERs for free (SQLite/libSQL-safe).
+7. **`SqlBackend → SqlEngine` rename (LR-18)** must also update `itrader/storage/__init__.py`
+   (which re-exports `SqlBackend`), `env.py`'s `from itrader.storage.backend import
+   NAMING_CONVENTION` (→ `storage.engine`), the storage factory, and `halt_record_store.py`'s
+   `from itrader.storage import SqlBackend`. Grep for `SqlBackend` before landing — it is
+   imported in ≥4 modules.
+
+**SQLAlchemy version note:** 2.0.50 → 2.0.51 is the only available bump and is a patch
+release; **not required** for v1.8. Do NOT jump to the 2.1 beta line (2.1.0b2) — it is
+pre-release and would be a needless correctness risk on a money-bearing store.
+
+### 3. Venue plugin/registry system — stdlib Protocol + dict registry ✅
+
+**Verdict: stdlib, no new dependency. An entry-points / plugin library is DISQUALIFIED by the
+inertness gate.**
+
+`typing.Protocol` for the `ExecutionVenuePlugin` / `LiveDataProvider` contracts + a plain
+`dict[str, Plugin]` registry with **lazy imports inside `build_bundle`** is exactly right and
+is already the house idiom (`PortfolioReadModel`, `AbstractExchange`, the exchange sub-registry
+in `ExecutionHandler`).
+
+Why an entry-points/plugin lib (`importlib.metadata.entry_points`, `pluggy`, `stevedore`,
+`straight.plugin`) is the **wrong** tool here:
+- The core requirement is *"registering `'okx'` pulls no `ccxt.pro` until `build_bundle` is
+  called."* Entry-point discovery mechanisms **eagerly import** the target module to resolve
+  the object — the direct opposite of the lazy-import inertness contract. They would break
+  `test_okx_inertness.py`.
+- Plugin libs solve *third-party/out-of-tree* discovery. All venues here are first-party,
+  in-repo, and known at composition time. A dict literal populated by the factory is simpler,
+  fully typed under mypy, and trivially unit-testable.
+- The `replay` "test-only plugin registered only by a fixture" pattern (design §8e) is a
+  three-line `registry["replay"] = ReplayPlugin()` in a conftest — no framework needed.
+
+```python
+class ExecutionVenuePlugin(Protocol):
+    name: str
+    connector_key: str | None
+    def build_bundle(self, *, ctx, spec, connector, simulated_exchange) -> "VenueBundle": ...
+    def new_account(self, *, portfolio_ref, config) -> "Account": ...
+
+class OkxPlugin:                       # concrete, registered eagerly, imports NOTHING heavy
+    name = "okx"; connector_key = "okx"
+    def build_bundle(self, *, ctx, spec, connector, simulated_exchange):
+        from itrader.execution_handler.exchanges.okx import OkxExchange   # LAZY — first heavy import here
+        ...
+```
+
+Connector memoization = a lazy `dict[(venue, account_id), LiveConnector]` at the composition
+root (design §8c). Builtin dict; no library.
+
+### 4. Runtime-config platform — SQLAlchemy Core + pydantic ✅
+
+**Verdict: stdlib + existing deps, no new dependency. No config-overlay library warranted.**
+
+The runtime-config platform is three things, each already covered:
+- **The durable key-value store** (`SystemStore`: `(key, value_json, updated_at)`, namespaced
+  keys, upsert) → SQLAlchemy **Core** over the shared `sql_engine`, identical to
+  `HaltRecordStore`. `value_json` uses the existing `json_variant` type helper from
+  `itrader/storage/types.py`. No document-store or KV library.
+- **The overlay** (`RuntimeConfig` = `defaults ← YAML ← env ← persisted overrides`) → a
+  pydantic model with an explicit merge in the live factory, injected as
+  `EngineContext.config`. pydantic-settings already layers env/YAML; the persisted-override
+  layer is a dict merge over the base model. **Do NOT add `dynaconf` / `python-configuration`
+  / `hydra`** — they bring their own loader/lifecycle that conflicts with the "engine-thread-
+  write, snapshot-read" single-writer contract and with the import-safety split (eager vs lazy
+  `sql` accessor). The design's overlay is a deliberately small, auditable merge; a framework
+  would obscure the allowlist/immutable-at-runtime governance (§6e).
+- **The scoped mutation flow** (`ConfigUpdateEvent` on the CONTROL plane → engine-thread
+  handler routes to owner store) → existing event + queue machinery. No library.
+
+The allowlist of runtime-mutable keys (§6e) is a frozenset/dict literal validated with
+pydantic type/range checks — again stdlib + pydantic.
+
+### 5. Inertness — nothing forces a new dep onto the BACKTEST import path ✅
+
+**Verdict: confirmed clean for every item.**
+
+| v1.8 item | Backtest-path import cost | Inertness verdict |
+|-----------|---------------------------|-------------------|
+| `FifoEventBus` (backtest bus) | `import queue` (already imported) | Inert — no priority path, no heavy import |
+| `PriorityEventBus` | Constructed only by the live factory | Never touched on the backtest path |
+| 3 new SQL stores | `EngineContext(sql_engine=None)` on backtest → stores never built; SQL-heavy modules stay quarantined out of `storage/__init__.py` (as today) | Inert — same GATE-01 discipline as v1.6/v1.7 |
+| `migrations/` relocation | `env.py` executed by Alembic only, never imported at runtime | Inert (unchanged) |
+| Venue registry / plugins | Registering `'okx'` imports no `ccxt.pro`; concretions lazy-imported inside `build_bundle` | Inert — the core plugin contract *is* the inertness guarantee |
+| `SystemConfig` extension | Eager fields plain-BaseModel; `sql` via `cached_property` (first-access); venue creds owned by plugin | Inert — Postgres `SqlSettings` never constructed at import |
+
+Guarding test: `tests/integration/test_okx_inertness.py` stays the enforcement mechanism.
+Every new live-only module must be lazy-imported inside a `LiveTradingSystem`/factory arm and
+must NOT be re-exported from a package barrel (`__init__.py`) that the backtest path imports —
+the exact rule that keeps `SqlBackend`'s SQL-heavy `sql_store` out of `storage/__init__.py`
+today.
 
 ---
 
 ## Alternatives Considered
 
-| Recommended | Alternative | When to Use Alternative |
-|-------------|-------------|-------------------------|
-| ccxt.pro (in-package) for OKX | `python-okx 0.4.1` native SDK | Only if a concrete OKX-fidelity gap in ccxt is proven at plan time (e.g. kline confirm-flag unreliability, order-status field loss). Wrap behind `LiveConnector` either way. |
-| Hand-rolled v5 native escape hatch (`aiohttp`/`websockets`) | `okx-sdk 5.5.812` (burakoner) | If the native surface needed is large enough that hand-rolling is more error-prone than a maintained SDK — but that adds a third-party trust + dep surface; bias toward thin hand-rolled. |
-| stdlib `run_coroutine_threadsafe` bridge | `janus 2.0.0` | Only if you need the async side to *consume* from a queue the sync side *produces into* (reverse of the sketch's flow). |
-| Postgres LISTEN/NOTIFY (no dep) | Redis / broker | If/when a separate-process topology needs durable fan-out beyond NOTIFY's 8 KB transient payload, or sub-ms latency. |
+| Recommended | Alternative | When the alternative would win (it does not here) |
+|-------------|-------------|---------------------------------------------------|
+| stdlib `queue.PriorityQueue` + `itertools.count` | pypubsub / blinker / an actor lib (pykka) | If the engine needed multi-consumer fan-out or network transport. It has one consumer thread + one asyncio connector loop bridged by the queue — a bus library adds import weight and async surface for zero benefit and breaks inertness. |
+| stdlib `Protocol` + dict registry | `importlib.metadata` entry-points / pluggy / stevedore | If venues were third-party/out-of-tree and discovered at install time. They are all first-party and eager discovery **breaks lazy-import inertness** — disqualifying. |
+| SQLAlchemy Core `SystemStore` KV | Redis / an embedded KV (lmdb, sqlitedict) | If config/state needed sub-ms cross-process reads or a cache tier. The store is low-frequency operator/config state on the existing SQL spine; a second datastore is unjustified operational surface. |
+| pydantic `RuntimeConfig` overlay | dynaconf / hydra / python-configuration | If the project wanted convention-driven multi-source config with its own lifecycle. It conflicts with the single-writer snapshot-read contract and the eager/lazy import-safety split; the explicit small merge is safer and auditable. |
+| SQLAlchemy 2.0.50 (keep) | SQLAlchemy 2.1.0b2 | Never for a money store mid-refactor — it is a pre-release. Revisit 2.1 only after it goes stable and outside an oracle-gated milestone. |
 
 ## What NOT to Use
 
-| Avoid | Why | Use Instead |
-|-------|-----|-------------|
-| A separate "ccxtpro" package install or license | ccxt.pro merged into free `ccxt` in 2022 — a separate package is stale/wrong | `import ccxt.pro as ccxtpro` from the `ccxt` you already have |
-| `python-okx 0.4.1` as a *default* dependency | Low version + community-maintained; mirrors the libSQL beta-driver rejection (v1.6 Q2) — adds risk for capability you mostly already have in ccxt | ccxt.pro by default; native escape hatch only on a proven, documented gap |
-| `websocket-client` (the v1.6 Binance streamer) for OKX | Sync, callback-style, quarantined D-live module; mixing it with the async connector splits the transport model | ccxt.pro async `watch_*` on the connector's asyncio loop |
-| `asyncio.get_event_loop()` / redefining `event_loop` test fixture | Deprecated patterns; will hard-error in future asyncio/pytest-asyncio | `asyncio.new_event_loop()` on the daemon thread; `asyncio_default_fixture_loop_scope` config |
-| Adding `aiohttp` explicitly | It arrives transitively with ccxt async; an explicit pin risks version drift against ccxt's expectation | Let ccxt resolve it; just verify the lockfile |
+| Avoid | Why (specific problem) | Use Instead |
+|-------|------------------------|-------------|
+| `pluggy` / `stevedore` / entry-points plugin loader | Eager module import on discovery → breaks `test_okx_inertness.py` (registering `'okx'` must pull no `ccxt.pro`) | stdlib `Protocol` + dict registry + lazy import inside `build_bundle` |
+| `blinker` / `pypubsub` / an actor framework | Multi-consumer/async transport the single-writer engine thread doesn't need; heavy import on a path that must stay light | `queue.PriorityQueue` + `itertools.count` |
+| `dynaconf` / `hydra` / `python-configuration` | Own loader lifecycle fights the engine-thread-write/snapshot-read contract and the eager-vs-lazy import-safety split; obscures the runtime allowlist governance | pydantic `RuntimeConfig` overlay + explicit merge |
+| Redis / lmdb / sqlitedict for `SystemStore` | Second datastore = new ops surface + a non-SQL money-adjacent store; no latency need | SQLAlchemy Core over the shared `sql_engine` (the `HaltRecordStore` template) |
+| SQLAlchemy 2.1 beta | Pre-release on a money-bearing, oracle-gated milestone | Stay on 2.0.x (2.0.50; 2.0.51 optional patch) |
+| Migrating Alembic config into `pyproject.toml [tool.alembic]` | Needless blast radius during the `migrations/` relocation; a known "No 'script_location' key" upgrade footgun | Keep `alembic.ini`; change only the `script_location` line |
 
 ## Stack Patterns by Variant
 
-**If staying paper-first (the DoD, Phases 1–4):**
-- You need **only the ccxt bump + the asyncio-bridge (stdlib) + pytest-asyncio**. The `PaperConnector` reuses the pure `MatchingEngine` (LX-06); it consumes the connector's **data arm** (`watch_ohlcv`) only. No order-arm creds, no secrets module strictly required until Phase 5.
+**If the project ever adopts a free-threaded (PEP 703, no-GIL) CPython build:**
+- Wrap `next(self._seq)` in a `threading.Lock` in `PriorityEventBus`.
+- Because `itertools.count().__next__` atomicity relies on the GIL today; document the
+  assumption at the seam now.
 
-**If advancing to the real/sandbox path (Phase 5):**
-- Add the **OkxSettings secrets module** (3 creds + sandbox flag) and exercise the **order arm** (`create_order` + `watch_orders`/`watch_balance`/`watch_positions`) against OKX **demo** first.
+**If a fourth+ durable store is added later:**
+- Follow the same `build_*_table` registrar + `create_all(checkfirst=True)` test path +
+  chained Alembic migration; add the registrar call to `env.py`. The pattern scales without
+  new dependencies.
 
-**If a separate-process runtime topology is chosen (LX-15, b/c):**
-- Default to **Postgres LISTEN/NOTIFY** (zero new dep, reuses v1.6) before reaching for Redis/broker.
+**If multi-provider concurrency (the deferred feed-router, §14) is built later:**
+- Still stdlib: the two-registry decoupling already enables a `dict`-keyed provider-router;
+  no library needed then either.
 
 ## Version Compatibility
 
-| Package | Compatible With | Notes |
-|---------|-----------------|-------|
-| `ccxt 4.5.62` | Python 3.13 ✓ | ccxt does not pin `requires_python`; 4.5.x supports 3.13. Bump is a minor within your existing `^4.5` range — low risk. |
-| `ccxt.pro` (in-package) | `aiohttp` (transitive) | The async/WS layer needs aiohttp; verify it's resolved in `poetry.lock` after the bump. |
-| `pytest-asyncio 1.4.0` | pytest `^9.0.3` (dev), Python 3.13 ✓ | requires py ≥3.10. **Requires** explicit `asyncio_mode` + `asyncio_default_fixture_loop_scope` to coexist with `filterwarnings=["error"]`. |
-| `python-okx 0.4.1` (if added) | py ≥3.7 | Low version; community wrapper — libSQL-caution. Pin exact, behind `LiveConnector`. |
-| `janus 2.0.0` (if added) | py ≥3.9 | `aclose()` required on shutdown or it emits errors. |
+| Package | Installed | Compatible / current | Notes |
+|---------|-----------|----------------------|-------|
+| SQLAlchemy | 2.0.50 | 2.0.51 latest 2.0.x | Keep; patch bump optional, not required. Avoid 2.1 beta. |
+| Alembic | 1.18.5 | 1.18.5 latest | Already latest; uses modern `%(here)s`/`path_separator=os` ini model — relocation is a one-line edit. |
+| pydantic / pydantic-settings | 2.13.4 / 2.14 | current 2.x | Keep; extend models only. |
+| Python | 3.13 | 3.13 | All stdlib constructs (`PriorityQueue`, `itertools.count`, `Protocol`, `cached_property`) present and stable. |
 
-## Integration Points With Existing Code
+## Integration Points (for the roadmap)
 
-- **`itrader/price_handler/providers/ccxt_provider.py`** — the symbol-formatting (`BTC/USDT` ↔ `BTCUSDT`), market loading, and OHLCV→Decimal `Bar` conversion logic is reusable. The new live connector is a *new seam* (data arm + order arm), not an edit of this read-only provider; mine it for symbol/format helpers and the `fetch_ohlcv` warmup-backfill call (LX-09 REST `fetch_ohlcv` for warmup).
-- **`itrader/price_handler/providers/binance_stream.py`** — the **quarantined D-live** sync `websocket-client` streamer. Its `msg['k']['x']` closed-bar gate is the *concept* mirror for OKX's confirm flag (LX-08), but **replace it, don't extend it** — OKX uses async ccxt.pro, not the sync callback model.
-- **`itrader/config/sql.py`** (`SqlSettings`) — the **template for the new `OkxSettings`**: `env_prefix`, `SecretStr` fields, driver-conditional fail-loud `model_validator`, `extra="forbid"`. Clone this pattern for `ITRADER_OKX_*` (key/secret/passphrase/sandbox).
-- **`itrader/config/settings.py`** — keep OKX creds OUT of the general `Settings` (mirror how DB creds moved to their own `SqlSettings`); a dedicated `OkxSettings` keeps the backtest path credential-free and env-tolerant.
-- **`pyproject.toml [tool.mypy]`** — `ccxt.*` is already `ignore_missing_imports`; `live_trading_system`/`trading_interface`/`binance_stream` are already `ignore_errors`. New live code should target **strict-clean** (DoD §4); add per-module overrides only where a third-party stubless surface forces it, not as a blanket.
+- **`SqlBackend` (→ `SqlEngine`, `storage/backend.py` → `storage/engine.py`)** — the 3 new
+  stores each *compose* one `SqlEngine` by reference (has-a), exactly like `HaltRecordStore`.
+  Rename touches `storage/__init__.py`, `env.py`, the storage factory, and `halt_record_store.py`.
+- **`EventHandler` (`events_handler/full_event_handler.py`)** — the bus feeds `process_events()`;
+  the `_on_handler_error` seam becomes the injected `ErrorPolicy` (removing the live monkeypatch),
+  and live routes compose in via `LiveRouteRegistrar` (no subclass, no runtime `routes` mutation —
+  the existing explicit-empty live route slots stay inert on the backtest handler).
+- **Alembic chain** — new head progression `d10_halt_records → system_store → venue_config →
+  strategy_registry`; `env.py` gains three `build_*_table` calls sharing `NAMING_CONVENTION`.
 
 ## Sources
 
-- https://github.com/ccxt/ccxt/issues/15171 — "CCXT Pro Websockets merged with CCXT" (packaging, free, in-package) — HIGH
-- https://docs.ccxt.com/ and https://docs.ccxt.com/docs/pro-manual — ccxt.pro manual, `watch_*` + `createOrderWs`, `import ccxt.pro as ccxtpro` — HIGH
-- https://pypi.org/project/ccxt/ — ccxt 4.5.62 latest (verified via PyPI JSON API) — HIGH
-- https://www.okx.com/en-us/help/api-faq + https://app.okx.com/docs-v5/en/ — OKX demo trading, `x-simulated-trading: 1` header, passphrase requirement — HIGH
-- https://github.com/ccxt/ccxt/issues/11923, /11855, /17295 — OKX `set_sandbox_mode` + demo header + WS demo caveats — MEDIUM (issue threads, version-drift cautions)
-- https://docs.python.org/3/library/asyncio-task.html#asyncio.run_coroutine_threadsafe + https://github.com/aio-libs/janus — asyncio cross-thread bridge + janus — HIGH
-- https://pypi.org/project/python-okx/ (0.4.1, 2026-01-08), https://github.com/burakoner/okx-sdk (5.5.812) — native escape-hatch candidates — MEDIUM
-- https://pypi.org/project/pytest-asyncio/ (1.4.0) + https://pytest-asyncio.readthedocs.io/ — async test driver + loop-scope/event_loop deprecation under strict warnings — HIGH
-- https://pypi.org/project/janus/ (2.0.0) — sync↔async queue (flagged, not recommended) — HIGH
+- Installed versions verified locally: `poetry run python -c "import sqlalchemy, alembic, pydantic"` → SQLAlchemy 2.0.50, Alembic 1.18.5, pydantic 2.13.4 (HIGH)
+- Migration chain head verified locally via `grep down_revision` over `itrader/storage/migrations/versions/` → head = `d10_halt_records` (HIGH)
+- `alembic.ini` + `itrader/storage/migrations/env.py` + `itrader/storage/backend.py` + `itrader/storage/halt_record_store.py` (repo) — relocation/rename mechanics, `%(here)s`/`path_separator` model, `HaltRecordStore` template (HIGH)
+- Design spec `docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md` §4/§6/§7/§8 — bus tuple ordering, config platform, stores, venue registry (HIGH)
+- [SQLAlchemy · PyPI](https://pypi.org/project/SQLAlchemy/) / [SQLAlchemy Releases](https://github.com/sqlalchemy/sqlalchemy/releases) — latest 2.0.x = 2.0.51; 2.1 line still beta (2.1.0b2) (HIGH)
+- [Alembic 1.18.5 Configuration docs](https://alembic.sqlalchemy.org/en/latest/api/config.html) / [alembic · PyPI](https://pypi.org/project/alembic/) — 1.18.5 latest; `script_location` / `[tool.alembic]` (1.16+) relocation semantics (HIGH)
 
 ---
-*Stack research for: live crypto trading (OKX, paper-first) additions to the iTrader backtest engine*
-*Researched: 2026-06-30*
+*Stack research for: v1.8 Live System Refactor — brownfield structural refactor, backtest-oracle + import-inertness gated*
+*Researched: 2026-07-09*

--- a/.planning/research/SUMMARY.md
+++ b/.planning/research/SUMMARY.md
@@ -1,309 +1,268 @@
 # Project Research Summary
 
-> ## ⚠ Superseded framing — read `phases/02-okx-connector/02-CONTEXT.md` first
->
-> The Phase-2 discussion (2026-07-01) revised the live architecture; this snapshot
-> predates it and still describes the **two-arm `LiveConnector`** model. **Superseded
-> framings** (everything else here remains valid):
-> - Connector is a **session/transport primitive**, not a two-arm venue object; the data/order/account arms are **domain adapters** (`OkxDataProvider` / `OkxExchange` / `VenueAccount`), **injected** with the session, never cross-domain-imported.
-> - The **`OkxExchange` adapter emits `FillEvent`** — the connector owns no operations and emits no domain events.
-> - Paper needs **no connector**: the paper execution adapter implements **`AbstractExchange`** (not `LiveConnector`).
-> - `OkxSettings` reads **plain `OKX_API_*` (no env prefix)** — not `ITRADER_OKX_*`.
->
-> See design-doc LX-05/LX-06 revision notes and `02-CONTEXT.md` D-01..D-10.
+**Project:** iTrader — v1.8 Live System Refactor & Live-Readiness Hardening
+**Domain:** Event-driven algorithmic-trading engine (brownfield structural refactor)
+**Researched:** 2026-07-09
+**Confidence:** HIGH (MEDIUM only on the P10–P12 trim-boundary judgment calls)
 
-**Project:** iTrader v1.7 — Live Trading Readiness (paper-first OKX, trimmed N+4)
-**Domain:** Live crypto trading deployment layer over an event-driven, Decimal-exact, deterministic backtest engine
-**Researched:** 2026-06-30
-**Confidence:** HIGH (all four researchers grounded in the locked design LX-01..LX-15 + direct source reading; MEDIUM on two OKX/ccxt externals called out below)
-
----
+> Synthesized from `STACK.md`, `FEATURES.md`, `ARCHITECTURE.md`, `PITFALLS.md`. The research
+> **validates the already-locked design** (`docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md`,
+> decisions LR-00..LR-22, folded TODOs CF-1..CF-10) against mature frameworks (Nautilus Trader, LEAN),
+> Python stdlib, and refactor-pitfall knowledge — it does not re-open the design.
 
 ## Executive Summary
 
-iTrader v1.7 adds live OKX trading to a proven event-driven backtest engine — paper-first, with a correctness gate anchored to the byte-exact oracle (`134 trades / 46189.87730727451`). The defining structural insight from all four researchers is that **v1.5's BarFeed ABC and MatchingEngine were built for this**: the engine above the feed already speaks one contract, and switching the backing store from a precomputed frame to a ring buffer is the bulk of Phase 3's work. Similarly, the `PortfolioReadModel` Protocol seam means the Phase 1 Account abstraction extraction does not ripple into the order domain at all — it is code-motion, not re-architecture. The headline stack finding is equally reassuring: **almost nothing new is strictly required**. ccxt.pro is already inside the free `ccxt` package you ship; the asyncio bridge is stdlib; `pytest-asyncio` is the only real addition. OkxSettings and the order-arm secrets module are deferred to Phase 5.
+v1.8 decomposes the 2,171-line `LiveTradingSystem` God object (~17 concerns) into a factory + shared
+`compose_engine` + `LiveRunner` + focused controllers, adding a two-tier priority event bus, a venue
+registry/plugin system, three new SQL stores, a runtime-config platform, and multi-portfolio-live —
+**without disturbing the byte-exact backtest oracle (`134 / 46189.87730727451`) or the OKX
+import-inertness gate.** Research against Nautilus Trader and QuantConnect LEAN confirms the locked
+design is the proven shape of a mature live kernel: the shared-kernel + mode-factory split (LR-10)
+mirrors Nautilus's `NautilusKernel`/`TradingNode`; the two-registry split (execution venue vs data
+provider, LR-17) is exactly Nautilus's `add_exec_client_factory`/`add_data_client_factory` and LEAN's
+`IBrokerageFactory`/`IDataQueueHandler`. The 2,171-line God object is the precise anti-pattern both
+frameworks avoid.
 
-The six-phase structure is load-bearing: Phase 1 is the universal oracle-gated gate (everything live depends on Account abstraction being behavior-preserving), Phase 3 is where complexity concentrates on the data path (monotonic-forward-only delivery + reconnect gap-fill + warmup-through-update), and Phase 5 is the reconciliation cluster (partial fills, broker-side restart, write-through ordering, VenueAccount drift policy). Phase 4 (PaperConnector + paper-parity gate) is the milestone DoD and is reachable with only the data arm of the connector — no live order I/O required.
+**Zero new third-party dependencies are needed.** Every mechanic resolves to Python stdlib
+(`queue.PriorityQueue`, `itertools.count`, `typing.Protocol`, `functools.cached_property`) plus
+already-pinned deps (SQLAlchemy 2.0.50, Alembic 1.18.5, pydantic 2.13). Adding any library would
+regress the inertness gate — so **"no new dependency, no poetry change"** is a milestone-wide
+constraint. The priority-bus tuple-ordering is provably safe via a single process-wide monotonic
+`seq` (comparison terminates at `seq`, never dereferencing the non-orderable frozen event).
 
-The dominant risk is the forming-bar / confirm-flag problem: ccxt's unified `watchOHLCV` does not surface OKX's `confirm` field (ccxt issue #21885), so a native escape hatch at the connector edge is mandatory before the feed can safely emit `BarEvent`s. This single fact — verified against the OKX v5 docs and ccxt tracker — is the anchor for LX-05/LX-08 and must be plumbed in Phase 2 before Phase 3 can close. The second dominant risk is the Phase 5 reconciliation cluster, where broker-side restart, partial fills, fee ingest, and write-through ordering converge and interact; that phase warrants its own plan-time research sprint.
-
----
+Residual risk concentrates in three places: (1) **P9's CF-1 aggregate circuit breaker** — the one fold
+that adds a real acceptance criterion (must actually trip on a money route failing every event; must
+preserve the WR-06 two-guard terminal safety and leave backtest fail-fast byte-for-byte unchanged);
+(2) a **genuine table-stakes GAP** — a pre-trade order-submit-rate / max-notional throttle that
+Nautilus's `RiskEngine` enforces but iTrader lacks (it has only post-hoc CF-1 + per-order
+`EnhancedOrderValidator` — nothing caps submission velocity from a runaway strategy emitting *valid*
+orders); needs an owner decision, candidate fold into P8/P9; (3) the **★ P10–P12 feature-adds**, where
+P10's runtime-config *mutation* path is the highest over-engineering risk.
 
 ## Key Findings
 
 ### Recommended Stack
 
-The existing stack needs only a minor ccxt bump (`^4.5.56` -> `^4.5.62`), stdlib `asyncio` for the bridge (no new library), and `pytest-asyncio ^1.4.0` in the dev group. ccxt.pro is free, in-package, and already shipped; `import ccxt.pro as ccxtpro` unlocks `watch_ohlcv`, `watch_orders`, `watch_balance`, and `create_order_ws` with zero additional install. The asyncio bridge follows a proven, dependency-free pattern: connector owns `asyncio.new_event_loop()` on a daemon thread; `run_coroutine_threadsafe` submits work into the loop; outbound `global_queue.put(event)` is thread-safe stdlib. OkxSettings (`ITRADER_OKX_*` env prefix, `SecretStr` for all three credentials including the mandatory passphrase, `sandbox: bool`) is deferred to Phase 5.
+**Zero new dependencies.** All five evaluated mechanics resolve to stdlib or already-validated deps;
+adding a library would regress the OKX inertness gate. (Full detail: `STACK.md`.)
 
-**Core technologies:**
-- `ccxt ^4.5.62` (bump existing pin): ccxt.pro live data + order arm via in-package async/WS surface — no new install, no license key
-- Python stdlib `asyncio` (3.13): connector event loop on daemon thread, `run_coroutine_threadsafe` bridge — zero new dependencies
-- `pytest-asyncio ^1.4.0`: async test driver — required; must be configured with `asyncio_mode` + `asyncio_default_fixture_loop_scope` or `filterwarnings=["error"]` escalates its deprecation warnings
-- `aiohttp` (transitive via ccxt async): verify it resolves in `poetry.lock`; do not pin explicitly
-- `python-okx 0.4.1` / `janus 2.0.0` / `redis ^5`: do NOT add up front — each is a flagged candidate only on a proven, documented gap
-
-**Critical version interaction:** `pytest-asyncio` emits `PytestDeprecationWarning` when `asyncio_default_fixture_loop_scope` is unset; under `filterwarnings=["error"]` this fails the suite. Set both `asyncio_mode = "auto"` and `asyncio_default_fixture_loop_scope = "function"` in `pyproject.toml`. Do not redefine the `event_loop` fixture.
+**Core technologies (all already present):**
+- **`queue.PriorityQueue` + `itertools.count()`** — the two-tier `PriorityEventBus` substrate; the
+  `(tier, seq, event)` tuple is ordered by a globally-unique monotonic `seq` so comparison never
+  reaches the non-orderable frozen event. Stdlib, no new dep.
+- **`typing.Protocol` + a dict registry** — the venue/data-provider registries and `VenuePlugin`.
+  Entry-points/pluggy/stevedore are **disqualified** (eager discovery import breaks lazy-import
+  inertness — registering `'okx'` must pull no `ccxt.pro`).
+- **SQLAlchemy 2.0.50 Core + Alembic 1.18.5** — the three new stores follow the existing
+  `HaltRecordStore` template; migration chain `d10_halt_records → system_store → venue_config →
+  strategy_registry` (verified head = `d10_halt_records`). `migrations/` relocation is a one-line
+  `script_location` edit (ini already uses `%(here)s`; `down_revision` chains by id, path-independent).
+- **pydantic 2.13 + pydantic-settings** — the `SystemConfig` eager/lazy split and `RuntimeConfig`
+  overlay; no dynaconf/hydra (they fight the single-writer snapshot-read contract).
 
 ### Expected Features
 
-The 26 identified behaviors split cleanly across the six phases. The DoD is Phase 4 (paper-parity gate). Phase 5 is the "should-have in-milestone" cluster; Phase 6 is the lean poll seam only.
+Validated against Nautilus + LEAN. 12 table-stakes capabilities (all AGREE with the spec), 6
+differentiators, 8 correctly-deferred anti-features. (Full detail: `FEATURES.md`.)
 
-**Must have — Phase 1 (gates everything):**
-- Account ABC + `SimulatedCashAccount` / `SimulatedMarginAccount` leaves (code-motion, byte-exact)
-- `Portfolio` receives injected `self.account`; `cash` -> `account.balance`
-- Margin/liq math moved from `PortfolioHandler` to `SimulatedMarginAccount`; liquidation *emission* stays in the handler (queue-only rule preserved)
-- `Portfolio.user_id` stripped (app-layer concern); `TradingInterface` deleted (replaced by typed engine command surface)
-- `LiveConnector` Protocol defined (interface-only in Phase 1)
-- Oracle re-confirmed byte-exact after extraction
+**Must have (table stakes — the core refactor, P1–P9 + P13):**
+- Shared-kernel + mode-factory decomposition (LR-10) — the God-object teardown itself
+- Two-registry venue system (LR-17) — the exact Nautilus/LEAN separation
+- Venue bundles + connector memoization; precision/validate as exchange capabilities
+- Safety subsystem: halt/pause state machine + durable halt record + startup refusal + reconciliation
+- Handler-owns-storage-init; centralized `SystemConfig`; `SqlEngine` rename + migrations relocation
 
-**Must have — Phases 2 + 3 (feed pipeline):**
-- `OkxConnector` data arm: `watch_ohlcv` via ccxt.pro + native OKX `confirm` flag via escape hatch (LX-05/LX-08) — the confirm field is the enabling prerequisite for the whole feed
-- `LiveBarFeed(BarFeed)` ring buffer: `deque(maxlen=cap)` per `(symbol, timeframe)`, capacity derived from `cache_capacity()` same as backtest
-- Bar-close detection emits `BarEvent` only on `confirm == 1`; bar `time` = venue bar-open stamp (not wall-clock)
-- Warmup/backfill: REST `fetch_ohlcv` last-K, replayed one-by-one through the identical `update(bar)` path (LX-09) — no bulk fast-path exists
-- Monotonic-forward-only delivery: gap -> REST-backfill-and-replay; duplicate -> drop; stale/OOO -> reject; reconnect -> gap-fill
-- WS reconnect with gap recovery; rate-limit handling coordinated across ccxt and native paths
+**Should have (differentiators):**
+- Two-tier priority bus (CONTROL > BUSINESS) — genuinely *exceeds* Nautilus's single-tier FIFO;
+  solves "kill-switch queued behind a market-data backlog" (caveat: `SIGNAL` stays BUSINESS)
+- ★ Runtime-config platform (P10), ★ strategies registry (P11) — durable, survive restart
 
-**Must have — Phase 4 (the DoD):**
-- `PaperConnector(LiveConnector)`: composes `MatchingEngine` + `apply_costs` helper (extracted from `_emit_fill`) + `SimulatedAccount` — no OKX I/O
-- Paper-parity gate: replay fixed dataset -> assert `134 / 46189.87730727451`; byte-exact, not tolerance-based
-- `TimeEvent` synthesized on each closed-bar arrival so existing `_routes` TIME-before-BAR ordering holds
-- Determinism seams: seeded RNG + business-time stamping thread through the paper path
+**GAP (table-stakes, owner decision):**
+- **Pre-trade submit-rate / max-notional throttle** — Nautilus `RiskEngine` has it; iTrader has no
+  runaway-valid-orders guard. Candidate fold into P8/P9, or explicit defer.
 
-**Must have — Phase 5 (real/sandbox path):**
-- `OkxConnector` order arm: `create_order` (async REST) + `watch_orders` / `watch_fills`; single `sandbox: bool` routes both ccxt (`set_sandbox_mode`) and native (`x-simulated-trading` header)
-- `VenueAccount` impl: caches venue balance/margin/position streams, reconciles per-symbol drift (LX-04 1:1)
-- Partial-fill handling: accumulate by fill ID; terminalize only at full fill or venue-reported closed
-- Restart rehydration two-sided: store + broker reconcile (not store-only)
-- Write-through live-drive: create/terminalize sync-durable; append/metrics writes buffered only if profiled necessary
-- Halt-and-alert drift policy; auto-correct only within defined tolerance
-- `OkxSettings(BaseSettings)` with `SecretStr` for all three OKX credentials
-
-**Must have — Phase 6:**
-- Warmup-on-add (reuses Phase 3 `update(bar)` backfill path per-symbol)
-- Open-position-handling-on-remove (force-close vs orphan-and-track policy defined)
-- Lean universe membership poll seam only — not the production screener
-
-**Defer (explicitly out of scope — do not build):**
-- Tick-level local-paper fills (LX-13: bar-based only; sub-bar realism lives in OKX sandbox)
-- Bulk `warmup_from(series)` fast-path (LX-09: forbidden — opens parity audit)
-- Wall-clock bar-close inference (LX-08: always drive from `confirm`)
-- Perp realism Phase B (FUND-01..04): own future milestone
-- Full production screener: lean poll seam only
-- Multi-venue / multi-asset: connector interface *shaped* for a 2nd venue but only OKX implemented
-- Cross-margin pooling: deferred beyond N+2 Phase B
-- In-process engine inside FastAPI (LX-15: separate worker process)
-- Auto-correct-everything reconciliation: halt-and-alert is the safe default
+**Defer (correctly cut by the spec — do NOT build):**
+- Shared-`account_id` risk allocator, config audit table, errors-history table, multi-provider
+  feed-router, single-connector-multi-account optimization.
 
 ### Architecture Approach
 
-The integration spine is the `PortfolioReadModel` Protocol at the center: the order domain already reads through it, so re-homing balance/margin truth into an `Account` abstraction does not ripple into `OrderManager` or the validator. Phase 1 is pure code-motion behind an existing seam. The async->sync boundary is bottled entirely at the connector edge: the connector runs its own asyncio loop on its own daemon thread and only calls `global_queue.put(frozen_event)` — the existing D-19 single-writer contract is never crossed. All state mutation stays on the engine's dispatch thread.
+Every integration point traced against real existing files (`compose.py`, `full_event_handler.py`,
+`backtest_runner.py`). The `.put()` non-change is load-bearing: the bus is injected into the *same
+constructor slot* handlers use for `global_queue` today; `FifoEventBus`/`PriorityEventBus` are
+`queue.Queue`-API-compatible; tier assignment happens *inside* `PriorityEventBus.put` via a
+`_CONTROL_EVENT_TYPES` frozenset — **zero call-site edits**. Backtest's `process_events()` drain stays
+literally unchanged. (Full detail: `ARCHITECTURE.md`.)
 
-**Major new/modified components:**
-1. `Account` ABC + `portfolio_handler/account/` package — NEW; `SimulatedCashAccount` (CashManager code-motion), `SimulatedMarginAccount` (liq math from PortfolioHandler); `VenueAccount` interface-only in P1, implemented in P5
-2. `Portfolio` — MODIFIED: inject `self.account`; `cash` -> `account.balance`; `user_id` stripped
-3. `PortfolioHandler` — MODIFIED: margin/liq math moved out; `_run_liquidation_pass` emission stays (queue-only rule)
-4. `TradingInterface` — DELETED; replaced by typed engine command surface consuming from Postgres command channel
-5. `LiveConnector` Protocol — NEW: data arm (`watch_ohlcv` / `fetch_ohlcv`), order arm (`submit` / `cancel` / `watch_fills`), account arm (`fetch_balances` / `watch_balances` / `fetch_positions`)
-6. `OkxConnector` — NEW: ccxt.pro default + native OKX escape hatch behind the interface; single `sandbox: bool` routes both arms
-7. `LiveBarFeed(BarFeed)` — NEW: `price_handler/feed/live_bar_feed.py`; ring buffer; same ABC the engine already consumes
-8. `apply_costs` helper — NEW: extracted from `SimulatedExchange._emit_fill` (byte-exact); shared by both `SimulatedExchange` and `PaperConnector`; eliminates dual fill-pricing drift
-9. `PaperConnector(LiveConnector)` — NEW: `MatchingEngine` + `apply_costs` + `SimulatedAccount`; no OKX I/O; bar-based fills only
-10. `VenueAccount` impl — NEW (Phase 5): caches + reconciles connector balance/position/fill streams under LX-04
-11. Worker process + Postgres command/status channel — NEW (Phase 5): ships as (b) architected as (c) with N=1
+**Major components (new vs modified):**
+1. `EventBus` Protocol + `FifoEventBus`/`PriorityEventBus` — NEW; injected into `compose_engine`
+2. `EngineContext` (frozen: bus/config/environment/sql_engine) — NEW; threaded once into `compose_engine`
+3. `LiveRunner` + `build_live_system` factory + focused controllers (`SafetyController`,
+   `ReconciliationCoordinator`, `StreamRecoveryHandler`, `WorkerSupervisor`, `SessionInitializer`) — NEW
+4. `ExecutionVenueRegistry` + `DataProviderRegistry` + `VenuePlugin`/`VenueBundle` — NEW
+5. `LiveRouteRegistrar` — NEW; merges live routes into the SINGLE `EventHandler` (no subclass)
+6. `compose_engine`, `LiveTradingSystem` (→ ~200-line facade), Order/Strategies handler storage-init,
+   shared `UniverseWiring` — MODIFIED
 
-**Runtime topology recommendation (LX-15):** Ship option (b) — separate worker — architected as (c) per-portfolio with N=1. Rationale: (a) in-process couples FastAPI + connector asyncio + engine sync thread in one OS process; (b)/(c) activates the v1.6 store-as-truth investment; LX-04's 1:1 constraint makes per-portfolio process isolation natural from day one. Decide before Phase 4 wiring. Default IPC: Postgres LISTEN/NOTIFY (zero new dep, reuses v1.6).
+**4 build-order refinements to the spec's §16 dependency table:**
+1. **P3 depends on P2** (the table omits this) — `EngineContext.bus` needs the `EventBus` from P2.
+2. **Introduce a minimal `EngineContext` skeleton in P2** so `compose_engine`'s signature settles once
+   rather than being double-edited across P2 and P3.
+3. **P2 must add the new CONTROL `EventType` members** (`STREAM_STATE`/`CONNECTOR_FATAL`/`CONFIG_UPDATE`)
+   — the bus tier frozenset references them, even though consumers land in P8/P10.
+4. **Fold the `SqlBackend→SqlEngine` rename into P3** (it collides with `EngineContext.sql_engine:
+   Optional[SqlEngine]` typing); only the migrations *relocation* stays a P4-standalone.
 
 ### Critical Pitfalls
 
-1. **Forming-bar acted on (confirm-flag gap in ccxt)** — ccxt's `watchOHLCV` does not surface OKX's `confirm` field (ccxt #21885); paper-parity fails immediately and silently. Prevention: `OkxConnector` reads native OKX candle `confirm` field via escape hatch; `LiveBarFeed` emits `BarEvent` only on `confirm == 1`. Plumbed in Phase 2; enforced in Phase 3.
+Top items from `PITFALLS.md` (8 refactor-specific pitfalls, each with warning signs + prevention +
+owning phase):
 
-2. **ccxt returns floats — Decimal boundary violation** — every ccxt price/amount/fee/balance is a float; `Decimal(some_ccxt_float)` is binary-float poison. Prevention: all ccxt->Decimal conversion at connector edge through `to_money(x)` = `Decimal(str(x))` (D-04); string precision helpers for outbound quantities. Applies Phase 2 + Phase 5.
-
-3. **Wall-clock leaking into business `time`** — existing `LiveTradingSystem` already has multiple `datetime.now(UTC)` usages; the pattern is contagious. Prevention: connector stamps domain events from venue bar-open timestamps; audit every `datetime.now` on the live path before merge. Business time never equals wall clock.
-
-4. **Backfill divergence from a fast-path (LX-09 violation)** — a bulk `warmup_from(series)` alongside `update()` is a second state-building path; stateful indicators have no rewind. Prevention: LX-09 is absolute — one-by-one `update(bar)` only; never add `warmup_from`/`seed`/`prime` to any indicator or feed API.
-
-5. **Phase 5 reconciliation cluster — broker-side restart gap** — v1.6 restart rehydration was store-only; a live restart on store-only resurrects positions the venue closed. Prevention: two-sided restart: store rehydration + live venue fetch + idempotent downtime fill replay + bracket parent/child re-establishment from venue truth.
-
----
+1. **Behavior-drift during "pure code-motion"** — the `UniverseWiring` extraction (P7) is the single
+   highest oracle-risk seam (analogous to v1.2 MOD-01). Prevention: move as one intact unit incl. the
+   WR-03 desync assert; **byte-exact oracle + determinism double-run as a per-PLAN gate on P1–P6 +
+   P7-UniverseWiring**, not per-phase.
+2. **Inertness regression** — an eager import sneaking in via a barrel re-export, a non-lazy
+   `SqlSettings`, or a registry importing concretions at registration. Prevention: lazy-import-inside-
+   `build_bundle` IS the contract; make `test_okx_inertness.py` the P6 acceptance gate (extended to
+   assert register-vs-build for P1/P2/P5/P6).
+3. **CF-1 circuit-breaker false-green** — a breaker that "runs green with zero settlements," or that
+   reintroduces the WR-06 error→error livelock. Prevention: P9 scoped as "ship the aggregate breaker"
+   (hard acceptance criterion: it must actually trip; SETTLEMENT halt-on-first), not "refactor the
+   error seam."
+4. **Threading-contract violation** — CF-2 `backfill_on_resume` on the engine thread = a second
+   concurrent ring writer. Prevention: it must land **loop-native** (connector loop via the reconnect
+   callback, P8), with an assertion no engine-thread path reaches it.
+5. **Alembic chain divergence** — relocation + 3-store chain multi-head/`create_all`-vs-migration
+   drift. Prevention: explicit P4/P5 gate (`upgrade head` on clean DB + `alembic heads == 1` +
+   create_all/migration parity test).
 
 ## Implications for Roadmap
 
-### Phase 1: Account Abstraction Extraction (Oracle-Gated Refactor)
+Suggested structure: **13 phases (P1–P13)**, matching spec §16 with the 4 architecture refinements
+folded in. Full scope chosen (incl. ★ P10–P12).
 
-**Rationale:** The universal prerequisite. Every live component depends on `Account` being the stable truth surface. Behavior-preserving code-motion behind the existing `PortfolioReadModel` seam — does not ripple into the order domain. Must be oracle-confirmed byte-exact before any live code merges.
+### Phase 1: Config centralization
+**Rationale:** No dependencies; hosts the lazy `sql` accessor (a core inertness lever) + the CF-8
+`HaltReason` enum that P8 consumes.
+**Delivers:** `SystemConfig` aggregation (eager/lazy/templates), module-constant migration, dead-config
+audit, `extra` normalization. **Avoids:** inertness regression (lazy `sql`).
 
-**Delivers:** `Account` ABC + `SimulatedCashAccount` (CashManager code-motion) + `SimulatedMarginAccount` (liq math from PortfolioHandler); `Portfolio` receives `self.account`; `PortfolioHandler` emission path untouched; `Portfolio.user_id` stripped; `TradingInterface` deleted; `LiveConnector` Protocol defined (interface-only); oracle byte-exact confirmed (`134 / 46189.87730727451`).
+### Phase 2: Event bus
+**Rationale:** Foundational; P3's `EngineContext.bus` needs it.
+**Delivers:** stdlib `EventBus` Protocol + `FifoEventBus`/`PriorityEventBus`, the new CONTROL
+`EventType` members, and a minimal `EngineContext` skeleton (refinements 2+3). **Uses:**
+`queue.PriorityQueue` + `itertools.count`. **Test:** tuple comparison never reaches the event.
 
-**Key constraint:** `_process_transaction_spot` is byte-exact site #2 — operand-for-operand identical Decimal ops, in order; `apply_fill_cash_flow` full-precision no-quantize contract preserved. Gate: oracle numbers + determinism double-run + `mypy --strict`.
+### Phase 3: EngineContext + storage-in-handler + SqlEngine rename
+**Rationale:** Depends on {P1, P2} (refinement 1). **Delivers:** full `EngineContext`, handler-owns
+storage init (Order/Strategies), new `compose_engine(ctx, spec)` signature, and the `SqlBackend→SqlEngine`
+rename folded in (refinement 4). **Implements:** the shared composition seam.
 
-**Avoids:** Liquidation math left in PortfolioHandler (A6); user_id on Account (A5); downstream parity failures from mis-homed truth.
+### Phase 4: Migrations relocation
+**Rationale:** Mechanical, now standalone (rename moved to P3). **Delivers:** `itrader/storage/migrations/`
+→ project-root `migrations/`; `alembic.ini` `script_location` edit. **Gate:** single-head + parity test.
 
-**Research flag:** Skip — v1.2 MOD-01 OrderManager-decomposition playbook; well-established pattern.
+### Phase 5: New durable stores
+**Rationale:** Depends on P4 (chain relocated). **Delivers:** `SystemStore`/`VenueStore`/
+`StrategyRegistryStore` via the `HaltRecordStore` template + single-head Alembic chain + rehydrate.
 
----
+### Phase 6: Venue registry + bundle
+**Rationale:** Depends on {P2, P3}; highest inertness risk. **Delivers:** two registries,
+`VenuePlugin`/`VenueBundle`, `LiveDataProvider` Protocol, connector memoization by `(venue,
+account_id)`, precision/validate on the exchange, per-portfolio account factory, shared
+`StreamSupervisor` (CF-3/4/9). **Avoids:** inertness regression (`test_okx_inertness` = acceptance gate).
 
-### Phase 2: OKX Connector (Data Arm + Order Arm)
+### Phase 7: LiveRunner + factory + facade shrink
+**Rationale:** Depends on {P5, P6}; **highest oracle risk** (UniverseWiring). **Delivers:**
+`build_live_system`, `LiveRunner`, `SessionInitializer` + shared `UniverseWiring` *(oracle-sensitive)*,
+`LiveRouteRegistrar`, `UniverseHandler` proper init, `StrategyWarmupConsumer` rehome, drop legacy
+`print_status`/`get_statistics`/`__init__` params (CF-10).
 
-**Rationale:** The connector supplies the closed-bar stream Phase 3 consumes and the order arm Phase 5 exercises. The data arm's native `confirm` flag read is the enabling prerequisite for the whole feed. Must precede Phase 3.
+### Phase 8: Safety + reconciliation + stream recovery
+**Rationale:** Depends on P7. **Delivers:** `SafetyController`, `ReconciliationCoordinator`,
+`StreamRecoveryHandler`, CONTROL routes, flag machinery deleted (CF-2 loop-native, CF-7, CF-8).
+**Candidate home** for the pre-trade throttle GAP (owner decision).
 
-**Delivers:** `OkxConnector(LiveConnector)` with ccxt.pro `watch_ohlcv` + native OKX `confirm` field; REST `fetch_ohlcv`; async REST `create_order` + `watch_orders`/`watch_fills` (order arm for Phase 5); single `sandbox: bool` routes both ccxt and native paths; `load_markets` lot/tick/contract-size validation; idempotent client order IDs via `idgen` UUIDv7; rate-limit coordination; `SecretStr` secret loading.
+### Phase 9: Error subsystem
+**Rationale:** Depends on P7. **Delivers:** `ErrorPolicy` injected (no monkeypatch), `ErrorHandler`
+formalized, two-guard terminal safety, and **CF-1 aggregate circuit breaker (hard acceptance
+criterion)** + CF-5 pluggable alert sink seam.
 
-**Architecture:** connector owns its asyncio loop on a daemon thread; only calls `global_queue.put(...)` on the engine side (D-19 preserved). `pytest-asyncio` unit tests use mocked transports.
+### Phase 10 ★: Runtime-config platform
+**Rationale:** Depends on {P5, P8}. **Delivers:** SystemStore-backed overrides, scoped
+`ConfigUpdateEvent`, allowlist (cap ~5–8 keys explicitly), restart layering, `RuntimeConfig` overlay,
+stats snapshot. **Trim note:** first trim candidate if pressure hits (keep the read-model, cut the
+mutation path).
 
-**Avoids:** Pitfalls 1 (forming bar), 6 (ccxt float), 7 (OKX rounding), 8 (async races), 9 (blocking loop), 15 (split-brain), 16 (secrets leakage), 18 (strict-suite warnings).
+### Phase 11 ★: Strategies registry
+**Rationale:** Depends on {P5, P7}. **Delivers:** durable `StrategyRegistryStore` rehydrate,
+enable/disable via `STRATEGY_COMMAND`, survives restart. **Trim note:** second trim candidate (keep
+durable-resume, cut runtime toggle).
 
-**Research flag:** NEEDS PLAN-TIME RESEARCH — OKX `confirm` exact behavior + ccxt.pro gap list; `set_sandbox_mode` WS header verification; demo key requirements.
+### Phase 12 ★: Multi-portfolio-live
+**Rationale:** Depends on {P6, P8}; LR-03 mandate — **never trim**. **Delivers:** per-`account_id`
+account factory, drop single-portfolio guard + distinct-`account_id` invariant (fail loud),
+per-portfolio reconcile, connector keyed `(venue, account_id)`, `PortfolioSpec.account_id`,
+`clOrdId→client_order_id`.
 
----
-
-### Phase 3: LiveBarFeed (Real-Time Data Engine)
-
-**Rationale:** Most unique live complexity concentrates here. Monotonic-forward-only delivery with reconnect gap-fill has no backtest equivalent. Must follow Phase 2.
-
-**Delivers:** `LiveBarFeed(BarFeed)` ring buffer (`deque(maxlen=cap)` per symbol/tf, same capacity derivation as backtest); bar-close detection on `confirm == 1`; warmup/backfill through `update(bar)` one-by-one (LX-09); monotonic-forward-only enforcement; `TimeEvent` synthesized on each closed bar (recommended — preserves TIME-before-BAR route ordering); event-driven time source replaces `TimeGenerator` on the live path.
-
-**Key seam decision at plan time:** emit paired `TimeEvent` on bar close (recommended) vs. move metric recording to BAR route.
-
-**Avoids:** Pitfalls 1 (forming bar), 4 (backfill fast-path), 5 (backward indicator feed).
-
-**Research flag:** NEEDS PLAN-TIME RESEARCH — ring-buffer capacity with multiple timeframes/consumers; reconnect debounce strategy; after-the-fact venue bar correction policy (re-warm vs forward-only-and-log).
-
----
-
-### Phase 4: Paper Path + Parity Gate (The DoD)
-
-**Rationale:** The milestone DoD. Requires Phase 1 + Phase 3 + connector data arm only — no order arm, no OKX credentials. The paper path is reachable without any live order I/O.
-
-**Delivers:** `PaperConnector(LiveConnector)` composing `MatchingEngine` + shared `apply_costs` helper (byte-exact extraction) + `SimulatedAccount`; bar-based fills only (LX-13); `FillEvent.time = T + tf_base` (next-bar-open via reused `MatchingEngine`); determinism seams throughout (seeded RNG + business-time stamping); paper-parity gate: `134 / 46189.87730727451`, `check_exact=True`.
-
-**Pre-wiring requirement:** LX-15 topology decision must be committed before Phase 4 wires the live runtime.
-
-**Avoids:** Pitfalls 2 (next-bar-open off-by-one), 3 (wall-clock in business time), A3 (dual fill pricing from two separate cost implementations).
-
-**Research flag:** NEEDS PLAN-TIME RESEARCH — parity harness design (offline replay of fixed dataset recommended); LX-15 topology decision + Postgres LISTEN/NOTIFY vs Redis; determinism seam threading in live runtime.
-
----
-
-### Phase 5: Real/Sandbox Path + Reconciliation + Persistence Live-Drive
-
-**Rationale:** The reconciliation cluster — heaviest phase by unique live complexity. Five concerns converge: VenueAccount, partial fills, broker-side restart, write-through ordering, fee ingest. Warrants its own plan-time research sprint.
-
-**Delivers:** `OkxConnector` order arm vs OKX demo; `VenueAccount` implementation (per-symbol drift under LX-04 1:1); partial-fill handling (fill-ID dedup, `accFillSz` accumulation, terminalize on venue-closed); two-sided restart reconciliation; halt-and-alert drift policy; v1.6 SQL store driven by real feed (create/terminalize sync-durable; writes buffered only if profiled stalling); venue fee ingest via `to_money`; `OkxSettings` with three `SecretStr` credentials.
-
-**Avoids:** Pitfalls 6 (ccxt float in VenueAccount), 10 (engine as source of truth), 11 (partial/duplicate fills), 12 (fee drift), 13 (broker-side restart gap), 14 (write ordering / loop stall).
-
-**Research flag:** NEEDS PLAN-TIME RESEARCH — reconciliation drift/repair policy (tolerance thresholds, halt triggers, auto-correct scope); write-through transaction boundary design; OKX partial-fill field cadence; bracket restart from venue truth.
-
----
-
-### Phase 6: Dynamic Universe (Lean Poll Seam)
-
-**Rationale:** Pairs with Phase 3 — warmup-on-add reuses the Phase 3 `update(bar)` backfill path. Cheap only if Phase 3 built the seam generically (per-symbol, not start-only).
-
-**Delivers:** Lean universe membership poll seam; warmup-on-add via `update(bar)` (reuses Phase 3 path); open-position-handling-on-remove policy defined. Does NOT deliver full screener, multi-venue, cross-margin, or perp funding.
-
-**Avoids:** Pitfall 17 (over-building screener/screener chains).
-
-**Research flag:** Skip — reuses Phase 3 backfill seam; standard patterns if Phase 3 is built generically.
-
----
+### Phase 13: Replay→fixture + gates
+**Rationale:** Depends on {P7, P12}; lands last. **Delivers:** `run_paper_replay`→`ReplayRunner` in
+`tests/`, `replay` plugin fixture-registered, production replay-free; live-smoke / config-restart /
+multi-portfolio attribution gates.
 
 ### Phase Ordering Rationale
-
-- **Phase 1 is the hard gate** — oracle-gated; no live code may be written against Account until backtest re-confirmed byte-exact. Non-negotiable.
-- **Phase 2 before Phase 3** — `LiveBarFeed` consumes the connector's data arm + native `confirm` field. Cannot build the feed without the connector.
-- **Phase 4 DoD reachable at Phase 3 + data arm only** — critical sequencing insight: paper-parity requires no order arm, no OKX sandbox access, no live credentials. Fastest path to the milestone gate.
-- **Phase 5 after Phase 4** — order arm + VenueAccount + reconciliation require the paper path proven before real money is risked, even on sandbox.
-- **Phase 6 last** — pairs with Phase 3's backfill seam; no new hard dependencies beyond the live path being live.
-- **LX-15 topology decided before Phase 4 wiring** — worker process structure is cross-cutting; wiring Phase 4 without a topology decision creates rework.
-
----
-
-### Watch Out For
-
-These are the failure modes all four researchers independently flagged:
-
-1. **Forming-bar / confirm-flag paper-parity risk** — the single most likely source of parity failure; the native escape hatch is mandatory. Plan-time: produce the OKX ccxt-vs-native gap list before Phase 2 design is locked.
-
-2. **ccxt returns floats everywhere** — no `to_money` call exists yet in any ccxt order/balance/fee path (existing providers only convert OHLCV rows). Every new connector method handling prices/amounts/fees/balances must route through `to_money`. The failure mode is invisible until reconciliation drift accumulates.
-
-3. **Wall-clock in business time is contagious** — the existing `LiveTradingSystem` has multiple `datetime.now(UTC)` usages. Audit every new `datetime.now` before merge; especially likely in error-handling paths.
-
-4. **Phase 5 reconciliation policy is the most under-specified area** — do not start Phase 5 without decisions on: (a) auto-correct tolerance thresholds, (b) halt-and-alert trigger conditions, (c) bracket parent/child restart re-establishment, (d) write-through transaction boundary. Build a research sprint into Phase 5 planning.
-
-5. **`filterwarnings=["error"]` + async tests** — any unclosed ccxt.pro session/transport or unset `asyncio_default_fixture_loop_scope` fails the entire suite. Use mocked/recorded connectors for unit tests. Never relax the global filter.
-
-6. **Scope creep is the second most likely derailer** — the connector interface invites generalization; sub-bar fills feel "more real"; screener seam looks half-built. The trimmed-N+4 posture is explicit: paper-parity DoD at Phase 4, one venue, bar-based only, lean screener. Every "while I'm here" must be deferred with a note, not absorbed.
-
----
+- Foundation (P1–P4) is oracle-gated and dependency-linear: config → bus → context/storage → migrations.
+- Stores (P5) precede the venue/live decomposition that consumes them (P6–P9).
+- The ★ feature-adds (P10–P12) depend on the decomposed core, so they land after P5–P9.
+- Test migration (P13) lands last because it gates the whole live surface incl. multi-portfolio.
 
 ### Research Flags
+Phases likely needing deeper (plan-time) research:
+- **P7** — UniverseWiring byte-exact extraction discipline (the highest oracle-risk seam)
+- **P9** — CF-1 route-classification + livelock-test design
+- **P12** — `client_order_id`/`portfolio_id` two-key attribution discipline
 
-**Needs plan-time research sprint:**
-- **Phase 2:** OKX `confirm` flag exact behavior + ccxt.pro gap list; `set_sandbox_mode` WS header; demo key requirements
-- **Phase 4:** Parity harness design (offline replay recommended); LX-15 topology decision; determinism seam in live runtime
-- **Phase 5:** Reconciliation drift/repair policy; write-through transaction boundary; OKX partial-fill field cadence; bracket restart from venue truth
+Requirements-definition decisions (not research):
+- **P10** allowlist scope (pin an explicit key cap)
+- The **pre-trade throttle GAP** — fold into P8, P9, or defer (owner call)
 
-**Standard patterns (skip dedicated research phase):**
-- **Phase 1:** v1.2 MOD-01 playbook; `PortfolioReadModel` seam already in place; code-motion only
-- **Phase 3:** `BarFeed` ABC seam exists; ring buffer is bounded deque; monotonic enforcement mirrors BacktestBarFeed cursor discipline
-- **Phase 6:** Reuses Phase 3 backfill-through-update; lean membership seam is well-scoped
-
----
+Phases with standard patterns (skip research-phase):
+- **P2** (bus pattern fully specified), **P4/P5** (mechanical Alembic + proven `HaltRecordStore`
+  template), **P6** (house Protocol+dict idiom)
 
 ## Confidence Assessment
 
 | Area | Confidence | Notes |
 |------|------------|-------|
-| Stack | HIGH | ccxt.pro packaging verified (in-package, free, merged v1.95); asyncio bridge pattern (stdlib, dependency-free, canonical); `pytest-asyncio` filterwarnings interaction documented. MEDIUM: `python-okx`/`janus` as candidates — flagged, not selected |
-| Features | HIGH | All 26 behaviors grounded in locked design LX-01..LX-15 + existing engine code. LOW flag: OKX partial-fill field cadence (consistent across docs, not freshly re-verified live) |
-| Architecture | HIGH | Account layering read from source (`portfolio.py`, `portfolio_handler.py`, `cash/cash_manager.py`, `core/portfolio_read_model.py`); `TradingInterface` deletion grep-confirmed no production consumers; BarFeed ABC seam; MatchingEngine purity. MEDIUM: OKX confirm-flag exposure in ccxt.pro (web-sourced; verify at Phase 2 plan time) |
-| Pitfalls | HIGH (engine-internal) / MEDIUM-HIGH (OKX/ccxt) | Engine-internal pitfalls read directly from source. OKX/ccxt pitfalls verified against ccxt issues + OKX v5 docs; exact behavior confirmed at plan time |
+| Stack | HIGH | stdlib semantics + tuple-ordering proof unambiguous; chain head + versions inspected in-repo |
+| Features | HIGH | grounded in Nautilus/LEAN official docs; MEDIUM only on trim-boundary calls |
+| Architecture | HIGH | every integration point traced against real existing files |
+| Pitfalls | HIGH | grounded in the spec §4/§15/§18 + locked CLAUDE.md constraints |
 
-**Overall confidence:** HIGH on Phase 1 (pure internal refactor); HIGH on Phases 2-4 except confirm-flag gap-list detail (MEDIUM); MEDIUM-HIGH on Phase 5 (reconciliation policy and write-through boundary are the under-specified areas).
+**Overall confidence:** HIGH (MEDIUM only on the P10–P12 trim-boundary judgment calls)
 
 ### Gaps to Address
-
-The following five open questions were flagged independently by all four researchers (sketch §8 convergent open items):
-
-1. **OKX `confirm` flag reliability + native-vs-ccxt gap list** — determine the full list of OKX behaviors ccxt.pro does not surface; validate `set_sandbox_mode(True)` applies `x-simulated-trading` on both REST and WS. How to handle: Phase 2 plan-time research; block Phase 2 design until resolved.
-
-2. **Reconciliation drift/repair policy** — specific tolerance thresholds, halt-and-alert triggers, auto-correct scope, bracket parent/child re-establishment on restart. How to handle: Phase 5 plan-time research sprint; do not start Phase 5 coding until decided and documented.
-
-3. **Parity harness design** — offline replay of a fixed dataset (recommended: CI-runnable, deterministic) vs. record-a-live-session-then-replay (non-deterministic, network-bound). How to handle: decide in Phase 4 planning; offline replay strongly recommended, aligns with byte-exact oracle discipline.
-
-4. **Write-through transaction boundary** — which operations are sync-durable before the irreversible venue action (create, terminalize), which can be buffered (append, metrics), and when buffering is profile-gated vs. always-on. This is the v1.6 carried flag. How to handle: Phase 5 plan-time; default sync for create/terminalize, measure before buffering anything else.
-
-5. **LX-15 topology decision before Phase 4 wiring** — option (b) separate worker architected as (c) with N=1 is recommended; Postgres LISTEN/NOTIFY default (zero new dep). How to handle: decide in Phase 3/4 planning handoff; default to Postgres LISTEN/NOTIFY and revisit only if a concrete latency/durability gap is proven.
-
----
+- **Pre-trade submit-rate / max-notional throttle (GAP)** — the only table-stakes item missing from the
+  26 concerns + CF-list; needs an owner decision at requirements (fold P8/P9 or defer).
+- **P10 runtime-mutable-key allowlist** — enumerate + cap explicitly during requirements, not left open.
+- **Free-threaded CPython `itertools.count()` atomicity** — documentation-only note; not active for this
+  milestone (assumes GIL build).
 
 ## Sources
 
 ### Primary (HIGH confidence)
-- `docs/superpowers/specs/2026-06-30-live-trading-milestone-design.md` (LX-01..LX-15) — locked design, phase structure, parity spine
-- `itrader/portfolio_handler/portfolio.py`, `portfolio_handler.py`, `cash/cash_manager.py` — Account layering source analysis
-- `itrader/core/portfolio_read_model.py` — seam confirmation
-- `itrader/price_handler/feed/bar_feed.py` — 7-rule bar-timing contract; BacktestBarFeed cursor discipline; BarFeed ABC
-- `itrader/execution_handler/matching_engine.py`, `exchanges/simulated.py` — MatchingEngine purity; `_emit_fill` cost helper extraction site
-- `itrader/trading_system/live_trading_system.py`, `trading_interface.py` — `TradingInterface` no-consumer grep; existing `datetime.now` wall-clock usages
-- `itrader/core/money.py` — D-04 `to_money(x)` = `Decimal(str(x))`
-- https://docs.ccxt.com/docs/pro-manual — ccxt.pro `watch_*` surface, `createOrderWs`, import structure
-- https://pypi.org/project/ccxt/ — ccxt 4.5.62; in-package ccxt.pro (free, merged v1.95, issue #15171)
-- https://www.okx.com/docs-v5/en/ — OKX v5 WS candle `confirm` field; `x-simulated-trading` header; passphrase requirement
-- https://pypi.org/project/pytest-asyncio/ — `asyncio_default_fixture_loop_scope` config; `event_loop` fixture deprecation
+- NautilusTrader — Architecture, Risk API, Live API (docs.nautilustrader.io) — kernel/factory split,
+  RiskEngine throttle, exec/data client separation
+- QuantConnect LEAN — Brokerages contribution guide — `IBrokerageFactory`/`IDataQueueHandler`
+- SQLAlchemy · PyPI + GitHub Releases (2.0.50/2.0.51); Alembic Configuration docs + PyPI (1.18.5) —
+  version currency, `script_location`/`down_revision` semantics
+- In-repo inspection: `alembic.ini`, migration chain head, `storage/backend.py`, `compose.py`,
+  `full_event_handler.py`, `backtest_runner.py`
 
 ### Secondary (MEDIUM confidence)
-- https://github.com/ccxt/ccxt/issues/21885 — ccxt `watchOHLCV` does not surface `closed`/`confirm` flag; native escape hatch required
-- https://github.com/ccxt/ccxt/issues/17710 — OKX amount precision / contract-size multiple rejection
-- https://github.com/ccxt/ccxt/issues/7415 — OKX `create_order` `InvalidOperation` (float precision symptom)
-- https://github.com/ccxt/ccxt/issues/11923, /11855, /17295 — OKX `set_sandbox_mode` + demo header + WS demo caveats
-- https://pypi.org/project/python-okx/ (0.4.1), https://github.com/burakoner/okx-sdk (5.5.812) — native escape-hatch candidates (flagged, not selected)
-- https://pypi.org/project/janus/ (2.0.0) — sync/async queue candidate (flagged, not recommended)
-- Framework patterns (Nautilus 1.227.0, freqtrade, Hummingbot, QuantConnect LEAN) — table-stakes feature confirmation; iTrader's distinctive choices mapped against industry norms
+- The spec's own §16 phasing + trim boundary (validated, with 4 refinements)
 
 ---
-*Research completed: 2026-06-30*
+*Research completed: 2026-07-09*
 *Ready for roadmap: yes*

--- a/.planning/research/v1.7-archive/ARCHITECTURE.md
+++ b/.planning/research/v1.7-archive/ARCHITECTURE.md
@@ -1,0 +1,549 @@
+# Architecture Research — v1.7 Live Trading Readiness
+
+> ## ⚠ Superseded framing — read `phases/02-okx-connector/02-CONTEXT.md` first
+>
+> The Phase-2 discussion (2026-07-01) revised the live architecture; this snapshot
+> predates it and still describes the **two-arm `LiveConnector`** model (the §2
+> `LiveConnector(Protocol)` code block, the §4 `PaperConnector` section, and the
+> parity-spine table below all reflect the OLD shape). **Superseded framings**
+> (everything else — reuse assets, matching-core reuse, pitfalls — remains valid):
+> - Connector is a **session/transport primitive**, not a two-arm venue object; the data/order/account arms are **domain adapters** (`OkxDataProvider` in `price_handler/providers/` / `OkxExchange` in `execution_handler/exchanges/` impl `AbstractExchange` / `VenueAccount`), **injected** with the session, never cross-domain-imported.
+> - The **`OkxExchange` adapter emits `FillEvent`** — the connector owns no operations and emits no domain events.
+> - Paper needs **no connector**: the paper execution adapter implements **`AbstractExchange`** (not `LiveConnector`), composing `MatchingEngine` + `apply_costs` + `SimulatedAccount`.
+> - `OkxSettings` reads **plain `OKX_API_*` (no env prefix)** — not `ITRADER_OKX_*`.
+>
+> See design-doc LX-05/LX-06 revision notes and `02-CONTEXT.md` D-01..D-10.
+
+**Domain:** Live-trading integration onto an event-driven backtest engine (iTrader, paper-first OKX)
+**Researched:** 2026-06-30
+**Confidence:** HIGH (existing code mapped directly; locked design `2026-06-30-live-trading-milestone-design.md` LX-01..LX-15; one MEDIUM external grounding — OKX confirm-flag in ccxt.pro)
+
+> Scope: how the NEW live components integrate WITHIN the locked decisions. The
+> existing event core, handlers, BarFeed ABC, MatchingEngine, and v1.6 store are
+> NOT re-researched — they are the integration surface. Every recommendation is
+> grounded in a real file/class. "New" vs "modified" is called out per component.
+
+---
+
+## Standard Architecture
+
+### Target system overview (paper path = the DoD)
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  FastAPI app layer (future; user_id -> portfolio_id mapping)          │
+│   reads STATUS/RESULTS from Postgres; writes COMMANDS to a channel    │
+└───────────────┬──────────────────────────────────────────────────────┘
+                │ Postgres LISTEN/NOTIFY (command + status channel)
+                ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│  LiveTradingSystem worker process  (1 worker : 1 portfolio : 1 acct)  │
+│                                                                        │
+│   ┌────────────────────────┐      enqueue (thread-safe put)           │
+│   │ Connector thread        │ ───────────────────────────────┐        │
+│   │  (own asyncio loop)      │   BarEvent / FillEvent /        │        │
+│   │  OkxConnector|Paper      │   balance+position updates      ▼        │
+│   │  watch_ohlcv / fills     │                         ┌──────────────┐│
+│   └────────────────────────┘                          │ global_queue ││
+│                                                        │ (queue.Queue)││
+│   ┌─────────────────────────────────────────┐         └──────┬───────┘│
+│   │ ENGINE THREAD (single writer, D-19)      │ ◄──────────────┘        │
+│   │  EventHandler._routes dispatch           │  get()+_dispatch        │
+│   │   BAR -> LiveBarFeed.window / strategies │                         │
+│   │        -> PaperConnector.on_bar (fills)  │                         │
+│   │   SIGNAL -> OrderHandler                  │                         │
+│   │   FILL  -> PortfolioHandler / OrderHandler│                        │
+│   │  Portfolio -> Account (balance/margin)   │                         │
+│   └─────────────────────────────────────────┘                         │
+│                       │ write-through (v1.6 operational store)         │
+└───────────────────────┼───────────────────────────────────────────────┘
+                        ▼
+              ┌────────────────────────┐
+              │ Postgres (system of    │  orders / portfolio_state /
+              │ record, v1.6)          │  signals + command/status
+              └────────────────────────┘
+```
+
+The whole live machinery is **inert on the backtest hot path**: backtest keeps
+`TimeGenerator` -> `BacktestBarFeed.generate_bar_event` -> `SimulatedExchange`,
+and `Portfolio` -> `SimulatedAccount` computes the same numbers the oracle froze.
+
+### The parity spine (left column shared by paper)
+
+| World | Time source | Account | Execution |
+|---|---|---|---|
+| Backtest | `TimeGenerator` (pinned grid) | `SimulatedAccount` (computes) | `SimulatedExchange` (`MatchingEngine`) |
+| Paper (live feed) | closed-bar arrival | `SimulatedAccount` (computes) | `PaperConnector` (reuses `MatchingEngine`) |
+| Live real | closed-bar arrival | `VenueAccount` (caches+reconciles) | `OkxConnector` |
+
+Paper shares the backtest's **Account** computation — that is the mechanism that
+makes the paper-parity gate (LX-11) hold.
+
+---
+
+## 1. Account abstraction extraction (Phase 1) — concrete layering
+
+### Where balance/margin truth lives TODAY (the smell)
+
+| Concern | Current home | File:symbol |
+|---|---|---|
+| Cash balance (`_balance`), reservations, locked margin | `CashManager` (owned by `Portfolio`) | `cash/cash_manager.py` |
+| `Portfolio.cash` read | property -> `cash_manager.balance` | `portfolio.py:199` |
+| Spot settlement cash effects | `Portfolio._process_transaction_spot` | `portfolio.py:308` |
+| Margin lock-and-settle cash effects | `Portfolio._process_transaction_margin` | `portfolio.py:391` |
+| Short borrow carry -> cash | `Portfolio._accrue_short_carry` | `portfolio.py:730` |
+| `available_cash` / `reserve` / `release` | `PortfolioHandler` (delegating to CashManager) | `portfolio_handler.py:260/276/282` |
+| `maintenance_margin` / `margin_ratio` | **`PortfolioHandler`** (mis-housed) | `portfolio_handler.py:339/374` |
+| Isolated-liq math (`_isolated_liq_price`, `_is_breached`, `_liquidation_penalty`, `_liq_inputs`) | **`PortfolioHandler`** (mis-housed) | `portfolio_handler.py:399–460` |
+| Liquidation engine (`_run_liquidation_pass`, `_collect_breaches_over_prices`, `_liquidate_position`) | **`PortfolioHandler`** (mixes truth + queue I/O) | `portfolio_handler.py:462–651` |
+
+### Target layering
+
+```
+Account (ABC)                      owns BALANCE / MARGIN TRUTH + decisions
+├── CashAccount    → SimulatedCashAccount    | VenueCashAccount   (interface-only P1)
+└── MarginAccount  → SimulatedMarginAccount  | VenueMarginAccount (interface-only P1)
+       (N+2 computed liq model)                (caches venue balance/margin)
+```
+
+- **`Account` (ABC)** — the truth surface that the `PortfolioReadModel` Protocol
+  already names: `balance`/`available_cash`, `reserve`/`release`, `maintenance_margin`,
+  `margin_ratio`. NEW abstraction, but the *Protocol contract already exists*
+  (`core/portfolio_read_model.py`) — Phase 1 moves the implementation behind it,
+  the seam stays. This is the single most important integration fact: **the order
+  domain already reads through `PortfolioReadModel`, so re-homing the truth does
+  not ripple into `OrderManager`/validator** (mypy-enforced structural conformance).
+- **`SimulatedCashAccount`** ≈ today's `CashManager` verbatim (`_balance`,
+  reservations, locked-margin, `apply_fill_cash_flow`, `assert_funds_invariant`,
+  `assert_lock_fits_buying_power`, `reserve_cash`/`release_reservation`). The
+  cash-vs-margin axis maps cleanly onto the existing
+  `_process_transaction_spot` (CashAccount) vs `_process_transaction_margin`
+  (MarginAccount) split — those two methods are the seam line.
+- **`SimulatedMarginAccount`** = CashAccount + the lock-and-settle path
+  (`lock_margin`/`release_margin`) + the **margin math** moved out of
+  `PortfolioHandler` (`maintenance_margin`, `margin_ratio`, `_isolated_liq_price`,
+  `_is_breached`, `_liquidation_penalty`, `_liq_inputs`).
+- **`Venue*` leaves: interface-only in Phase 1.** They cache the connector's
+  balance/margin/position streams (Phase 5 impl).
+
+### `Portfolio.cash` -> `Portfolio.account.cash` without disturbing the oracle
+
+- `Portfolio` gains an injected `self.account` exactly as it injects four managers
+  in `_init_managers` (`portfolio.py:83`). `Portfolio.cash` (`portfolio.py:199`)
+  changes from `self.cash_manager.balance` to `self.account.balance`. The cash
+  SETTER is already deleted (`portfolio.py:208`), so there is no write seam to chase.
+- **Byte-exact discipline = pure code-motion** (the v1.2 MOD-01 OrderManager-
+  decomposition playbook). `_process_transaction_spot` is the documented
+  "byte-exact site #2" (`portfolio.py:309`) — operand-for-operand identical
+  Decimal ops, in order. The extraction must preserve operand order and the
+  `apply_fill_cash_flow` full-precision (no-quantize) contract. Gate: SMA_MACD
+  `134 / 46189.87730727451`, determinism double-run, `mypy --strict`.
+
+### The queue-vs-truth seam for liquidation (the one non-trivial split)
+
+`_liquidate_position` (`portfolio_handler.py:462`) does TWO things: (1) computes
+liq price/penalty (truth) and (2) **mints an `Order`, writes `order_storage`, and
+`global_queue.put(FillEvent)`** (I/O). Convention forbids a manager/Account from
+holding the queue. **Recommended split:**
+
+- `SimulatedMarginAccount` owns the **decision**: "is this position breached, and
+  at what liq price/penalty?" (`_isolated_liq_price`, `_is_breached`,
+  `_liquidation_penalty`, `maintenance_margin`).
+- `PortfolioHandler` keeps the **emission**: `_run_liquidation_pass` stays as the
+  queue-owning orchestrator that asks the Account for breaches and mints the
+  forced-close `FillEvent` + `order_storage` write.
+
+This keeps the queue-only / no-queue-in-manager convention intact and is
+oracle-dark (default-off: zero breaches on the spot golden path), so it moves
+safely.
+
+### Positions stay in Portfolio — seam confirmed
+
+`PositionManager` stays on `Portfolio` (`portfolio.py:96`). `maintenance_margin`
+needs positions + `Universe` + current price; under **LX-04 (1 account : 1
+portfolio)** Account and Portfolio share scope, so `maintenance_margin` is a
+**computed read-model that composes Account (locked margin) + Portfolio
+(positions) + Universe** — no ownership conflict. Confirmed: do NOT relocate
+positions in Phase 1.
+
+### `Portfolio.user_id` strip (paired Phase-1 cleanup)
+
+`user_id` is set in `Portfolio.__init__` (`portfolio.py:52`), passed by
+`PortfolioHandler.add_portfolio(user_id, ...)` (`portfolio_handler.py:152`), and
+surfaced in `to_dict` (`portfolio.py:851`). Multi-tenancy is app-layer (FastAPI
+maps `user_id -> portfolio_id`); it must NOT relocate onto `Account`. This is a
+constructor-signature ripple that touches golden-master wiring -> re-confirm
+byte-exact.
+
+---
+
+## 2. LiveConnector interface (ours, over ccxt.pro — LX-05)
+
+### Shape (NEW abstraction; shaped on OKX reality)
+
+```python
+class LiveConnector(Protocol):   # mirrors AbstractExchange's role for live
+    # --- data arm (feeds Phase 3 LiveBarFeed) ---
+    async def watch_ohlcv(self, symbol, timeframe) -> AsyncIterator[ClosedBar]: ...
+    async def fetch_ohlcv(self, symbol, timeframe, limit) -> list[Bar]:  # REST backfill (LX-09)
+    # --- order arm (exercised in Phase 5 sandbox) ---
+    async def submit(self, order) -> Ack: ...
+    async def cancel(self, order_id) -> Ack: ...
+    async def watch_fills(self) -> AsyncIterator[Fill]: ...
+    # --- account arm (feeds Phase 5 VenueAccount) ---
+    async def fetch_balances(self) -> Balances: ...
+    async def watch_balances(self) -> AsyncIterator[Balances]: ...
+    async def fetch_positions(self) -> Positions: ...
+```
+
+- `OkxConnector` implements it with **ccxt.pro by default + a native OKX escape
+  hatch** behind the interface (LX-05). A single `sandbox: bool` routes BOTH
+  ccxt (`set_sandbox_mode`) and native calls (`x-simulated-trading` header) to
+  OKX demo — no split-brain.
+- Reuse plumbing from existing `price_handler/providers/ccxt_provider.py` and
+  `binance_stream.py` (those are read-only providers; the connector is the
+  live-feed + order arm).
+
+### Async loop -> synchronous `global_queue` (the determinism boundary)
+
+This boundary already exists and is documented:
+
+- `SimulatedExchange` docstring: *"queue.Queue is the thread boundary — other
+  threads only put events"* (D-19, `simulated.py:44`). `Portfolio`/`PortfolioHandler`
+  carry the same single-writer contract.
+- `LiveTradingSystem._event_processing_loop` already drains on a daemon thread and
+  dispatches via `event_handler._dispatch(event)` (`live_trading_system.py:365`).
+
+**Integration rule:** the connector runs its **own asyncio loop in its own
+thread**; on every venue message it translates to a frozen domain event and calls
+`global_queue.put(...)` — a thread-safe handoff. It NEVER mutates engine state
+directly. All state mutation stays on the single engine thread (the existing D-19
+single-writer contract). Therefore:
+
+- **Determinism of the backtest path is untouched** — the async bridge does not
+  exist on the backtest path at all (inert).
+- Live runs are inherently wall-clock-nondeterministic, but the engine-thread
+  *processing* is still a serialized FIFO drain, so per-event handler logic stays
+  reproducible given the same event sequence. The async boundary is "bottled at
+  the connector edge" (sketch §4 Phase 2).
+- **Event `time` must be the venue bar/fill business time, never wall clock**
+  (the bar-timing contract + the determinism convention). The connector stamps
+  domain events from venue timestamps.
+
+---
+
+## 3. LiveBarFeed as a BarFeed impl (Phase 3, LX-07)
+
+### NEW concrete class; same ABC the engine already consumes
+
+`LiveBarFeed(BarFeed)` implements the four abstract methods (`feed/base.py:75`):
+`current_bars`, `window`, `megaframe`, `newest_bar`. The engine above the feed is
+unchanged — strategies, screeners, execution all speak the same contract.
+
+| Concern | BacktestBarFeed (existing) | LiveBarFeed (new) |
+|---|---|---|
+| Backing store | whole frame precomputed; monotonic int64 cursor | **bounded `deque(maxlen=cap)` per `(symbol, timeframe)`** |
+| Capacity | holds full history | `cap = cache_capacity()` — the SAME `cache_registration.derive` over registered consumers (`feed/base.py:118`), i.e. `max(lookback)` (warmup=100 for SMA_MACD) |
+| `window(asof, max_window)` | `iloc` slice of cached frame | trailing N from the ring |
+| `newest_bar` | last `current_bars` walk writes `_newest_bars` | set on each `update(bar)` |
+| Time source | `TimeGenerator` pinned grid | **closed-bar arrival** |
+
+### Replacing TimeGenerator's role
+
+- Backtest: `TimeGenerator` yields `TimeEvent`s; the TIME route calls
+  `feed.generate_bar_event(time_event)` -> `BarEvent` (`bar_feed.py:448`).
+- Live: there is no pinned grid. The connector's closed bar drives
+  `LiveBarFeed.update(bar)` which appends to the ring and **emits the `BarEvent`
+  directly**. Downstream BAR-route cycle (portfolio mark -> matching -> strategies)
+  is unchanged.
+- **Integration gap to flag:** `LiveTradingSystem` records portfolio metrics on
+  `EventType.TIME` (`live_trading_system.py:374`). Live has no `TimeEvent` unless
+  the feed/connector synthesizes one per closed bar. Decide at plan time: emit a
+  paired `TimeEvent` on bar close (cleanest — keeps the TIME route semantics), or
+  move metric recording to the BAR route. Recommend: synthesize a `TimeEvent` on
+  closed-bar arrival so the existing `_routes` ordering (TIME before BAR) holds.
+
+### Bar-close detection (LX-08) — the native escape hatch earns its keep
+
+OKX's native WS kline channel carries a `confirm` field (`"0"` forming, `"1"`
+closed). **ccxt.pro `watchOHLCV` does not reliably surface a closed/confirm flag**
+across exchanges (it is exchange-specific and not part of the unified return)
+([ccxt #21885](https://github.com/ccxt/ccxt/issues/21885)). This is exactly the
+LX-05 native-escape-hatch case: drive "closed" off OKX's confirm flag via the
+native path, never wall-clock inference. Emit a `BarEvent` only on a completed bar
+(7-rule contract: completed bars only, no forming bucket).
+
+### Warmup/backfill through the IDENTICAL update path (LX-09)
+
+At live-start: REST `fetch_ohlcv` the last K bars, then **replay them one-by-one
+through the same `update(bar)` path** live streaming uses. **No bulk
+`warmup_from(series)` fast-path** — a second state-building path diverges and
+re-opens the parity audit. Stateful indicators (v1.5) self-buffer through the same
+per-bar push, so this is what keeps paper-parity intact.
+
+### Monotonic-forward-only delivery (LX-10)
+
+Both feeds are monotonic by construction (the BacktestBarFeed cursor is
+forward-only with a safe-rebuild on a non-monotonic cutoff, `bar_feed.py:639`).
+LiveBarFeed enforces: gap -> REST-backfill and replay through `update`; duplicate
+-> drop; out-of-order/stale -> reject (stateful indicators have no rewind);
+reconnect -> gap-fill the interim.
+
+---
+
+## 4. PaperConnector (Phase 4 — the DoD)
+
+### NEW class composing the pure matching core (LX-06), NOT the whole exchange
+
+`SimulatedExchange` (`simulated.py:36`) composes `MatchingEngine` +
+`fee_model`/`slippage_model` and adds I/O (`_emit_fill`, `_emit_rejection`,
+admission, connection telemetry). `PaperConnector` composes the **same pure
+pieces** and satisfies `LiveConnector`:
+
+```
+PaperConnector(LiveConnector)
+├── MatchingEngine            (reused verbatim — pure, I/O-free: submit / on_bar -> decisions)
+├── fee_model + slippage_model (reused)
+└── SimulatedAccount          (Phase 1 — provides balances/positions = backtest math)
+```
+
+- `submit`/`cancel` -> `matching_engine.submit`/`cancel`.
+- On each `LiveBarFeed` **closed** bar -> `matching_engine.on_bar(bar)` -> apply
+  fee/slippage -> emit `FillEvent` (bar-based fills only, LX-13).
+- `fetch_balances`/`fetch_positions` -> read `SimulatedAccount` locally.
+
+### Two-adapter-over-one-matching-core symmetry + a refactor to enable it
+
+The fee/slippage application logic lives **only** in `SimulatedExchange._emit_fill`
+(`simulated.py:247`) — maker/taker classification, the D-03 limit-no-slippage
+gate, `to_money` normalization. To avoid two divergent fill-pricing paths (a
+parity hazard), **extract a pure helper** (e.g. `apply_costs(decision, fee_model,
+slippage_model) -> (executed_price, commission)`) that BOTH `SimulatedExchange`
+and `PaperConnector` call. This is the "two adapters over one matching core"
+made real: one matching core (`MatchingEngine`) AND one cost core. Modified:
+`simulated.py` (extract helper, keep behavior byte-exact); New: the helper +
+`PaperConnector`.
+
+### Correctness gate (LX-11)
+
+Paper-parity vs the backtest oracle on the same data: local paper is deterministic
++ bar-based precisely so this holds. The shared `SimulatedAccount` (column 1) and
+shared `MatchingEngine`/cost-core are the mechanism.
+
+---
+
+## 5. Runtime / deployment topology (LX-15)
+
+| Option | Integration points | Verdict |
+|---|---|---|
+| **(a) in-process** — engine thread inside FastAPI | none new; FastAPI calls `LiveTradingSystem` directly | **Reject.** Couples engine+web lifecycles; mixes FastAPI's async loop + connector asyncio thread + engine sync thread in one process; one crash kills both. |
+| **(b) separate worker** — FastAPI controls lifecycle; Postgres system-of-record + command/status channel | v1.6 store (shared truth); Postgres `LISTEN/NOTIFY` (or commands table) for control; worker write-through | **Recommended baseline.** This is *precisely what v1.6's durable store + restart rehydration were built to enable* — store is the shared truth a separate process reads while the worker writes. Crash isolation; FastAPI stays thin. |
+| **(c) process-per-portfolio** — 1 worker : 1 portfolio + shared price-feed service | per-OKX-subaccount isolation; shared feed avoids duplicate streams/rate-limits | **Target end-state under LX-04.** Natural fit for 1 account : 1 portfolio + one OKX subaccount per portfolio. |
+
+### Recommendation (rationale-backed)
+
+**Ship (b) now, architected as (c) with N=1.** Build the worker as a
+**single-portfolio process** (effectively (c) with one portfolio), with the
+price-feed living inside it for v1.7 but behind a seam that can be extracted to a
+shared price-feed service later. Rationale, grounded in three locked facts:
+
+1. **v1.6 store-as-truth** — the operational store + restart rehydration only pay
+   off if a *separate* reader (FastAPI) and writer (worker) share Postgres. (b)
+   activates the v1.6 investment; (a) wastes it.
+2. **The async bridge** — keeping the connector's asyncio thread + the engine's
+   sync thread in their own OS process (not co-resident with FastAPI's event loop)
+   is the cleanest isolation of the three concurrency models.
+3. **LX-04 1:1 constraint** — one portfolio : one OKX subaccount makes
+   per-portfolio process isolation natural; designing the worker as
+   per-portfolio from day one means scaling to (c) is "run N workers + extract the
+   feed," not a re-architecture.
+
+For the v1.7 DoD (one portfolio, paper) a single worker IS (c) with N=1 — so (b)
+and the (c) end-state converge on the same build now. The FastAPI app itself is
+out of v1.7 scope (deferred), but the command/status channel + write-through
+contract must be designed in Phase 4–5 wiring.
+
+---
+
+## 6. TradingInterface (LX-14) — DELETE, replace with a thin engine command surface
+
+### What depends on it today
+
+Grep result: **no production consumer.** Only the barrel export
+(`trading_system/__init__.py:6/12`), the class itself, and one *comment* in a test
+(`test_admission_rules.py:267`) + a golden-doc note. `LiveTradingSystem` likewise
+has no production wiring (live composition root deferred per RETAIN-03/D-01). The
+FastAPI app does not exist yet.
+
+### Why delete
+
+`TradingInterface` (`trading_interface.py`) is the *pre-FastAPI* bridge. It is
+also stale: it builds `OrderEvent`s with **float** price/quantity and naive
+`datetime.now()` (`trading_interface.py:79/129`), and **bypasses the order domain's
+sizing/validation** (`SizingResolver`/`EnhancedOrderValidator`) by constructing
+sized orders directly. Under topology (b)/(c), the web layer talks to the worker
+via the Postgres command channel — it never calls `LiveTradingSystem` methods
+in-process — so an in-process bridge is redundant.
+
+**Recommendation:** delete `TradingInterface`; introduce a thin, typed **engine
+command surface** the worker consumes from the command channel (submit-signal /
+cancel / status), routing through the *real* order domain (signal -> sizing ->
+validation -> order), Decimal + UUIDv7 + tz-aware time. This pairs with the
+`user_id` strip (both are "engine vs app layer" cleanups) and **scopes FL-13** —
+test the surface that survives (the command surface + `LiveTradingSystem`
+lifecycle), not the deleted bridge.
+
+---
+
+## 7. Suggested build order (honors §7 locked dependencies)
+
+```
+Phase 1  Account abstraction extraction        [GATES EVERYTHING — oracle-gated]
+  └─ + user_id strip + TradingInterface delete + LiveConnector interface (interface-only)
+         │
+         ├──────────────► Phase 2  OkxConnector (data arm + order arm)
+         │                   └─ data arm ─────► Phase 3  LiveBarFeed (ring buffer)
+         │                                          │
+         ▼                                          ▼
+   (SimulatedAccount ready)                  Phase 4  PaperConnector  ◄── PaperConnector needs
+         └──────────────────────────────────►  = milestone DoD          1 + 3 + connector DATA arm
+                                                  (NOT the order arm)     (paper-parity gate, LX-11)
+                                                       │
+   Phase 2 order arm + Phase 1 VenueAccount + v1.6 store
+                                                       ▼
+                                            Phase 5  Real/sandbox path
+                                              (VenueAccount reconcile + persistence live-drive)
+                                                       
+   Phase 6  Dynamic universe membership  (pairs with Phase 3 — reuses backfill-through-update)
+```
+
+**Hard dependencies (from sketch §7, verified against code):**
+
+1. **Phase 1 first, oracle-gated.** Account extraction is behavior-preserving;
+   the `PortfolioReadModel` seam means it does not ripple into the order domain.
+   Everything else implements against the Phase-1 `LiveConnector`/`Account`
+   interfaces.
+2. **Phase 2 data arm before Phase 3.** `LiveBarFeed` consumes the connector's
+   `watch_ohlcv`/`fetch_ohlcv`. The bar-close confirm flag (LX-08) depends on the
+   Phase-2 native escape hatch.
+3. **Phase 4 (DoD) needs 1 + 3 + connector DATA arm only — NOT the order arm.**
+   `PaperConnector` does its own matching (reused `MatchingEngine`); it never
+   submits to OKX. This is the critical sequencing insight: the paper DoD is
+   reachable without any live order I/O.
+4. **Phase 5 needs Phase 2 order arm + Phase 1 `VenueAccount` impl + the v1.6
+   store.** Reconciliation = per-symbol drift detection under LX-04.
+5. **Phase 6 pairs with Phase 3** (warmup-on-add reuses backfill-through-update).
+6. **Topology (LX-15) decided before Phase 4 wires the runtime** (cross-cutting,
+   not a phase).
+
+---
+
+## New vs Modified (explicit ledger for the roadmap)
+
+| Component | Status | File / location |
+|---|---|---|
+| `Account` ABC + `CashAccount`/`MarginAccount` + `Simulated*`/`Venue*` leaves | **NEW** | new `portfolio_handler/account/` |
+| `Portfolio` — inject `self.account`; `cash` -> `account.balance` | **MODIFIED** | `portfolio.py` |
+| `CashManager` math/state -> `SimulatedCashAccount` | **MOVED** (code-motion, byte-exact) | `cash/cash_manager.py` -> account leaf |
+| `PortfolioHandler` margin/liq math -> `SimulatedMarginAccount` | **MOVED** | `portfolio_handler.py:339–460` |
+| `PortfolioHandler._run_liquidation_pass` queue emission | **KEPT** (asks Account for breaches) | `portfolio_handler.py:557` |
+| `PortfolioReadModel` Protocol | **UNCHANGED** (seam preserved) | `core/portfolio_read_model.py` |
+| `Portfolio.user_id` | **REMOVED** (app-layer) | `portfolio.py:52` |
+| `TradingInterface` | **DELETED** + replaced by engine command surface | `trading_interface.py` |
+| `LiveConnector` Protocol | **NEW** (interface-only in P1) | new |
+| `OkxConnector` (ccxt.pro + native escape hatch) | **NEW** | new `execution_handler/connectors/` (or `price_handler/providers/`) |
+| `LiveBarFeed(BarFeed)` ring buffer | **NEW** | new `price_handler/feed/live_bar_feed.py` |
+| `apply_costs` fee/slippage helper (extract from `_emit_fill`) | **NEW** (refactor) | `execution_handler/` |
+| `SimulatedExchange._emit_fill` -> call shared helper | **MODIFIED** (byte-exact) | `simulated.py:247` |
+| `PaperConnector` (MatchingEngine + costs + SimulatedAccount) | **NEW** | new |
+| `VenueAccount` impl (reconcile) | **NEW** (P5; interface in P1) | account leaf |
+| `LiveTradingSystem` — real feed/connector wiring, TimeEvent-on-bar-close, command channel | **MODIFIED** | `live_trading_system.py` |
+| Worker process + Postgres command/status channel | **NEW** | new |
+
+---
+
+## Anti-Patterns (domain-specific, to flag in the roadmap)
+
+### A1: A second state-building path for warmup
+Bulk `warmup_from(series)` alongside the per-bar `update`. Diverges from the live
+path and re-opens the parity audit. **Instead:** replay backfill one-by-one
+through the identical `update(bar)` (LX-09).
+
+### A2: Mutating engine state from the connector thread
+Any direct call from the asyncio thread into `Portfolio`/`Account`/handlers breaks
+the D-19 single-writer contract and determinism. **Instead:** connector thread
+ONLY `global_queue.put(...)`; all mutation on the engine thread.
+
+### A3: Duplicating fill pricing in PaperConnector
+Re-implementing maker/taker + slippage gating instead of reusing the matching core
++ a shared cost helper. Two pricing paths drift -> paper-parity fails silently.
+**Instead:** one `MatchingEngine`, one `apply_costs` helper, two adapters.
+
+### A4: Wall-clock bar-close inference
+Inferring "bar closed" from local time instead of OKX's confirm flag. Drops/double-
+counts bars on latency. **Instead:** drive closed off the native confirm flag
+(LX-08), via the native escape hatch (ccxt.pro does not surface it reliably).
+
+### A5: Re-homing `user_id` onto Account
+Multi-tenancy belongs to the FastAPI app layer (`user_id -> portfolio_id`).
+Putting it on Account couples the engine to tenancy. **Instead:** strip it; map
+in the app layer.
+
+### A6: Liquidation math left in PortfolioHandler
+Leaving `_isolated_liq_price`/`maintenance_margin` in the handler perpetuates the
+exact smell Phase 1 exists to fix and fights the future `VenueAccount` mirror.
+**Instead:** truth/decision in `SimulatedMarginAccount`, queue emission stays in
+the handler.
+
+---
+
+## Integration Points
+
+### External services
+
+| Service | Integration pattern | Notes / gotchas |
+|---|---|---|
+| OKX (data) | ccxt.pro `watch_ohlcv` + native WS for confirm flag | ccxt.pro does not surface a unified closed/confirm flag — native escape hatch required (LX-05/LX-08) |
+| OKX (orders/account) | ccxt.pro submit/cancel/watch + native, single `sandbox` flag | `set_sandbox_mode` (ccxt) AND `x-simulated-trading` header (native) — route both or split-brain |
+| Postgres (v1.6) | system-of-record + command/status channel (`LISTEN/NOTIFY`) | worker writes; FastAPI reads — the (b) topology enabler |
+
+### Internal boundaries
+
+| Boundary | Communication | Notes |
+|---|---|---|
+| connector thread ↔ engine thread | `global_queue.put` only | D-19 single-writer; determinism boundary bottled here |
+| order domain ↔ portfolio truth | `PortfolioReadModel` Protocol | unchanged in P1 — Account moves behind it |
+| `Portfolio` ↔ `Account` | direct (injected, same-process, 1:1) | mirrors the 4-manager delegation; not queue-mediated |
+| feed ↔ engine | `BarFeed` ABC (`current_bars`/`window`/`megaframe`/`newest_bar`) | LiveBarFeed swaps the backing store only |
+| paper execution ↔ matching | `MatchingEngine.submit`/`on_bar` (pure) | reused by both SimulatedExchange and PaperConnector |
+
+---
+
+## Confidence & gaps
+
+- **HIGH** — Account layering, the `PortfolioReadModel` seam, the async->queue
+  boundary, BarFeed ABC reuse, MatchingEngine reuse, TradingInterface deletion
+  (grep-confirmed no consumers): all read directly from the code.
+- **MEDIUM** — OKX confirm-flag exposure in ccxt.pro (web-sourced; verify the
+  exact native channel + confirm semantics at Phase 2/3 plan time — carried
+  research flag).
+- **Gaps for plan-time research:** (1) live `TimeEvent`-on-bar-close vs moving
+  metric recording to the BAR route; (2) ring-buffer capacity when multiple
+  timeframes/consumers register (extend `cache_registration.derive`); (3)
+  reconciliation repair policy (auto-correct vs halt-and-alert); (4) write-through
+  transaction boundary (v1.6 carried flag); (5) exact native-vs-ccxt OKX gap list.
+
+## Sources
+
+- Existing code (HIGH): `portfolio.py`, `portfolio_handler.py`, `cash/cash_manager.py`,
+  `core/portfolio_read_model.py`, `price_handler/feed/{base,bar_feed}.py`,
+  `execution_handler/{matching_engine.py,exchanges/simulated.py}`,
+  `trading_system/{live_trading_system,trading_interface}.py`.
+- Locked design: `docs/superpowers/specs/2026-06-30-live-trading-milestone-design.md` (LX-01..LX-15).
+- [ccxt #21885 — closed/confirm flag for websocket candles](https://github.com/ccxt/ccxt/issues/21885)
+- [ccxt OKX exchange docs](https://docs.ccxt.com/docs/exchanges/okx)
+- [ccxt.pro manual](https://docs.ccxt.com/docs/pro-manual)
+
+---
+*Architecture research for: v1.7 Live Trading Readiness (paper-first OKX)*
+*Researched: 2026-06-30*

--- a/.planning/research/v1.7-archive/FEATURES.md
+++ b/.planning/research/v1.7-archive/FEATURES.md
@@ -1,0 +1,293 @@
+# Feature Research
+
+> ## ⚠ Superseded framing — read `phases/02-okx-connector/02-CONTEXT.md` first
+>
+> The Phase-2 discussion (2026-07-01) revised the live architecture; this snapshot
+> predates it and still describes the **two-arm `LiveConnector`** model. **Superseded
+> framings** (the feature set itself remains valid):
+> - Connector is a **session/transport primitive**, not a two-arm venue object; the data/order/account arms are **domain adapters** (`OkxDataProvider` / `OkxExchange` / `VenueAccount`), **injected** with the session, never cross-domain-imported.
+> - The **`OkxExchange` adapter emits `FillEvent`** — the connector owns no operations and emits no domain events.
+> - Paper needs **no connector**: the paper execution adapter implements **`AbstractExchange`** (not `LiveConnector`).
+> - `OkxSettings` reads **plain `OKX_API_*` (no env prefix)** — not `ITRADER_OKX_*`.
+>
+> See design-doc LX-05/LX-06 revision notes and `02-CONTEXT.md` D-01..D-10.
+
+**Domain:** Live crypto-trading deployment layer (paper-first, single-venue OKX) over a complete event-driven backtest engine
+**Researched:** 2026-06-30
+**Confidence:** HIGH (locked design + verified venue/lib specifics; LOW flags called out inline)
+
+> Scope guard: this researches the FEATURE-LEVEL behaviors that must work *within* the locked
+> milestone design (`docs/superpowers/specs/2026-06-30-live-trading-milestone-design.md`,
+> LX-01..LX-15). It does NOT re-litigate locked decisions. Where a behavior is fixed by a locked
+> decision it is tagged (e.g. `[LX-13]`) and treated as a constraint, not an open option.
+> "Complexity" is engineering cost *given the existing engine*; "Dependencies" name the existing
+> components a behavior leans on. Phase tags map to the 6 locked phases.
+
+---
+
+## Verified venue/library facts (the load-bearing ones)
+
+These three facts shape almost every table-stakes behavior below:
+
+1. **OKX `candle{tf}` WS channel carries a `confirm` flag** — the candle payload is
+   `[ts, o, h, l, c, vol, volCcy, volCcyQuote, confirm]`; `confirm="1"` = closed/final,
+   `confirm="0"` = still forming. The first message after subscribe may be an incomplete bucket.
+   *(HIGH — OKX v5 docs.)* This is the authoritative bar-close signal (LX-08); wall-clock inference
+   is unnecessary and wrong.
+2. **ccxt.pro `watchOHLCV` returns the still-forming last candle** — it emits the current bucket on
+   every update (and typically the prior formed candle), so a naive "take `[-1]`" leaks an unconfirmed
+   bar into the engine. The LiveBarFeed MUST gate on `confirm` (native field) and only emit on the
+   transition `0→1` (or the arrival of a new bucket that closes the prior one). *(HIGH — ccxt issues +
+   pro manual; this is exactly why LX-12 keeps a native escape hatch for confirm-flag fidelity.)*
+3. **REST `fetch_ohlcv` returns closed bars** and is the correct warmup/backfill/gap-fill source;
+   it is paginated and rate-limited. *(HIGH — ccxt unified method.)*
+
+A fourth, lower-confidence flag carried for plan-time: OKX `orders`/`fills` private channels deliver
+partial fills as incremental `fillSz`/`accFillSz` updates with an order `state`
+(`live`/`partially_filled`/`filled`/`canceled`); fees and funding arrive on their own events. *(MEDIUM
+— consistent across OKX docs + ccxt `watchOrders`/`watchMyTrades`, exact field cadence is the Phase 2/5
+plan-time research item already flagged in the sketch §8.)*
+
+---
+
+## Feature Landscape
+
+The 7 question areas are grouped under each category. Each row notes complexity and the existing
+component it depends on.
+
+### Table Stakes (Required to be Correct/Safe)
+
+| # | Feature | Why Required | Complexity | Phase / Depends on |
+|---|---------|--------------|------------|--------------------|
+| **Live data engine** |
+| 1 | **Bar-close detection via OKX `confirm` flag** — emit a `BarEvent` only on a *completed* bar; never on the forming bucket | Strategies/indicators are built on closed-bar semantics (bar-feed rule 2); a forming bar = look-ahead + indicator corruption. ccxt streams the forming candle, so this gate is mandatory, not optional | MEDIUM | P3. `BarFeed` ABC; 7-rule contract in `bar_feed.py`; OKX connector data arm (P2) |
+| 2 | **Warmup/backfill at live-start through the *identical* `update(bar)` path** [LX-09] | Stateful O(1) indicators (SMA/EMA/MACD/RSI) need K prior bars to be "ready"; a second bulk-warm path diverges and re-opens the parity audit. REST `fetch_ohlcv` last-K, replayed one-by-one | MEDIUM | P3. Stateful indicators (v1.5); `cache_capacity()` derivation; REST data arm |
+| 3 | **Monotonic-forward-only delivery** [LX-10] — gap→backfill-and-replay; duplicate→drop; out-of-order/stale→reject; reconnect→gap-fill interim | Stateful indicators have **no rewind**; feeding state backward silently corrupts every downstream decision. This is the single hardest correctness property of the live feed | HIGH | P3. Ring-buffer feed; stateful indicators; connector reconnect (P2) |
+| 4 | **Ring-buffer `BarFeed` impl serving `window()`/`newest_bar()`/`current_bars()`** [LX-07] | The engine above the feed speaks one contract; only the backing store changes (precompute→stream). Bounded deque per `(symbol, tf)` sized by the same wiring-time capacity as backtest | MEDIUM | P3. `BarFeed` ABC (the seam already exists) |
+| 5 | **Event-driven time source replacing `TimeGenerator`** — closed-bar arrival drives the cycle | Backtest iterates a pinned grid; live has no grid — the closed bar *is* the clock tick | MEDIUM | P3. `EventHandler` TIME/BAR routes; `generate_bar_event` factory |
+| **Live execution loop** |
+| 6 | **Order submit→ack→fill-stream lifecycle** (market/limit/stop on OKX) | A live venue is async and authoritative: you submit, get an order-id ack, then fills arrive asynchronously on a stream — unlike backtest where `on_bar` returns fills synchronously | HIGH | P2/P5. `LiveConnector` interface; order mirror (v1.6); async/sync bridge |
+| 7 | **Partial-fill handling** — accumulate `accFillSz`, weighted-avg fill price, terminalize only at full fill/cancel | Real venues fill in pieces; the engine's `MatchingEngine` is full-quantity-only (D-06). The *live* path must reconcile partials the matching engine never produces | HIGH | P5. Order mirror reconcile (`on_fill`); `VenueAccount` |
+| 8 | **Order-status reconciliation from venue truth** — map OKX `state` → mirror status (`live`→PENDING, `partially_filled`/`filled`→FILLED, `canceled`→CANCELLED, rejected→REJECTED) | The venue, not the engine, is the source of truth live. Mirror must follow venue state transitions, same shape as today's `OrderHandler.on_fill` reconcile | MEDIUM | P5. Order mirror; `VALID_ORDER_TRANSITIONS`; SQL order store (v1.6) |
+| 9 | **Idempotent client order IDs** (`clOrdId`) on every submit | Resend after a timeout/reconnect must not double-submit; the venue dedupes on client id. The engine already has a single UUIDv7 scheme to source these | LOW | P2. `idgen` (UUIDv7); `LiveConnector` |
+| **Paper trading** |
+| 10 | **Local paper reuses the pure `MatchingEngine` + fee/slippage, bar-based fills only** [LX-06/LX-13] | This is the milestone DoD's correctness anchor: same matching core → deterministic → paper-parity holds. A `PaperConnector` composes the I/O-free engine (`submit`/`on_bar→decisions`) | MEDIUM | P4. `MatchingEngine`; fee/slippage models; `SimulatedAccount` (P1) |
+| 11 | **Paper-parity gate vs the backtest oracle on a fixed dataset** [LX-11] | Live has no golden-master; paper-parity-vs-backtest is the closest equivalent. Replaying a fixed dataset through the live path offline must reproduce `134 / 46189.87730727451` | HIGH | P4. Oracle harness; `SimulatedAccount`; `LiveBarFeed` |
+| 12 | **`SimulatedAccount` computes balance/margin locally (paper + backtest)** [LX-03] | Paper shares the *backtest's* computation column — that shared math is exactly what preserves parity. Same spot/margin code, verbatim | MEDIUM | P1. `Portfolio`/`cash` managers; margin model (v1.4) |
+| **Account abstraction** |
+| 13 | **`Account` ABC owning balance/margin truth; `Simulated*` vs `Venue*` leaves; cash-vs-margin axis** [LX-03] | Margin/liq logic currently mis-housed in `PortfolioHandler` is an *account* concept; extracting it cleanly is the oracle-gated Phase 1 refactor that everything live depends on | HIGH | P1. `Portfolio`, `PortfolioHandler` (margin/liq methods); v1.4 margin model. **Must stay byte-exact** |
+| 14 | **`VenueAccount` caches venue balance/margin/position streams** [LX-03] | Live cannot compute truth locally (fees, funding, venue rounding diverge); it caches what the venue reports and reconciles | MEDIUM | P5. `LiveConnector` balances/positions stream; `Account` ABC (P1) |
+| 15 | **1 account : 1 portfolio** [LX-04] — one OKX subaccount per strategy-portfolio | Dissolves venue-aggregate→per-portfolio *attribution* at the source; reconciliation collapses to per-symbol drift. Assumes exclusive control of the (sub)account | LOW (constraint, not code) | P1/P5. `Portfolio`; `Account` |
+| **Venue reconciliation** |
+| 16 | **Per-symbol drift detection** (partial fills, fees, funding, liquidations) under 1:1 | Without it, cached `VenueAccount` silently diverges from reality and the engine trades on a phantom balance — the core live-safety property | HIGH | P5. `VenueAccount`; SQL portfolio-state store (v1.6); connector streams |
+| 17 | **Repair policy: halt-and-alert on unexplained drift** (auto-correct only within a defined tolerance) | Trading through an unreconciled discrepancy is how live systems blow up. Default-safe = stop and surface; auto-correct is the *narrow* exception, not the rule | MEDIUM | P5. `LiveTradingSystem` publish-and-continue error seam; `ErrorEvent` |
+| **Persistence live-drive** |
+| 18 | **Drive the v1.6 operational store with the real feed** (orders / portfolio-state / signals write-through) | The store was built + testcontainer-verified but never driven by a live feed; live is where write-through/purge-on-terminalize actually run | MEDIUM | P5. SqlOrderStorage, SqlPortfolioStateStorage, SqlSignalStorage (v1.6) |
+| 19 | **Restart rehydration against a live venue** — reconstruct working set from store *and* reconcile vs venue | v1.6 rehydration was store-only; the broker side needs the live adapter so a restart doesn't resurrect a stale position the venue already closed | HIGH | P5. v1.6 open-only restart rehydration; `VenueAccount`; reconciliation (#16) |
+| **Resilience / operational** |
+| 20 | **WebSocket reconnect with gap recovery** — connector owns transport reconnect; feed owns bar-gap fill | Streams drop; a silent reconnect that skips bars corrupts indicators. Reconnect must trigger the gap-fill path (#3) | HIGH | P2 (transport) + P3 (gap-fill). Connector; ring-buffer feed |
+| 21 | **Rate-limit handling** shared across ccxt + native paths | OKX throttles REST + WS subscribe; uncoordinated calls across the two paths get the connection banned | MEDIUM | P2. `OkxConnector` (ccxt.pro + native escape hatch) |
+| 22 | **Secrets management** — real OKX key/secret out of code; sandbox vs live key separation tied to the single `sandbox` flag | Live adds real credentials; leaking them = direct financial loss | LOW | P2/cross-cutting. `pydantic-settings` `Settings` (`ITRADER_` prefix), `SecretStr` |
+| 23 | **Single `sandbox: bool` routing both ccxt (`set_sandbox_mode`) and native (`x-simulated-trading` header)** [LX-05] | A split-brain live/demo state (one path live, one demo) is a catastrophic foot-gun; one flag, both paths | LOW | P2. `OkxConnector`; `Settings` |
+| 24 | **FL-13: test coverage on the live surface** (`LiveTradingSystem`/`TradingInterface`) | The live composition root is currently uncovered; build coverage as each phase lands, not after | MEDIUM | All live phases. `LiveTradingSystem`; LX-14 `TradingInterface` decision |
+| **Dynamic universe** |
+| 25 | **Warmup-on-add** — a newly added symbol replays history through the same `update(bar)` path | Adding a symbol mid-run with cold indicators = garbage signals; reuses Phase 3's backfill machinery | MEDIUM | P6. Phase 3 backfill-through-update; `universe/membership.py` (D-20) |
+| 26 | **Open-position-handling-on-remove** | Dropping a symbol that holds an open position silently orphans risk; must have a defined policy (force-close vs orphan-and-track) | MEDIUM | P6. `Portfolio` position manager; order submit path |
+
+### Differentiators (Beyond Correct-and-Safe)
+
+| Feature | Value Proposition | Complexity | Phase / Depends on |
+|---------|-------------------|------------|--------------------|
+| **Connector abstraction is ours, not ccxt's** [LX-05] — `LiveConnector` shaped on OKX reality, ccxt.pro default + native escape hatch hidden behind it | Keeps OKX fidelity (confirm flag, order-status nuance) *and* a cheap 2nd-venue path; most frameworks either marry ccxt or hand-roll one venue. This is the structural bet | HIGH | P2. New interface; reuse `ccxt_provider.py`/`binance_stream.py` plumbing |
+| **Trade-aggregation-capable bar source seam** [LX-12] — klines now, trades behind the same bar-close interface later | Future optionality (slippage research, tick-backtester) without paying for it now; justified by optionality, NOT by paper fills | LOW (seam only) | P3. Ingestion seam in `LiveBarFeed` |
+| **Separate-worker / process-per-portfolio runtime** [LX-15] — engine as its own service, FastAPI controls lifecycle via the Postgres system-of-record | Crash isolation, independent scaling, thin web layer. This is *precisely* what v1.6's durable store + restart rehydration were built to enable | HIGH | Cross-cutting (decide before P4 wiring). v1.6 store-as-truth; restart rehydration |
+| **Deterministic offline parity harness** — replay a recorded/fixed dataset through the live thread | Turns "did live break?" from a guess into a regression test; reuses the byte-exact oracle | MEDIUM | P4. Oracle; determinism seams (seeded RNG, injected clock) |
+| **OKX sandbox-validated real order arm** | A real I/O path proven against demo before any capital — de-risks the eventual real-money stretch | MEDIUM | P5. `OkxConnector` order arm; `x-simulated-trading` |
+
+### Anti-Features (Out of Scope — Do NOT Build)
+
+| Feature | Why It Seems Appealing | Why Problematic Here | Instead (locked) |
+|---------|------------------------|----------------------|------------------|
+| **Tick-level local-paper fills** | "More realistic" sub-bar fills | Breaks determinism + the paper-parity gate (the whole DoD); explodes complexity; sub-bar realism is what OKX *sandbox* is for | Bar-based local paper via reused `MatchingEngine` [LX-13]; sub-bar realism lives in OKX sandbox |
+| **Full production screener** | Mature frameworks have rich universe selection | Massive scope; not needed to deploy one strategy live | Lean poll seam only — `UniverseSelectionModel` growing `membership.py` [sketch §1, P6] |
+| **Multi-venue / multi-asset** | "Trade everywhere" | Each venue is months of fidelity work; dilutes the OKX correctness focus | Crypto-first, OKX-only; `LiveConnector` *shaped* for a 2nd venue but only OKX implemented [LX-05] |
+| **Perp realism "Phase B" (funding accrual, mark-price liq trigger, funding pipeline, freqtrade 4th oracle)** | Perps are the dominant crypto product | Additive on the v1.4 Phase-A core; its own future milestone; would derail the paper-parity gate | Deferred (FUND-01..04) [sketch §1] |
+| **Cross-margin pooling** | Capital efficiency across positions | A backtest-accounting driver, distinct from live reconciliation; conflicts with 1:1 | Deferred beyond N+2 Phase B; isolated-margin under 1:1 [sketch §1, LX-04] |
+| **Bulk `warmup_from(series)` fast-path** | Faster live-start than one-by-one replay | A second state-building path diverges from the live `update(bar)` path and re-opens the parity audit | Replay K bars one-by-one through the identical `update(bar)` path [LX-09] |
+| **Wall-clock bar-close inference** | Works when a venue has no confirm flag | OKX *has* a confirm flag; wall-clock guessing mis-fires on venue latency/clock skew and emits a forming bar | Drive "closed" off OKX `confirm`, never wall-clock [LX-08] |
+| **In-process engine inside the FastAPI process** | Simplest to wire | Couples engine + web lifecycles, mixes 3 event loops in one process, one crash kills both | Separate worker / process-per-portfolio via Postgres SoR [LX-15 b/c] |
+| **Async engine core** | The venue is async | Would rewrite the whole synchronous event engine; the async boundary belongs only at the connector edge | Async bottled in the connector thread; engine stays synchronous [sketch P2] |
+| **Auto-correct-everything reconciliation** | "Self-healing" | Trading through unexplained drift hides real bugs/loss | Halt-and-alert default; auto-correct only within a defined tolerance (#17) |
+
+---
+
+## Feature Dependencies
+
+```
+Phase 1: Account abstraction (Account ABC, Simulated* leaves, Venue* interface-only)
+    ├──gates──> SimulatedAccount math (#12)        ──required-by──> Paper parity (#11)
+    └──gates──> VenueAccount interface (#14)        ──required-by──> Reconciliation (#16)
+
+Phase 2: OKX connector (LiveConnector + OkxConnector, data arm + order arm)
+    ├── data arm ──required-by──> LiveBarFeed (#1,#4) [Phase 3]
+    └── order arm ──required-by──> Live real path (#6,#7,#8) [Phase 5]
+
+Phase 3: LiveBarFeed
+    ├── bar-close detection (#1) ──requires──> connector data arm + OKX confirm flag
+    ├── warmup-through-update (#2) ──requires──> stateful indicators (v1.5)
+    ├── monotonic-forward-only (#3) ──requires──> ring buffer (#4) + reconnect (#20)
+    └── backfill machinery ──reused-by──> warmup-on-add (#25) [Phase 6]
+
+Phase 4: Paper path (DoD)
+    └──requires──> Phase 1 (SimulatedAccount) + Phase 3 (LiveBarFeed) + connector DATA arm
+        (NOT the order arm) ──validated-by──> paper-parity gate (#11)
+
+Phase 5: Live real path
+    └──requires──> Phase 2 order arm + Phase 1 VenueAccount + v1.6 SQL store
+        ├── reconciliation (#16) ──required-by──> restart rehydration vs venue (#19)
+        └── partial fills (#7) ──feeds──> order-status reconcile (#8) ──writes──> SQL order store
+
+Phase 6: Dynamic universe
+    └──pairs-with──> Phase 3 (reuses backfill-through-update for warmup-on-add #25)
+
+Cross-cutting (Phases 2–5): runtime topology [LX-15] ──decide-before──> Phase 4 wiring
+                            reconnect/rate-limit/secrets/FL-13 ──woven-through──> each phase
+```
+
+### Dependency Notes
+
+- **Paper parity (#11) requires SimulatedAccount (#12) sharing the backtest computation column.**
+  Paper sits in the middle column of the parity spine but borrows the *left* (backtest) column's math —
+  that shared computation is the only thing that makes parity hold. If paper computed anything its own
+  way, the gate is meaningless.
+- **LiveBarFeed monotonic-forward-only (#3) requires reconnect (#20) to route into gap-fill, not
+  re-subscribe-fresh.** A reconnect that just resubscribes silently skips the interim bars; it must
+  detect the gap and REST-backfill-and-replay through `update(bar)`.
+- **Restart rehydration vs venue (#19) requires reconciliation (#16).** Rehydrating the working set
+  from the store alone (v1.6 behavior) can resurrect a position the venue closed while the worker was
+  down; the broker-side reconcile is the new live half.
+- **Phase 1 is the universal gate** — it is behavior-preserving and oracle-gated; *no live code may
+  depend on the Account abstraction until backtest is re-confirmed byte-exact* (`134 / 46189.87730727451`).
+- **Warmup-on-add (#25) reuses Phase 3 backfill (#2)** — same `update(bar)` replay path, so Phase 6 is
+  cheap *only if* Phase 3 built the seam generically (per-symbol, not start-only).
+
+---
+
+## Paper-Parity Requirements (concrete + testable — the DoD anchor)
+
+For the paper-parity gate [LX-11] to be meaningful and pass, ALL must hold:
+
+1. **Same matching core.** Local paper composes the *same* `MatchingEngine` instance class the backtest
+   uses (full-quantity fills, next-bar-open, OCO, STOP-beats-LIMIT, trailing ratchet) — no
+   paper-specific fill logic. [LX-06]
+2. **Same account math.** `SimulatedAccount` runs the verbatim spot/margin/carry/liquidation code
+   extracted in Phase 1 — Decimal end-to-end, same quantization boundaries. [LX-03]
+3. **Same closed bars, same order.** The fixed dataset replayed through `LiveBarFeed` must deliver the
+   identical sequence of closed `Bar`s (same timestamps, same Decimal OHLCV) the `BacktestBarFeed`
+   produces — proving bar-close detection + warmup-through-update introduce no drift.
+4. **Same determinism seams.** The seeded `random.Random` (`performance.rng_seed=42`) and injected
+   clock must thread into the paper path; fills must not consume wall-clock time or unsourced RNG.
+5. **Byte-exact equality, not tolerance.** The parity assertion reuses the oracle's exact-diff
+   discipline: `134` trades and `final_equity == 46189.87730727451` — `check_exact=True`, no float
+   tolerance.
+6. **Inertness on the backtest hot path.** The live machinery must be provably inert when not running
+   live — no W1/W2 regression vs the v1.5 baseline (15.7 s / 152.8 MB), same as the v1.6 import-quarantine
+   discipline.
+
+**Testable harness shape (open item, sketch §4):** prefer *replay a fixed dataset through the live path
+offline* (deterministic, CI-runnable) over *record-a-live-session-then-replay* (non-deterministic,
+network-bound). The offline replay feeds a recorded/fixed bar stream into `LiveBarFeed` and asserts the
+oracle numbers — this is also the differentiator "deterministic offline parity harness."
+
+---
+
+## MVP Definition (maps to the locked phases)
+
+### Launch With (the milestone DoD)
+
+- [ ] **Phase 1 — Account abstraction** (#13, #12, #14-interface, #15) — gates everything; backtest stays byte-exact
+- [ ] **Phase 2 — OKX connector data + order arm** (#6, #9, #21, #23) — feeds Phases 3/5
+- [ ] **Phase 3 — LiveBarFeed** (#1, #2, #3, #4, #5, #20) — the real-time data engine
+- [ ] **Phase 4 — Paper path + parity gate** (#10, #11, #12) — *this is the DoD* (LX-01)
+- [ ] **Phase 5 — Real/sandbox path** (#7, #8, #14, #16, #17, #18, #19) — sandbox-validated
+- [ ] **Phase 6 — Dynamic universe** (#25, #26) — lean poll seam
+- [ ] **Cross-cutting** — secrets (#22), FL-13 (#24), runtime topology decision (LX-15)
+
+### Add After Validation (gated stretch / next milestones)
+
+- [ ] **Real-capital execution** — gated stretch beyond sandbox validation [LX-01]; trigger = sandbox path proven + owner sign-off
+- [ ] **Async/buffered write-through** — keep-only-measured; build only if the live loop profiles a stall [sketch P5]
+- [ ] **Trade-aggregation bar source** — slot behind the LX-12 seam; trigger = slippage-research or tick-backtester need
+
+### Future Consideration (explicitly deferred)
+
+- [ ] **Perp realism Phase B** (FUND-01..04) — own milestone
+- [ ] **Full production screener** — beyond the lean poll seam
+- [ ] **Multi-venue / multi-asset** — 2nd connector against the shaped interface
+- [ ] **Cross-margin pooling** — backtest-accounting driver, distinct concern
+
+---
+
+## Feature Prioritization Matrix
+
+| Feature | Safety/Value | Implementation Cost | Priority |
+|---------|--------------|---------------------|----------|
+| Account abstraction (oracle-gated) (#13) | HIGH (gates all) | HIGH | P1 |
+| Bar-close via confirm flag (#1) | HIGH | MEDIUM | P1 |
+| Monotonic-forward-only delivery (#3) | HIGH | HIGH | P1 |
+| Warmup-through-update (#2) | HIGH | MEDIUM | P1 |
+| Paper-parity gate (#11) | HIGH (the DoD) | HIGH | P1 |
+| Local paper via reused MatchingEngine (#10) | HIGH | MEDIUM | P1 |
+| Submit→ack→fill lifecycle (#6) | HIGH | HIGH | P1 |
+| Partial-fill handling (#7) | HIGH | HIGH | P1 |
+| Per-symbol drift reconciliation (#16) | HIGH | HIGH | P1 |
+| Halt-and-alert repair policy (#17) | HIGH | MEDIUM | P1 |
+| WS reconnect + gap recovery (#20) | HIGH | HIGH | P1 |
+| Restart rehydration vs venue (#19) | HIGH | HIGH | P1 |
+| Secrets + single sandbox flag (#22, #23) | HIGH | LOW | P1 |
+| Idempotent client order IDs (#9) | MEDIUM | LOW | P1 |
+| Rate-limit handling (#21) | MEDIUM | MEDIUM | P2 |
+| Persistence live-drive (#18) | MEDIUM | MEDIUM | P2 |
+| Dynamic universe add/remove (#25, #26) | MEDIUM | MEDIUM | P2 |
+| Separate-worker runtime (LX-15) | MEDIUM | HIGH | P2 |
+| Trade-aggregation seam (LX-12) | LOW | LOW | P3 |
+
+**Priority key:** P1 = required for the DoD; P2 = should-have in-milestone; P3 = seam-only/future.
+
+---
+
+## Competitor Feature Analysis (how mature frameworks handle these)
+
+| Feature | Nautilus Trader | freqtrade | Hummingbot | QuantConnect LEAN | iTrader approach |
+|---------|-----------------|-----------|------------|-------------------|------------------|
+| Bar-close detection | Bar aggregator emits on close; venue confirm where available | Polls closed candles; treats last as incomplete | Real-time order-book/trade driven; candles secondary | Consolidators emit on bar close; data feed-driven | OKX `confirm` flag, never wall-clock [LX-08] |
+| Warmup/backfill | History request → same handler path; "warmup range" | `startup_candle_count` REST prefetch | N/A (order-book first) | Warm-up period replays through algorithm | One-by-one replay through identical `update(bar)` [LX-09] |
+| Gap/reconnect | Reconnect + subscription resync; data-quality checks | Re-fetch on each loop (poll model masks gaps) | Auto-reconnect; order-book resync | Brokerage reconnect + data resync | Gap→REST-backfill-replay; forward-only [LX-10] |
+| Account truth | `Account` per venue; cached from venue, reconciled | Wallet object synced from exchange | Per-connector budget checker | `SecurityHolding`/cash synced from brokerage | `Simulated*` computes / `Venue*` caches [LX-03] |
+| Paper trading | `BacktestEngine` reuse + sandbox adapters | dry-run mode (simulated wallet, live data) | paper_trade mode (simulated balances) | Paper brokerage on live data | Reused pure `MatchingEngine`, bar-based [LX-06/13] |
+| Reconciliation | Built-in venue reconciliation on start/stream | Re-sync open trades vs exchange | Status polling per order | Brokerage reconcile of holdings/orders | Per-symbol drift under 1:1, halt-and-alert [LX-04] |
+| Connector model | Native per-venue adapters | ccxt-based | Native per-connector | Native brokerage plugins | Ours over ccxt.pro + native escape hatch [LX-05] |
+| Universe | Full instrument provider / discovery | pairlists (rich) | Fixed config markets | Universe selection framework | Lean poll seam only (anti: full screener) |
+| Runtime | Standalone node/process | Single process + (optional) API | Standalone | Cloud/standalone engine | Separate worker via Postgres SoR [LX-15] |
+
+**Takeaway:** every behavior in the table-stakes list is something *all four* mature frameworks
+implement — confirming they are genuine table-stakes, not gold-plating. iTrader's distinctive choices
+(reused pure matching engine for paper, ours-over-ccxt connector, Postgres-as-system-of-record runtime)
+are deliberate differentiators that fall out of the existing engine's structure (the parity spine, v1.6
+durable store). The deferred items (full screener, multi-venue, perps) are exactly where the mature
+frameworks have spent years — correctly out of scope for "minimum surface to deploy live."
+
+---
+
+## Sources
+
+- OKX v5 WebSocket candle channel `confirm` flag — [OKX API guide](https://www.okx.com/docs-v5/en/) (HIGH)
+- ccxt.pro `watchOHLCV` returns forming last candle — [CCXT Pro Manual](https://docs.ccxt.com/docs/pro-manual), [ccxt #24107](https://github.com/ccxt/ccxt/issues/24107) (HIGH)
+- Locked milestone design — `docs/superpowers/specs/2026-06-30-live-trading-milestone-design.md` (LX-01..LX-15) (HIGH)
+- Existing engine seams — `itrader/price_handler/feed/bar_feed.py` (7-rule contract), `itrader/execution_handler/matching_engine.py` (pure I/O-free engine), `CLAUDE.md` architecture (HIGH)
+- Project state — `.planning/PROJECT.md` (v1.7 section, validated requirements) (HIGH)
+- Framework patterns (Nautilus/freqtrade/Hummingbot/LEAN) — training-data + design-sketch references; the per-cell behaviors are MEDIUM (well-established, not freshly re-verified per framework this session)
+
+---
+*Feature research for: live crypto-trading deployment layer (paper-first OKX) over an event-driven backtest engine*
+*Researched: 2026-06-30*

--- a/.planning/research/v1.7-archive/PITFALLS.md
+++ b/.planning/research/v1.7-archive/PITFALLS.md
@@ -1,0 +1,684 @@
+# Pitfalls Research
+
+> ## ⚠ Superseded framing — read `phases/02-okx-connector/02-CONTEXT.md` first
+>
+> The Phase-2 discussion (2026-07-01) revised the live architecture; this snapshot
+> predates it and still describes the **two-arm `LiveConnector`** model. The pitfalls
+> themselves remain valid — only the connector-shape wording is stale. **Superseded framings:**
+> - Connector is a **session/transport primitive**, not a two-arm venue object; the data/order/account arms are **domain adapters** (`OkxDataProvider` / `OkxExchange` / `VenueAccount`), **injected** with the session.
+> - The **`OkxExchange` adapter emits `FillEvent`** — the connector emits no domain events.
+> - Paper needs **no connector**: the paper execution adapter implements **`AbstractExchange`** (not `LiveConnector`).
+> - `OkxSettings` reads **plain `OKX_API_*` (no env prefix)** — not `ITRADER_OKX_*`.
+>
+> See design-doc LX-05/LX-06 revision notes and `02-CONTEXT.md` D-01..D-10.
+
+**Domain:** Adding live crypto (OKX) trading to an event-driven, Decimal-exact, deterministic backtest engine — paper-first, oracle-gated (iTrader v1.7)
+**Researched:** 2026-06-30
+**Confidence:** HIGH on engine-internal pitfalls (read from source + locked sketch); MEDIUM-HIGH on OKX/ccxt integration facts (verified against ccxt issues + OKX v5 docs; firm up at plan-time)
+
+> Scope note: these are pitfalls specific to grafting a live OKX arm onto **this** engine — the
+> byte-exact SMA_MACD oracle (`134 / 46189.87730727451`), Decimal-end-to-end money, single-writer
+> `global_queue`, stateful no-rewind indicators, `filterwarnings=["error"]`, and the paper-parity
+> gate (LX-11). Generic "trading is hard" advice is omitted. Each pitfall names the v1.7 phase
+> (1-6) that should own its prevention.
+
+---
+
+## Critical Pitfalls
+
+### Pitfall 1: Acting on a forming (unconfirmed) bar — wall-clock close inference
+
+**What goes wrong:**
+The live feed emits a `BarEvent` for a candle that has not actually closed, so strategies compute
+indicators on a partial bar and fire signals the backtest would never produce. Paper-parity fails
+immediately and silently (the live run trades on data the oracle never saw).
+
+**Why it happens:**
+Two compounding traps. (a) ccxt's unified `watchOHLCV` does **not** expose a `closed`/`confirm`
+boolean — it streams the in-progress candle and you can only distinguish finalized bars by watching
+the timestamp roll over (ccxt issue #21885). (b) The naive fix — "the bar is closed when
+wall-clock ≥ open + timeframe" — is wrong under clock skew, late venue ticks, and the engine's own
+bar-stamping contract (rule 2: the tick at `T` means "the bar stamped `T` just closed", whose
+wall-clock semantics are `T + tf_base`). Inferring close from local time re-introduces exactly the
+look-ahead the 7-rule contract (`bar_feed.py`) was built to forbid.
+
+**How to avoid:**
+Drive "closed" off OKX's native `confirm` field (the last element of the WS candle array:
+`0`=forming, `1`=closed), never wall-clock (LX-08). Because ccxt drops this field, the OKX
+`confirm` read is precisely the "proven gap" that justifies the **native escape hatch** (LX-05) —
+the `OkxConnector` must reach the native OKX candle channel (or its own ccxt subclass) to recover
+`confirm`, and `LiveBarFeed` must emit `BarEvent` **only** on `confirm == 1`. Encode the bar-timing
+contract's rule 2 into the feed: the emitted `BarEvent.time` must be the bar's **open** stamp `T`,
+identical to backtest, so downstream `window()` cutoff math is unchanged.
+
+**Warning signs:**
+More signals live than in the oracle backtest on the same dates; a `BarEvent` whose timestamp equals
+the current wall-clock minute/day; indicator values that change between two events carrying the same
+bar timestamp (the tell-tale of a forming bar being re-delivered).
+
+**Phase to address:** Phase 3 (LiveBarFeed, LX-08); the native-`confirm` plumbing is Phase 2 (connector).
+
+---
+
+### Pitfall 2: Off-by-one between backtest next-bar-open fills and live closed-bar arrival
+
+**What goes wrong:**
+The backtest decides at tick `T` and fills the market order at the **open of `T + tf_base`** through
+the resting book (bar-timing rule 5, `FillEvent.time = T + tf_base`). A live/paper path that fills
+"now" on the same bar `T` (or fills on the close of `T`) shifts every fill by one bar. Equity curves
+diverge cumulatively; paper-parity never holds even with identical signals.
+
+**Why it happens:**
+In live, the decision and the next bar's arrival are separated by real time, so it feels natural to
+fill against the bar you just received. The backtest's "rest now, fill at next open" semantics are an
+engine invariant, not an obvious default — easy to lose when re-implementing fills in `PaperConnector`.
+
+**How to avoid:**
+`PaperConnector` must reuse the **pure `MatchingEngine`** (LX-06), not re-implement matching: the
+matching core already rests the market order and fills it on the *next* `on_bar` at that bar's open,
+preserving rule 5 by construction. Local paper stays strictly **bar-based** (LX-13) — no sub-bar /
+tick fills. The parity harness must replay the *same* dataset bar-stream so the "next bar" the paper
+path fills against is byte-identical to the oracle's.
+
+**Warning signs:**
+Paper trade count matches the oracle but fill prices are shifted to the previous/next bar's open;
+first divergence appears at the first trade and compounds; `FillEvent.time` in paper equals the
+deciding `BarEvent.time` instead of the following bar's.
+
+**Phase to address:** Phase 4 (paper path / `PaperConnector` reuse of `MatchingEngine`, LX-06/LX-13).
+
+---
+
+### Pitfall 3: Live wall-clock leaking into business `time`
+
+**What goes wrong:**
+A live component stamps an event, order, transaction, or metrics row with `datetime.now(UTC)`
+instead of the bar's business `time`. This corrupts determinism, breaks the paper-parity replay
+(records carry replay-time wall-clocks, not dataset times), and pollutes the persisted system of
+record with non-reproducible timestamps.
+
+**Why it happens:**
+The existing `LiveTradingSystem` already does this in several non-event-critical spots
+(`_stats['last_event_time'] = datetime.now(UTC)`, idle detection, `ErrorEvent` fallback
+`getattr(event, 'time', datetime.now(UTC))`), and the pattern is contagious. In live, "what time is
+it?" genuinely has two answers (the bar's business time vs. the wall clock for transport/heartbeat),
+and the wrong one is the convenient one.
+
+**How to avoid:**
+Hold the line from CLAUDE.md: business `time` is **always** the bar's stamp, never wall clock.
+Wall-clock is permitted **only** for transport/observability concerns that never enter accounting or
+event causality (heartbeat, reconnect backoff, idle-warning, log lines) — and those must never be
+written into a `FillEvent`/`OrderEvent`/transaction/metrics row. Introduce a live "session clock"
+seam that mirrors the injected `BacktestClock` (core/clock.py): the connector translates each
+confirmed bar into a `TimeEvent`/`BarEvent` whose `time` is the venue bar-open stamp, and that stamp
+is the only time the engine sees. Audit every `datetime.now` on the live path for "is this allowed to
+touch money/events?".
+
+**Warning signs:**
+Determinism double-run is no longer byte-identical on the paper path; persisted order/fill rows carry
+timestamps near real time rather than dataset dates; the parity harness output differs run-to-run.
+
+**Phase to address:** Phase 4 (determinism seam in the live runtime; the "how the live thread/clock
+interacts with determinism seams" open item is named in the sketch §4 Phase 4).
+
+---
+
+### Pitfall 4: Stateful-indicator divergence from a backfill fast-path (LX-09 violation)
+
+**What goes wrong:**
+Warmup/backfill builds indicator state via a bulk `warmup_from(series)` shortcut while live streaming
+uses per-bar `update(bar)`. The two code paths compute the same EMA/MACD/RSI recurrences slightly
+differently (seeding, first-value handling, order of operations), so the live indicator state diverges
+from what the oracle's per-bar path produced. Signals diverge; paper-parity fails in a way that is
+maddening to debug because both paths "look correct" in isolation.
+
+**Why it happens:**
+Bulk warmup is faster and feels harmless ("it's just the same data"). But the v1.5 stateful
+indicators (hand-written O(1) recurrences) have **no rewind** and are sensitive to seeding — a second
+state-building path is a second source of truth that re-opens the parity audit.
+
+**How to avoid:**
+LX-09 is absolute: warmup/backfill replays the last K bars **one-by-one through the identical
+`update(bar)` path** live streaming uses. **No bulk fast-path exists.** Both warmups (cache hydration
+and indicator readiness, §10.D-2 of the stateful-indicator spec) go through the same entry. Make this
+structurally impossible to violate: do not add a `warmup_from`/`seed`/`prime` method to the indicator
+or feed API at all. Add a test that asserts replaying K bars through `update()` yields byte-identical
+indicator state to the backtest feed at the same asof.
+
+**Warning signs:**
+Any method named `warmup_from`, `bulk_update`, `seed`, `prime`, `from_series` appears on an indicator
+or feed; paper-parity passes only after the warmup window and diverges in the first post-warmup bars;
+indicator state after backfill differs from `BacktestBarFeed` at the same timestamp.
+
+**Phase to address:** Phase 3 (LiveBarFeed backfill-through-update, LX-09); reused in Phase 6
+(warmup-on-add).
+
+---
+
+### Pitfall 5: Feeding indicator state backward on a gap / duplicate / out-of-order bar
+
+**What goes wrong:**
+The feed delivers a bar with a timestamp ≤ the last delivered bar (duplicate, stale re-send,
+out-of-order WS frame, or a venue correction). The stateful indicators have no rewind, so feeding an
+older bar corrupts state irreversibly — every subsequent signal is wrong, and there is no clean
+recovery short of re-warming.
+
+**Why it happens:**
+Crypto WS streams routinely re-send, reorder, or correct candles, especially around reconnects. The
+backtest never sees this (its `TimeGenerator` is a pinned monotonic grid), so the engine has no
+existing guard — the guard must be invented in `LiveBarFeed`.
+
+**How to avoid:**
+Enforce monotonic-forward-only delivery (LX-10): **duplicate → drop; out-of-order/stale → reject
+(never feed state backward); gap → REST-backfill the missing bars and replay through the same
+`update(bar)` path; reconnect → gap-fill the interim**. For after-the-fact corrections, do **not**
+patch in place — either re-warm from the ring buffer or forward-only-and-log (decide at plan time;
+the sketch leaves this open). The ring-buffer `LiveBarFeed` is the natural enforcement point (mirror
+the backtest cursor's "non-monotonic cutoff → safe rebuild" discipline in `window()`).
+
+**Warning signs:**
+Indicator values jump non-physically after a reconnect; a `BarEvent` timestamp ≤ `newest_bar`'s;
+duplicate timestamps reaching strategies; parity holds on a clean session but breaks on any session
+with a disconnect.
+
+**Phase to address:** Phase 3 (LiveBarFeed monotonic-forward delivery + reconnect gap-fill, LX-10).
+
+---
+
+### Pitfall 6: ccxt float money leaking into the Decimal accounting core
+
+**What goes wrong:**
+ccxt returns **floats** for every price, amount, fee, and balance (and `amount_to_precision` /
+`price_to_precision` historically return floats too). If any of those floats reach the engine via
+`Decimal(float)` — or are compared/arithmetic'd before conversion — the binary-float repr artifact
+(`Decimal(10.1) == 10.0999999...`) poisons the ledger. This is the locked correctness defect
+(money is Decimal end-to-end), now arriving from outside the engine for the first time.
+
+**Why it happens:**
+The whole codebase has so far controlled its own data ingress (`Bar.from_row` uses `Decimal(str(x))`).
+ccxt is the first money source the engine does not own, and its floats look like ordinary numbers.
+`Decimal(some_ccxt_float)` is a one-character mistake away everywhere.
+
+**How to avoid:**
+Bottle **all** ccxt→Decimal conversion at the connector edge through the existing `to_money(x)`
+(which is `Decimal(str(x))`, D-04) — never `Decimal(float)`, never float arithmetic before
+conversion. Treat the connector boundary like `Bar.from_row`: the moment a value crosses into the
+engine it is Decimal. For order submission *out* to OKX, convert with ccxt's **string** precision
+helpers (`decimal_to_precision` with `TRUNCATE`/`DECIMAL_PLACES`, or the string variants), not the
+float-returning `amount_to_precision`, so the venue sees a correctly-rounded string and the engine
+keeps its Decimal. Add a mypy/lint guard or a focused test that no `Decimal(` wraps a float on the
+live path.
+
+**Warning signs:**
+Any `Decimal(` call on the connector path whose argument is not a `str`; balances/fees with 15+ trailing
+digits in the ledger; `InvalidOperation` from OKX `create_order` (ccxt issue #7415, a classic
+float-precision symptom); reconciliation drift that is always tiny and always present.
+
+**Phase to address:** Phase 2 (connector edge conversion) and Phase 5 (`VenueAccount` balance/fee ingest).
+
+---
+
+### Pitfall 7: Rounding to the wrong OKX tick/lot/contract size
+
+**What goes wrong:**
+The engine sizes an order with its own per-instrument Decimal scales (8dp BTC), but OKX enforces its
+own `price` tick, `amount` lot step, **and contract-size multiple** — and rejects (or silently adjusts)
+anything off-grid. OKX amount must be a multiple of the lot/contract size; sending `0.123456` when the
+step is `0.0001` fails with "amount must be greater than minimum amount precision" (ccxt issue #17710).
+A silently-adjusted fill then mismatches the engine's intended quantity → reconciliation drift.
+
+**Why it happens:**
+The engine's `Instrument` scales (v1.4) were authored for the backtest and may not match OKX's live
+filters. The two precision systems (engine `quantize` vs. OKX market `precision`/`limits`) are easy to
+conflate.
+
+**How to avoid:**
+At connector init, load OKX market metadata (`load_markets`) and reconcile each traded symbol's
+OKX `precision`/`limits`/contract size into the engine `Instrument` (or a connector-side filter that
+runs after engine sizing). Round outbound quantities to OKX's lot step using ccxt's **string**
+precision helper, then re-quantize the resulting Decimal back into the engine so the engine's intended
+quantity equals what the venue will actually accept. Validate against `limits.amount.min` /
+`limits.cost.min` before submit; reject loud, never silently truncate to zero.
+
+**Warning signs:**
+OKX order rejections citing precision/min-amount; a fill quantity that differs from the submitted
+quantity; per-symbol drift that correlates with the least-significant digits of order size.
+
+**Phase to address:** Phase 2 (connector market-metadata load + outbound rounding); validated Phase 5 (sandbox).
+
+---
+
+### Pitfall 8: Races translating async ccxt.pro messages onto the synchronous single-writer queue
+
+**What goes wrong:**
+The connector's asyncio loop receives fills/balances/bars concurrently and pushes them onto
+`global_queue` from a thread/loop that is **not** the engine's single writer. The engine's
+single-writer contract (D-19, on which the backtest dropped all portfolio locks) is violated: two
+producers interleave, ordering guarantees the FIFO queue assumed are broken, and Portfolio/Account
+state mutated from the dispatch thread can race the connector thread.
+
+**Why it happens:**
+ccxt.pro is async-native; the engine is synchronous. Bridging them invites "just call
+`global_queue.put()` from the websocket callback" — which works until two callbacks fire close
+together or until the order-status stream races the bar stream.
+
+**How to avoid:**
+Bottle the async boundary **entirely at the connector edge** (Phase 2 design). The connector runs its
+own asyncio loop in its own thread and is the **only** producer that translates venue messages into
+domain events; the engine keeps its single dispatch thread as the **only** consumer/mutator.
+`queue.Queue.put()` is itself thread-safe (the FIFO crossing is fine); the danger is *state mutation*
+and *event ordering*, not the put. So: never let the connector thread touch Portfolio/Account/order
+state directly (queue-only contract — emit an event); preserve event causality by emitting in venue
+order; and keep the live `Portfolio`/`Account` `RLock`s where any read crosses threads (status/metrics
+queries from the API thread vs. the dispatch thread). Decide the LX-15 process topology early — a
+separate worker process (option b/c) sidesteps much of this by isolating the engine.
+
+**Warning signs:**
+`global_queue.put` called from anywhere other than the connector translator or an event handler;
+Portfolio/Account fields mutated off the dispatch thread; intermittent, unreproducible state
+corruption under load; events arriving out of causal order (fill before its order ack).
+
+**Phase to address:** Phase 2 (async/sync bridge at connector edge); topology decision is cross-cutting
+LX-15 (before Phase 4 wiring); thread-safety hardening Phase 4/5 (FL-13).
+
+---
+
+### Pitfall 9: Blocking the asyncio loop with engine/DB/sync work
+
+**What goes wrong:**
+A synchronous call (engine dispatch, a Postgres write-through, a `time.sleep`, a heavy pandas
+resample) runs inside the connector's asyncio loop coroutine, stalling all websocket I/O. Heartbeats
+miss, OKX drops the connection, and a reconnect storm follows — during which bars are missed and the
+gap-fill machinery (Pitfall 5) is stressed exactly when it matters most.
+
+**Why it happens:**
+The connector lives next to async code; it's tempting to "just await the engine" or do the DB write
+inline. The engine and DB are synchronous, so they block the loop.
+
+**How to avoid:**
+Strict separation: the asyncio loop does **only** network I/O and message translation, then hands off
+to the synchronous engine via the queue (a non-blocking `put`). No engine logic, no DB writes, no
+`sleep`, no pandas in a coroutine. Persistence write-through stays **keep-only-measured** (build async
+buffering only if the live loop profiles a stall, sketch Phase 5) — and even then it runs on the
+engine/storage side, never in the connector's loop. Run blocking work via `run_in_executor` only if
+unavoidable.
+
+**Warning signs:**
+Websocket reconnects correlate with order submissions or metrics writes; OKX "connection idle/timeout"
+disconnects under normal load; the asyncio loop's iteration latency spikes; `time.sleep` or a
+synchronous DB call inside any `async def`.
+
+**Phase to address:** Phase 2 (connector loop discipline); Phase 5 (persistence write-through must not stall).
+
+---
+
+### Pitfall 10: Treating the engine (not the venue) as source of truth in live
+
+**What goes wrong:**
+On the real path, the engine assumes its computed position/balance is correct and ignores or
+overwrites the venue's actual state. Partial fills, fees, funding, and venue-side liquidations make
+the venue the only authority; an engine that trusts its own books drifts from reality and can place
+orders against positions it doesn't actually hold.
+
+**Why it happens:**
+In backtest **and paper**, the `SimulatedAccount` legitimately *computes* truth — that's the parity
+spine (sketch §3). The instinct carries over to the real path, where it's wrong: `VenueAccount` must
+*cache and reconcile*, not compute (LX-03).
+
+**How to avoid:**
+Keep the two account leaves honest to their roles (LX-03): `SimulatedAccount` computes (backtest +
+paper, preserving parity); `VenueAccount` mirrors the connector's balance/position/fill streams and
+**reconciles** against them. Under 1 account : 1 portfolio (LX-04), reconciliation reduces to
+**per-symbol drift detection** (no cross-portfolio attribution) — assuming the portfolio has exclusive
+control of its OKX subaccount. Define a drift policy explicitly: auto-correct small drift vs.
+halt-and-alert (sketch Phase 5 open item) — never silently continue on unexplained drift.
+
+**Warning signs:**
+The real path has no code reading venue balances/positions after submit; engine position ≠ venue
+position after a partial fill; no drift threshold/alert; manual venue trades (or another process)
+silently desync the engine.
+
+**Phase to address:** Phase 5 (`VenueAccount` reconciliation, LX-04); interface shaped Phase 1.
+
+---
+
+### Pitfall 11: Partial / duplicate / mis-sequenced fill handling
+
+**What goes wrong:**
+OKX fills a large order in pieces, re-sends a fill on reconnect, or delivers a fill before the order
+ack. The order handler's mirror reconciliation (EXECUTED→FILLED etc.) — built for clean simulated
+fills — double-counts a duplicate, marks an order FILLED on the first partial, or chokes on a fill it
+has no order for. Position/cash diverge from the venue.
+
+**Why it happens:**
+The `SimulatedExchange`/`MatchingEngine` produces one clean terminal fill per order; partials and
+duplicates are a live-only reality the order mirror has never had to be idempotent against.
+
+**How to avoid:**
+Make fill ingestion idempotent and partial-aware at the connector/order-handler seam: key fills by the
+venue's fill/trade id (dedupe duplicates), accumulate partials against the order's filled-quantity
+(only terminalize when cumulative filled == order quantity or the venue reports the order closed), and
+tolerate fill-before-ack by buffering an orphan fill until its order appears (or reconciling from venue
+order status). The order mirror stays a **mirror** — the venue order-status stream, not the engine, is
+authoritative on the real path. Persist the cumulative-filled state so a restart can resume mid-partial
+(Pitfall 13).
+
+**Warning signs:**
+Order marked FILLED while venue shows it partially open; cash/position double-debited after a
+reconnect; a `FillEvent` with no matching order in the mirror; cumulative filled quantity exceeding
+order quantity.
+
+**Phase to address:** Phase 5 (order/fill reconciliation on the real path); connector fill stream Phase 2.
+
+---
+
+### Pitfall 12: Fees and funding drift the ledger silently
+
+**What goes wrong:**
+OKX charges maker/taker fees (and, on perps, funding) that differ from the engine's fee model. The
+engine's computed cash diverges from the venue balance by an accumulating fee/funding delta that looks
+like "small constant drift" and is easy to dismiss — until it isn't.
+
+**Why it happens:**
+Paper uses the engine's own fee/slippage models (correct for parity); the real path must instead ingest
+the venue's *actual* charged fees. Funding is explicitly out of scope (perp Phase B / FUND-01..04) but
+will be a visible drift source the moment anyone trades a perp.
+
+**How to avoid:**
+On the real path, ingest the venue's reported fee per fill (Decimal via `to_money`) into the ledger
+rather than recomputing — the engine fee model is for paper/backtest only. Make fee drift a *named,
+explained* component of reconciliation, not noise. Keep spot-only in v1.7 (funding out of scope); if a
+perp is ever traded, treat funding drift as expected-and-unmodeled and **halt rather than silently
+absorb** until Phase B lands.
+
+**Warning signs:**
+Reconciliation drift that grows linearly with trade count; engine cash consistently above venue cash by
+~the fee rate; any funding line item on a perp position the engine doesn't account for.
+
+**Phase to address:** Phase 5 (venue-fee ingest in reconciliation); funding deferred (out of scope, named).
+
+---
+
+### Pitfall 13: Restart rehydration reconciling store-only, ignoring the live venue (the v1.6 broker-side gap)
+
+**What goes wrong:**
+On restart, the engine rehydrates its working set from the v1.6 Postgres store and resumes — but the
+store is stale relative to the venue (fills landed while the engine was down, an order was canceled
+venue-side, a position was liquidated). The engine resumes on a false picture and acts on it.
+
+**Why it happens:**
+v1.6's restart-rehydration tests were **store-only** — they proved cache↔store consistency, never
+cache↔**broker** consistency, because there was no live adapter. The broker side is an explicit carried
+gap (sketch Phase 5).
+
+**How to avoid:**
+Restart reconciliation must be two-sided: rehydrate from the store **and** reconcile against the live
+venue (fetch open orders, positions, balances; replay any fills that landed during downtime through the
+idempotent fill path; cancel/expire orders the venue no longer holds). Bracket parents need special
+care: a parent that filled during downtime must have its children correctly activated/cancelled on
+restart (the engine's two-pass bracket gate must be re-established from venue truth, not assumed).
+Define the drift-on-restart policy (auto-reconcile vs. halt-and-alert) the same as steady-state
+(Pitfall 10).
+
+**Warning signs:**
+Restart path reads only the store, never the connector; open orders on OKX that the engine doesn't know
+about post-restart; a bracket child resting with no live parent (or vice versa); positions on the venue
+absent from the rehydrated portfolio.
+
+**Phase to address:** Phase 5 (cache↔broker restart reconciliation; persistence live-drive).
+
+---
+
+### Pitfall 14: Crash-safe write ordering / write-through stalling the live loop
+
+**What goes wrong:**
+Either (a) the engine acts (submits an order, applies a fill) before durably persisting the intent, so
+a crash between act-and-persist loses the record and breaks restart reconciliation; or (b) the
+write-through runs synchronously on the dispatch thread and stalls the live loop, backing up the queue
+and missing bars/fills.
+
+**Why it happens:**
+The two goals pull opposite ways — crash-safety wants write-before-act; latency wants act-then-write.
+The v1.6 store was built and tested on testcontainers but never *driven by a live feed* (its
+transaction-boundary design is an explicit carried research flag).
+
+**How to avoid:**
+Decide the transaction boundary per operation (sketch Phase 5 / v1.6 carried flag): **create and
+terminalize sync** (durable before the irreversible venue action), append-heavy/metrics writes can be
+async/buffered. Keep write-through **keep-only-measured** — only build async buffering if the live loop
+profiles a stall (don't pre-optimize). Persist the *intent* (order to be sent) before submit so a crash
+mid-submit is recoverable by reconciliation. Never run a Postgres write inside the connector asyncio
+loop (Pitfall 9).
+
+**Warning signs:**
+Queue depth grows during DB-heavy moments; orders submitted to OKX with no prior store row; restart
+finds a venue order with no engine record; p99 dispatch latency tracks DB write latency.
+
+**Phase to address:** Phase 5 (persistence live-drive, write ordering); profile-gated per keep-only-measured.
+
+---
+
+### Pitfall 15: Sandbox vs. live key split-brain
+
+**What goes wrong:**
+Part of the system talks to OKX demo and part to OKX live — e.g. ccxt is put in sandbox mode but a
+native escape-hatch call (Pitfall 1's `confirm` reader) hits production, or the data feed is live while
+the order arm is demo (or vice versa). Result: phantom fills, orders against the wrong book, or
+real-money trades when "paper" was intended. Catastrophic.
+
+**Why it happens:**
+OKX routes demo via two different mechanisms — ccxt's `set_sandbox_mode(True)` **and** the native
+`x-simulated-trading: 1` header — and the connector has two paths (ccxt.pro default + native escape
+hatch). Two switches → split-brain if only one is flipped.
+
+**How to avoid:**
+A **single `sandbox: bool`** (LX-05) routes *both* arms: it must call ccxt `set_sandbox_mode` **and**
+set the native `x-simulated-trading` header, with no second toggle anywhere. Pair sandbox/live with
+**separate key sets** keyed off the same flag (sandbox keys can't reach live, by construction). Add a
+startup assertion that both ccxt and native paths report the same environment before any order arm goes
+live. Paper-first (LX-01) means the order arm is sandbox-only until a deliberate gated promotion.
+
+**Warning signs:**
+Two independent sandbox/demo toggles in the codebase; the data feed and order arm configured
+separately; no startup check that ccxt and native agree on environment; live API keys present in a
+paper/sandbox config.
+
+**Phase to address:** Phase 2 (single-flag routing of both arms); secrets split cross-cutting (LX-05).
+
+---
+
+### Pitfall 16: Secrets leakage in logs / structured events
+
+**What goes wrong:**
+API key/secret/passphrase (OKX requires a passphrase) end up in logs, error events, or the persisted
+store — via a connector exception that logs the request, a `repr()` of a config object, or an
+`ErrorEvent.error_message` that includes the offending payload. The structlog setup logs liberally and
+`filterwarnings` won't catch a leaked secret.
+
+**Why it happens:**
+ccxt errors often include the request context; the engine's publish-and-continue policy logs every
+handler failure (`_publish_and_continue` logs `str(exc)` and emits an `ErrorEvent`); credentials in a
+config object get logged on init.
+
+**How to avoid:**
+Keys never in code (already the WR-10 posture — no hardcoded fallback). Load from env/secret store as
+Pydantic `SecretStr` (the codebase already uses `SecretStr database_url`) so `repr`/log renders
+`**********`. Scrub connector exceptions before logging/emitting (strip auth headers, redact request
+bodies). Never persist raw credentials in the store or `ErrorEvent`. Add a log/event scrubber on the
+live path and a test asserting no key material appears in emitted `ErrorEvent`s or log capture.
+
+**Warning signs:**
+API secret visible in any log line or `ErrorEvent`; config object logged without `SecretStr`
+wrapping; ccxt request context logged on error; secrets in the Postgres store.
+
+**Phase to address:** Phase 2 (secret loading via SecretStr); cross-cutting secrets hardening (Phases 2-5).
+
+---
+
+### Pitfall 17: Over-building beyond the trimmed scope
+
+**What goes wrong:**
+The team builds explicitly out-of-scope machinery — **tick-level local paper fills** (rejected by
+LX-13), a **full production screener** (only a lean poll seam is in scope, Phase 6), a
+**multi-venue abstraction** beyond shaping the interface (crypto/OKX-first, locked), or **perp Phase B
+funding realism** (FUND-01..04, its own future milestone). Each balloons the surface, delays the
+paper-parity DoD, and risks destabilizing the byte-exact oracle.
+
+**Why it happens:**
+The connector interface invites generalization ("while I'm here, let me support N venues");
+sub-bar realism feels more "real" than bar fills; the screener seam looks half-built. The pull toward
+completeness fights the trimmed-N+4 posture.
+
+**How to avoid:**
+Hold the sketch's explicit out-of-scope list (sketch §1). Local paper stays **bar-based** (LX-13) —
+sub-bar realism lives in OKX sandbox, not local paper. The connector is **shaped** for a 2nd venue but
+only `OkxConnector` is implemented (LX-05). Phase 6 ships only the lean membership poll seam, not the
+production screener. Funding/perp realism is deferred. Treat every "while I'm here" as scope creep to
+defer with a note, not absorb.
+
+**Warning signs:**
+A `TickPaperConnector` or sub-bar fill logic; a second connector implementation; screener filter
+chains beyond add/remove polling; funding-rate accrual code; the milestone slipping while "foundations"
+grow.
+
+**Phase to address:** All phases (scope discipline); Phase 4 (resist tick fills); Phase 6 (resist full screener).
+
+---
+
+### Pitfall 18: asyncio/websocket warnings failing the strict suite (`filterwarnings=["error"]`)
+
+**What goes wrong:**
+Live tests pull in ccxt.pro/aiohttp/websockets, which emit `ResourceWarning` (unclosed session/
+transport), `DeprecationWarning` (asyncio loop/`get_event_loop`), and "coroutine was never awaited"
+warnings. Under `filterwarnings=["error"]` **any** of these fails the test — so the live surface is
+hard to test at all, and the temptation is to weaken the strict gate globally (which would also weaken
+the backtest's correctness net).
+
+**Why it happens:**
+The strict suite was tuned for a synchronous, dependency-light engine. Async test teardown reliably
+leaks warnings unless sessions/loops are explicitly closed; ccxt.pro holds connections open by design.
+
+**How to avoid:**
+Never relax `filterwarnings` globally. Instead: ensure deterministic async teardown (close ccxt
+connections, await `exchange.close()`, close the loop) so no `ResourceWarning` escapes; use
+`pytest-asyncio` with explicit loop/fixture scoping; and where a third-party warning is genuinely
+unavoidable, scope a **narrow** per-test `filterwarnings` marker (or `pytest.warns`/`recwarn`)
+targeting that exact warning class+module — never a blanket ignore. Prefer testing the live surface
+against a **mocked/recorded connector** (replay fixtures) so most FL-13 coverage needs no live socket
+at all; reserve real-socket tests for a small sandbox-gated integration set.
+
+**Warning signs:**
+Live tests pass only with a broadened global `filterwarnings`; `ResourceWarning: unclosed`
+transport/session in test output; "coroutine never awaited"; pressure to mark the whole live suite
+`-W ignore`.
+
+**Phase to address:** Phase 2 onward (every live phase adds FL-13 coverage as it lands, sketch §5).
+
+---
+
+## Technical Debt Patterns
+
+| Shortcut | Immediate Benefit | Long-term Cost | When Acceptable |
+|----------|-------------------|----------------|-----------------|
+| Use ccxt unified `watchOHLCV`, infer close from timestamp roll-over | No native escape hatch needed | Forming-bar bugs, parity failure, fragile to stream quirks | Never for fills — `confirm` flag is mandatory (LX-08) |
+| Bulk `warmup_from(series)` for fast backfill | Faster start | Second state path diverges, re-opens parity audit (LX-09) | Never — forbidden by LX-09 |
+| `Decimal(ccxt_float)` directly | One line | Binary-float poison in the ledger | Never — route through `to_money` |
+| Synchronous write-through on dispatch thread | Simple, crash-safe | Stalls live loop, backs up queue | MVP only if profiled clean; keep-only-measured |
+| `VenueAccount` computes instead of caches | Reuse `SimulatedAccount` math | Engine drifts from venue truth (LX-03) | Never on real path; fine for paper (it IS `SimulatedAccount`) |
+| Run engine in-process with FastAPI | Simplest wiring | Couples lifecycles, mixes 3 concurrency models, one crash kills both | Throwaway demo only; sketch leans worker/process-per-portfolio (LX-15) |
+| Global `-W ignore` to pass live tests | Green suite fast | Destroys the backtest correctness net too | Never — scope warnings per-test |
+| Two sandbox toggles (ccxt + native separately) | Quick | Split-brain → real-money risk | Never — single `sandbox: bool` (LX-05) |
+
+## Integration Gotchas
+
+| Integration | Common Mistake | Correct Approach |
+|-------------|----------------|------------------|
+| OKX kline WS | Trusting ccxt `watchOHLCV` to tell you a bar closed | Read native `confirm` field (last array element, 0/1); ccxt drops it (issue #21885) → native escape hatch (LX-05) |
+| ccxt money | `Decimal(float)` on prices/amounts/fees/balances | `to_money(str)` at connector edge; string precision helpers outbound |
+| OKX order size | Engine 8dp quantity sent as-is | Round to OKX lot/contract step via ccxt string precision; validate `limits.amount.min` (issue #17710) |
+| OKX demo | `set_sandbox_mode` only, native calls hit live | Single flag sets BOTH ccxt sandbox + native `x-simulated-trading` header (LX-05) |
+| ccxt.pro async | `global_queue.put` / state mutation from WS callback thread | Connector translator is sole producer; queue-only; no cross-thread state mutation |
+| OKX auth | Forgetting the passphrase; logging the request | Passphrase required; `SecretStr`; scrub connector exceptions before log/emit |
+| ccxt.pro sessions | Tests leak unclosed sessions → `ResourceWarning` fails strict suite | `await exchange.close()` in teardown; mock/replay connector for most FL-13 |
+
+## Performance Traps
+
+| Trap | Symptoms | Prevention | When It Breaks |
+|------|----------|------------|----------------|
+| Blocking the asyncio loop with DB/engine/sleep | Reconnect storms under load; bars missed | Loop does only I/O + translate; sync work off-loop | First DB-heavy live session |
+| Sync write-through on dispatch thread | Queue depth tracks DB latency | Sync only create/terminalize; rest buffered, profile-gated | High trade rate / slow DB |
+| Live machinery imported on the backtest hot path | W1/W2 regression vs v1.5 (15.7s/152.8MB) | Lazy-import the live arm (mirror the existing SQL lazy-import); inertness test | Any backtest run after live code lands |
+| Per-bar REST gap-fill on a flaky connection | Latency spikes, rate-limit bans during reconnect | Bounded backfill window; ring buffer; reconnect debounce | Unstable network / frequent disconnects |
+
+## Security Mistakes
+
+| Mistake | Risk | Prevention |
+|---------|------|------------|
+| API key/secret/passphrase in logs or `ErrorEvent` | Account takeover | `SecretStr`; scrub connector exceptions; no raw creds in store/events |
+| Hardcoded credential fallback | Leaked key in repo | Already WR-10 (no fallback); keep it; env/secret-store only |
+| Sandbox/live key split-brain | Unintended real-money trades | Single `sandbox` flag routes both arms + key set; startup environment assertion |
+| Persisting credentials in the system-of-record | DB compromise = key compromise | Never persist creds; store references, not secrets |
+
+## "Looks Done But Isn't" Checklist
+
+- [ ] **Bar-close detection:** Often missing the `confirm`-flag read — verify `BarEvent` emits only on `confirm == 1`, never wall-clock
+- [ ] **Backfill:** Often missing the through-`update()` guarantee — verify no `warmup_from`/bulk path exists; state byte-matches backtest at same asof
+- [ ] **Paper fills:** Often missing next-bar-open semantics — verify `FillEvent.time == T + tf_base` via reused `MatchingEngine`
+- [ ] **Determinism:** Often missing the business-time discipline — verify paper double-run byte-identical; no wall-clock in events/ledger
+- [ ] **Reconciliation:** Often missing the broker side — verify restart reconciles store AND live venue, not store-only
+- [ ] **Partial fills:** Often missing idempotency — verify duplicate fills deduped, partials accumulated, fill-before-ack tolerated
+- [ ] **Money:** Often missing the ccxt-float boundary — verify no `Decimal(float)` on the live path; venue fees ingested (not recomputed)
+- [ ] **Sandbox:** Often missing dual-arm routing — verify single flag sets ccxt sandbox AND native header; startup env assertion
+- [ ] **Secrets:** Often missing exception scrubbing — verify no key material in any log/`ErrorEvent`
+- [ ] **Strict suite:** Often missing async teardown — verify live tests pass under `filterwarnings=["error"]` without global relaxation
+- [ ] **Backtest inertness:** Often missing the regression check — verify oracle byte-exact + no W1/W2 regression after live code lands
+
+## Recovery Strategies
+
+| Pitfall | Recovery Cost | Recovery Steps |
+|---------|---------------|----------------|
+| Forming-bar acted on / parity broken | MEDIUM | Switch to `confirm` flag; replay parity harness from clean dataset; re-validate gate |
+| Indicator state corrupted (backward feed / bad backfill) | MEDIUM | Re-warm from ring buffer through `update()`; no in-place patch; re-assert state vs backtest |
+| ccxt-float in ledger | HIGH | Audit all `Decimal(` on live path; re-route through `to_money`; reconcile/rebuild affected balances from venue |
+| Engine/venue drift undetected | HIGH | Add per-symbol drift detection; reconcile from venue truth; halt-and-alert policy; rebuild from venue + store |
+| Restart on stale store (broker gap) | MEDIUM | Add broker-side reconciliation; replay downtime fills idempotently; re-establish bracket parent/child from venue |
+| Sandbox/live split-brain | HIGH (if real money) | Halt; single-flag refactor; key-set separation; startup env assertion before any future run |
+| Secret leaked to log/store | HIGH | Rotate keys immediately; scrub logs/store; add scrubber + test |
+
+## Pitfall-to-Phase Mapping
+
+| Pitfall | Prevention Phase | Verification |
+|---------|------------------|--------------|
+| 1. Forming-bar / wall-clock close | Phase 3 (flag plumb Phase 2) | `BarEvent` emitted only on `confirm==1`; parity holds |
+| 2. Next-bar-open fill off-by-one | Phase 4 | `FillEvent.time == T+tf_base`; reused `MatchingEngine` |
+| 3. Wall-clock in business time | Phase 4 | Paper double-run byte-identical; no `now()` in events/ledger |
+| 4. Backfill fast-path divergence | Phase 3 (reused Phase 6) | No `warmup_from`; state == backtest at asof |
+| 5. Backward indicator feed | Phase 3 | Dup dropped / stale rejected / gap backfilled; reconnect parity |
+| 6. ccxt float in ledger | Phase 2 + 5 | No `Decimal(float)`; balances Decimal-clean |
+| 7. OKX tick/lot rounding | Phase 2 (sandbox Phase 5) | Outbound qty multiple of lot; no precision rejects |
+| 8. Async→queue races | Phase 2 (+ LX-15 topology) | Single producer; no off-thread state mutation |
+| 9. Blocking the asyncio loop | Phase 2 (+ Phase 5 write-through) | No sync/DB/sleep in coroutine; stable reconnects |
+| 10. Venue not source of truth | Phase 5 (interface Phase 1) | `VenueAccount` caches+reconciles; drift policy defined |
+| 11. Partial/duplicate fills | Phase 5 (stream Phase 2) | Idempotent fill ingest; partial accumulation |
+| 12. Fee/funding drift | Phase 5 | Venue fees ingested; drift named/explained; funding halts |
+| 13. Restart broker-side gap | Phase 5 | Restart reconciles store AND venue; bracket parents safe |
+| 14. Write ordering / loop stall | Phase 5 (profile-gated) | Create/terminalize durable pre-act; no loop stall |
+| 15. Sandbox/live split-brain | Phase 2 (LX-05) | Single flag both arms; startup env assertion |
+| 16. Secrets leakage | Phase 2 (cross-cutting) | No creds in logs/events/store |
+| 17. Over-build out of scope | All (Phase 4/6 esp.) | No tick fills / full screener / multi-venue / funding |
+| 18. Strict-suite async warnings | Phase 2 onward (FL-13) | Live tests green under `filterwarnings=["error"]`, no global relax |
+
+## Sources
+
+- [iTrader locked sketch — `docs/superpowers/specs/2026-06-30-live-trading-milestone-design.md`](file) — LX-01..LX-15, parity spine, carried research flags (HIGH)
+- iTrader source: `itrader/price_handler/feed/bar_feed.py` (7-rule bar-timing contract), `itrader/core/money.py` (D-04 string entry), `itrader/trading_system/live_trading_system.py` (daemon thread, publish-and-continue, wall-clock usage) (HIGH)
+- [ccxt issue #21885 — request for `closed`/`confirm` flag in watchOHLCV](https://github.com/ccxt/ccxt/issues/21885) — confirms unified ccxt does NOT expose candle-closed; native read needed (MEDIUM-HIGH)
+- [ccxt issue #17710 — OKX amount precision / contract-size multiple rejection](https://github.com/ccxt/ccxt/issues/17710) (MEDIUM)
+- [ccxt issue #7415 — OKX create_order InvalidOperation (float precision)](https://github.com/ccxt/ccxt/issues/7415) (MEDIUM)
+- [ccxt decimal_to_precision source](https://github.com/ccxt/ccxt/blob/master/python/ccxt/base/decimal_to_precision.py) — string TRUNCATE/DECIMAL_PLACES helpers (MEDIUM)
+- [OKX v5 WebSocket candlesticks channel docs](https://www.okx.com/docs-v5/en/) — candle array `[ts,o,h,l,c,vol,...,confirm]`, confirm 0/1 (MEDIUM-HIGH)
+- [ccxt OKX exchange docs](https://docs.ccxt.com/docs/exchanges/okx), [ccxt.pro manual](https://docs.ccxt.com/docs/pro-manual) (MEDIUM)
+
+---
+*Pitfalls research for: adding live OKX (paper-first) trading to the iTrader event-driven/Decimal/deterministic backtest engine*
+*Researched: 2026-06-30*

--- a/.planning/research/v1.7-archive/STACK.md
+++ b/.planning/research/v1.7-archive/STACK.md
@@ -1,0 +1,180 @@
+# Stack Research
+
+> ## ⚠ Superseded framing — read `phases/02-okx-connector/02-CONTEXT.md` first
+>
+> The Phase-2 discussion (2026-07-01) revised the live architecture; this snapshot
+> predates it and still describes the **two-arm `LiveConnector`** model. **Superseded
+> framings** (everything else here remains valid):
+> - Connector is a **session/transport primitive**, not a two-arm venue object; the data/order/account arms are **domain adapters** (`OkxDataProvider` / `OkxExchange` / `VenueAccount`), **injected** with the session, never cross-domain-imported.
+> - The **`OkxExchange` adapter emits `FillEvent`** — the connector owns no operations and emits no domain events.
+> - Paper needs **no connector**: the paper execution adapter implements **`AbstractExchange`** (not `LiveConnector`).
+> - `OkxSettings` reads **plain `OKX_API_*` (no env prefix)** — not `ITRADER_OKX_*`; secret manager deferred post-milestone.
+>
+> See design-doc LX-05/LX-06 revision notes and `02-CONTEXT.md` D-01..D-10.
+
+**Domain:** Live crypto trading (OKX, paper-first) — additions to an event-driven backtest engine
+**Researched:** 2026-06-30
+**Confidence:** HIGH (ccxt packaging/versions, OKX demo mechanics, asyncio bridge verified against current sources; MEDIUM on native-escape-hatch choice — a plan-time gap-list decision)
+
+> Scope: **only the NEW stack surface for v1.7 live OKX paper-first trading.** The existing
+> validated stack (Python 3.13, Poetry, `ccxt ^4.5.56` read-only providers, `websocket-client`,
+> `sqlalchemy`+`psycopg2-binary`+Postgres, `msgspec`, `structlog`, `pydantic`+`pydantic-settings`,
+> `uuid-utils`, Decimal money) is NOT re-researched. The headline: **almost nothing new is
+> strictly required** — the live capability is mostly *activating async ccxt that you already ship*
+> plus stdlib asyncio glue. Resist scope creep (libSQL-rejection precedent applies).
+
+---
+
+## Recommended Stack
+
+### Core Technologies
+
+| Technology | Version | Purpose | Why Recommended |
+|------------|---------|---------|-----------------|
+| `ccxt` (already pinned) | bump `^4.5.56` → `^4.5.62` (latest 4.5.62, Feb–Mar 2026) | **Live data arm + order arm** via its built-in WebSocket layer (ccxt.pro) and async REST | **ccxt.pro is already inside the free `ccxt` package** (merged at v1.95, 2022) — no separate license, no separate install, no new dependency. You already depend on ccxt for read-only providers; v1.7 just *uses its async + watch\* surface*. OKX is a first-class ccxt venue. This is the LX-05 default. |
+| Python stdlib `asyncio` | stdlib (3.13) | **Async/sync bridge** — run the connector's event loop on its own daemon thread; marshal across the boundary | `asyncio.run_coroutine_threadsafe()` (sync→async commands) + `loop.call_soon_threadsafe()` (loop control) is the canonical, dependency-free pattern. Outbound (async→sync `global_queue`) is just `queue.Queue.put()` — already thread-safe. **No new library needed for the bridge.** |
+| `aiohttp` | transitive via ccxt async (verify resolved ≥ 3.10) | HTTP transport for `ccxt.async_support` / `ccxt.pro` | Ships as a ccxt dependency for the async layer; confirm it resolves in `poetry.lock` rather than adding it explicitly. No direct use in our code. |
+
+### Supporting Libraries
+
+| Library | Version | Purpose | When to Use |
+|---------|---------|---------|-------------|
+| `pytest-asyncio` | `^1.4.0` (requires py ≥3.10 ✓) | Test `async def` connector coroutines (watch-loop parsing, ack handling, reconnect) | **Add to dev group.** Needed the moment you unit-test the connector's async edge in isolation. Configure explicitly (see "Version Compatibility" — interacts with `filterwarnings=["error"]`). |
+| `python-okx` (native escape hatch candidate) | `0.4.1` (okxapi/python-okx, last upload 2026-01-08, py ≥3.7) | LX-05 native OKX v5 escape hatch for *proven* ccxt gaps only | **Do NOT add up front.** Candidate only if a concrete gap is found at Phase 2/3 plan time. Version `0.4.1` is low and the wrapper is community-maintained — treat with the **libSQL-beta caution**. Preferred escape hatch is raw `aiohttp`/`websockets` against OKX v5 (see below). |
+| `janus` | `2.0.0` (py ≥3.9) | Purpose-built mixed sync↔async queue | **Probably NOT needed.** Only reach for it if you discover you need *async-side consumption* of a queue that the *sync side produces into* (the rare reverse direction). The forward path (`queue.Queue` out, `run_coroutine_threadsafe` in) covers the connector design in the sketch. Flag, don't add. |
+| `redis` (py client) | `^5.x` if chosen | LX-15 inter-process command/status channel (option) | Only if the topology decision picks Redis over Postgres LISTEN/NOTIFY. **Topology is an architecture decision (out of scope here)** — inventoried below, not selected. |
+
+### Development Tools
+
+| Tool | Purpose | Notes |
+|------|---------|-------|
+| `pytest-asyncio` | Async test driver | Set `asyncio_mode = "auto"` (or `"strict"`) AND `asyncio_default_fixture_loop_scope = "function"` in `[tool.pytest.ini_options]` — otherwise it emits a `PytestDeprecationWarning` that the `error` filter can escalate. Do NOT redefine the `event_loop` fixture (deprecated → future error). |
+| ccxt verbose / `exchange.verbose = True` | Inspect raw OKX WS frames during connector bring-up | Use to confirm the kline **confirm flag** payload shape (LX-08) and demo-header routing without writing throwaway scripts. |
+
+## Installation
+
+```bash
+# Core: bump the existing ccxt pin (NO new runtime dependency — ccxt.pro is in-package)
+poetry add "ccxt@^4.5.62"
+
+# Dev: async test driver
+poetry add --group dev "pytest-asyncio@^1.4.0"
+
+# DO NOT add up front (evaluate at plan time only):
+#   poetry add "python-okx@0.4.1"     # native escape hatch — only on a proven gap
+#   poetry add "janus@^2.0.0"         # only if reverse sync->async queue consumption is needed
+#   poetry add "redis@^5"             # only if LX-15 topology picks Redis
+```
+
+`aiohttp` is pulled transitively by ccxt's async layer — verify it lands in `poetry.lock`; do not pin it directly.
+
+---
+
+## The six questions, answered
+
+### 1. ccxt.pro packaging + OKX surface (LX-05)
+- **Packaging: definitively merged.** ccxt.pro is a **free part of the unified `ccxt` package** since v1.95 (2022). There is **no separate package, no separate install, no license key.** Confirmed against ccxt issue #15171 and the PyPI/docs current pages. The CLAUDE.md note that ccxt is "used today only as read-only providers" is an *internal usage* fact, not a packaging limit — the async + WS surface is already shipped in the wheel you have.
+- **Import structure (Python):**
+  - `import ccxt.pro as ccxtpro` — the **WebSocket** layer (`watch_*` streaming methods).
+  - `import ccxt.async_support as ccxt` — **async REST** (awaitable `create_order`, `fetch_ohlcv`, `fetch_balance`).
+  - `import ccxt` — the legacy **sync REST** layer (what `ccxt_provider.py` uses today).
+- **OKX WS method support (LX-05 data + order arms):** OKX supports `watch_ohlcv` (data arm), and the private streams `watch_orders`, `watch_balance`, `watch_my_trades`, `watch_positions`. Order placement: `create_order` (async REST) and `create_order_ws` (`createOrderWs`, same signature, over WS). `create_order_ws` is an optional optimization — start with async-REST `create_order` + `watch_orders` for the fill stream.
+- **Native escape hatch (LX-05):** the leanest escape hatch is **raw `aiohttp` (REST) + `websockets`/the ccxt-bundled WS client against the OKX v5 API directly** — both transports already ride in via ccxt, so no new dep. The packaged `python-okx 0.4.1` SDK is a *candidate* but is low-version + community-maintained (libSQL-caution); `okx-sdk` (burakoner, 5.5.812) is more complete but is a second third-party surface. **Recommendation: keep the escape hatch as thin hand-rolled v5 calls behind `LiveConnector`, add a native SDK only if a concrete, proven gap justifies it** at Phase 2/3 plan time.
+
+### 2. asyncio bridge
+- **Best practice (verified, dependency-free):** connector owns a `loop = asyncio.new_event_loop()` on a **daemon thread**; `run_coroutine_threadsafe(coro, loop)` to submit work *into* the loop from the sync engine; `loop.call_soon_threadsafe(loop.stop)` for graceful shutdown, then `thread.join()`. Outbound async→sync is `global_queue.put(event)` (stdlib `queue.Queue` is thread-safe). This keeps the async boundary "bottled at the connector edge" exactly as the sketch requires.
+- **No version-pinned dep required.** `janus 2.0.0` exists for the harder sync↔async-queue case but is **not needed** for this topology — flag it, don't add it.
+
+### 3. OKX sandbox/demo (single `sandbox: bool`)
+- **ccxt path:** `exchange.set_sandbox_mode(True)` routes OKX to demo endpoints. For OKX, demo also requires the **`x-simulated-trading: 1` HTTP header**; modern ccxt sets this for OKX when sandbox mode is on, but the header is the underlying mechanism — confirm it is applied on **both REST and WS** during bring-up (historical ccxt issues show drift here).
+- **Native path:** set `headers = {"x-simulated-trading": "1"}` and use the demo base URLs / WS URLs.
+- **Demo requires demo-specific API keys** (created in OKX → Demo Trading), distinct from live keys.
+- **Single-flag routing (LX-05):** one `sandbox: bool` on the connector config should (a) call `set_sandbox_mode(sandbox)` on the ccxt instance AND (b) inject the `x-simulated-trading` header on any native call AND (c) select the sandbox-vs-live **key set**. No split-brain — one flag, three effects.
+
+### 4. Secrets (OKX needs THREE)
+- **OKX auth = apiKey + secret + passphrase** (the "password" in ccxt's config is the OKX **passphrase**). Confirmed. This is unlike key+secret-only venues — the passphrase is mandatory.
+- **Best practice: env-only via the existing `pydantic-settings` `ITRADER_` pattern.** Add a dedicated `OkxSettings(BaseSettings)` mirroring `SqlSettings` (`itrader/config/sql.py`): `env_prefix="ITRADER_OKX_"`, all three credentials as `SecretStr | None`, a `sandbox: bool` field, and a `model_validator` that **fails loud** when live (sandbox=False) is selected without all three creds — the exact "no working secret defaults" discipline already proven in `sql.py`. Keys never in code; sandbox vs live keys separated by the single `sandbox` flag (LX-05 cross-cutting §5).
+
+### 5. Runtime topology IPC channels (LX-15) — INVENTORY ONLY (do not pick)
+| Channel | New dep? | Pros | Cons |
+|---------|----------|------|------|
+| **Postgres `LISTEN/NOTIFY`** (via existing `psycopg2`) | **None** — you already ship `psycopg2-binary` + Postgres (v1.6 store) | Reuses the v1.6 system-of-record as the shared truth; zero new infra; transactional with the state writes; "exactly what v1.6's durable store was built to enable" | NOTIFY payload ≤ 8 KB; not a durable queue (missed while disconnected unless paired with a polled table); LISTEN needs a dedicated connection/poll loop |
+| **Redis** (pub/sub or streams) | `redis` py client + a Redis server | Low-latency; mature pub/sub + durable Streams; natural fit for fan-out | New infra component + new dep + new ops surface; second source of truth alongside Postgres |
+| **Message broker** (RabbitMQ / NATS) | heavy client + broker | Strong delivery semantics, routing | Heaviest ops/dep footprint; overkill for a single-venue, few-process deployment |
+- **Lean read:** the Postgres LISTEN/NOTIFY option adds **zero dependencies** and reuses v1.6 — it is the obvious low-cost default *if* a separate-process topology (LX-15 option b/c) is chosen. **But the topology choice itself is an architecture decision and is out of scope here.**
+
+### 6. Testing libs + `filterwarnings=["error"]` interaction
+- **`pytest-asyncio ^1.4.0`** (py ≥3.10 ✓ for 3.13) is the standard async test driver.
+- **Strictness interaction (the gotcha):** the existing `[tool.pytest.ini_options]` has `filterwarnings = ["error", "ignore::UserWarning", "ignore::DeprecationWarning"]`. pytest-asyncio emits a `PytestDeprecationWarning` if `asyncio_default_fixture_loop_scope` is unset. `PytestDeprecationWarning` subclasses `pytest.PytestWarning` (→ `UserWarning`) **and** `DeprecationWarning` — your current ignores *may* absorb it, but **do not rely on that.** Set both config knobs explicitly:
+  ```toml
+  asyncio_mode = "auto"                          # or "strict"
+  asyncio_default_fixture_loop_scope = "function"
+  ```
+- **Do NOT redefine the `event_loop` fixture** — that override path is deprecated and slated to become a hard error; use the `scope=` arg on the asyncio marker or the `event_loop_policy` fixture instead.
+- Async network code tends to leak `ResourceWarning`/unclosed-session warnings; under `error` these fail the suite. Ensure connector teardown `await exchange.close()` in fixtures, and prefer **mocked transports** for unit tests (real OKX sandbox I/O belongs in `integration`/`e2e`, not unit).
+
+---
+
+## Alternatives Considered
+
+| Recommended | Alternative | When to Use Alternative |
+|-------------|-------------|-------------------------|
+| ccxt.pro (in-package) for OKX | `python-okx 0.4.1` native SDK | Only if a concrete OKX-fidelity gap in ccxt is proven at plan time (e.g. kline confirm-flag unreliability, order-status field loss). Wrap behind `LiveConnector` either way. |
+| Hand-rolled v5 native escape hatch (`aiohttp`/`websockets`) | `okx-sdk 5.5.812` (burakoner) | If the native surface needed is large enough that hand-rolling is more error-prone than a maintained SDK — but that adds a third-party trust + dep surface; bias toward thin hand-rolled. |
+| stdlib `run_coroutine_threadsafe` bridge | `janus 2.0.0` | Only if you need the async side to *consume* from a queue the sync side *produces into* (reverse of the sketch's flow). |
+| Postgres LISTEN/NOTIFY (no dep) | Redis / broker | If/when a separate-process topology needs durable fan-out beyond NOTIFY's 8 KB transient payload, or sub-ms latency. |
+
+## What NOT to Use
+
+| Avoid | Why | Use Instead |
+|-------|-----|-------------|
+| A separate "ccxtpro" package install or license | ccxt.pro merged into free `ccxt` in 2022 — a separate package is stale/wrong | `import ccxt.pro as ccxtpro` from the `ccxt` you already have |
+| `python-okx 0.4.1` as a *default* dependency | Low version + community-maintained; mirrors the libSQL beta-driver rejection (v1.6 Q2) — adds risk for capability you mostly already have in ccxt | ccxt.pro by default; native escape hatch only on a proven, documented gap |
+| `websocket-client` (the v1.6 Binance streamer) for OKX | Sync, callback-style, quarantined D-live module; mixing it with the async connector splits the transport model | ccxt.pro async `watch_*` on the connector's asyncio loop |
+| `asyncio.get_event_loop()` / redefining `event_loop` test fixture | Deprecated patterns; will hard-error in future asyncio/pytest-asyncio | `asyncio.new_event_loop()` on the daemon thread; `asyncio_default_fixture_loop_scope` config |
+| Adding `aiohttp` explicitly | It arrives transitively with ccxt async; an explicit pin risks version drift against ccxt's expectation | Let ccxt resolve it; just verify the lockfile |
+
+## Stack Patterns by Variant
+
+**If staying paper-first (the DoD, Phases 1–4):**
+- You need **only the ccxt bump + the asyncio-bridge (stdlib) + pytest-asyncio**. The `PaperConnector` reuses the pure `MatchingEngine` (LX-06); it consumes the connector's **data arm** (`watch_ohlcv`) only. No order-arm creds, no secrets module strictly required until Phase 5.
+
+**If advancing to the real/sandbox path (Phase 5):**
+- Add the **OkxSettings secrets module** (3 creds + sandbox flag) and exercise the **order arm** (`create_order` + `watch_orders`/`watch_balance`/`watch_positions`) against OKX **demo** first.
+
+**If a separate-process runtime topology is chosen (LX-15, b/c):**
+- Default to **Postgres LISTEN/NOTIFY** (zero new dep, reuses v1.6) before reaching for Redis/broker.
+
+## Version Compatibility
+
+| Package | Compatible With | Notes |
+|---------|-----------------|-------|
+| `ccxt 4.5.62` | Python 3.13 ✓ | ccxt does not pin `requires_python`; 4.5.x supports 3.13. Bump is a minor within your existing `^4.5` range — low risk. |
+| `ccxt.pro` (in-package) | `aiohttp` (transitive) | The async/WS layer needs aiohttp; verify it's resolved in `poetry.lock` after the bump. |
+| `pytest-asyncio 1.4.0` | pytest `^9.0.3` (dev), Python 3.13 ✓ | requires py ≥3.10. **Requires** explicit `asyncio_mode` + `asyncio_default_fixture_loop_scope` to coexist with `filterwarnings=["error"]`. |
+| `python-okx 0.4.1` (if added) | py ≥3.7 | Low version; community wrapper — libSQL-caution. Pin exact, behind `LiveConnector`. |
+| `janus 2.0.0` (if added) | py ≥3.9 | `aclose()` required on shutdown or it emits errors. |
+
+## Integration Points With Existing Code
+
+- **`itrader/price_handler/providers/ccxt_provider.py`** — the symbol-formatting (`BTC/USDT` ↔ `BTCUSDT`), market loading, and OHLCV→Decimal `Bar` conversion logic is reusable. The new live connector is a *new seam* (data arm + order arm), not an edit of this read-only provider; mine it for symbol/format helpers and the `fetch_ohlcv` warmup-backfill call (LX-09 REST `fetch_ohlcv` for warmup).
+- **`itrader/price_handler/providers/binance_stream.py`** — the **quarantined D-live** sync `websocket-client` streamer. Its `msg['k']['x']` closed-bar gate is the *concept* mirror for OKX's confirm flag (LX-08), but **replace it, don't extend it** — OKX uses async ccxt.pro, not the sync callback model.
+- **`itrader/config/sql.py`** (`SqlSettings`) — the **template for the new `OkxSettings`**: `env_prefix`, `SecretStr` fields, driver-conditional fail-loud `model_validator`, `extra="forbid"`. Clone this pattern for `ITRADER_OKX_*` (key/secret/passphrase/sandbox).
+- **`itrader/config/settings.py`** — keep OKX creds OUT of the general `Settings` (mirror how DB creds moved to their own `SqlSettings`); a dedicated `OkxSettings` keeps the backtest path credential-free and env-tolerant.
+- **`pyproject.toml [tool.mypy]`** — `ccxt.*` is already `ignore_missing_imports`; `live_trading_system`/`trading_interface`/`binance_stream` are already `ignore_errors`. New live code should target **strict-clean** (DoD §4); add per-module overrides only where a third-party stubless surface forces it, not as a blanket.
+
+## Sources
+
+- https://github.com/ccxt/ccxt/issues/15171 — "CCXT Pro Websockets merged with CCXT" (packaging, free, in-package) — HIGH
+- https://docs.ccxt.com/ and https://docs.ccxt.com/docs/pro-manual — ccxt.pro manual, `watch_*` + `createOrderWs`, `import ccxt.pro as ccxtpro` — HIGH
+- https://pypi.org/project/ccxt/ — ccxt 4.5.62 latest (verified via PyPI JSON API) — HIGH
+- https://www.okx.com/en-us/help/api-faq + https://app.okx.com/docs-v5/en/ — OKX demo trading, `x-simulated-trading: 1` header, passphrase requirement — HIGH
+- https://github.com/ccxt/ccxt/issues/11923, /11855, /17295 — OKX `set_sandbox_mode` + demo header + WS demo caveats — MEDIUM (issue threads, version-drift cautions)
+- https://docs.python.org/3/library/asyncio-task.html#asyncio.run_coroutine_threadsafe + https://github.com/aio-libs/janus — asyncio cross-thread bridge + janus — HIGH
+- https://pypi.org/project/python-okx/ (0.4.1, 2026-01-08), https://github.com/burakoner/okx-sdk (5.5.812) — native escape-hatch candidates — MEDIUM
+- https://pypi.org/project/pytest-asyncio/ (1.4.0) + https://pytest-asyncio.readthedocs.io/ — async test driver + loop-scope/event_loop deprecation under strict warnings — HIGH
+- https://pypi.org/project/janus/ (2.0.0) — sync↔async queue (flagged, not recommended) — HIGH
+
+---
+*Stack research for: live crypto trading (OKX, paper-first) additions to the iTrader backtest engine*
+*Researched: 2026-06-30*

--- a/.planning/research/v1.7-archive/SUMMARY.md
+++ b/.planning/research/v1.7-archive/SUMMARY.md
@@ -1,0 +1,309 @@
+# Project Research Summary
+
+> ## ⚠ Superseded framing — read `phases/02-okx-connector/02-CONTEXT.md` first
+>
+> The Phase-2 discussion (2026-07-01) revised the live architecture; this snapshot
+> predates it and still describes the **two-arm `LiveConnector`** model. **Superseded
+> framings** (everything else here remains valid):
+> - Connector is a **session/transport primitive**, not a two-arm venue object; the data/order/account arms are **domain adapters** (`OkxDataProvider` / `OkxExchange` / `VenueAccount`), **injected** with the session, never cross-domain-imported.
+> - The **`OkxExchange` adapter emits `FillEvent`** — the connector owns no operations and emits no domain events.
+> - Paper needs **no connector**: the paper execution adapter implements **`AbstractExchange`** (not `LiveConnector`).
+> - `OkxSettings` reads **plain `OKX_API_*` (no env prefix)** — not `ITRADER_OKX_*`.
+>
+> See design-doc LX-05/LX-06 revision notes and `02-CONTEXT.md` D-01..D-10.
+
+**Project:** iTrader v1.7 — Live Trading Readiness (paper-first OKX, trimmed N+4)
+**Domain:** Live crypto trading deployment layer over an event-driven, Decimal-exact, deterministic backtest engine
+**Researched:** 2026-06-30
+**Confidence:** HIGH (all four researchers grounded in the locked design LX-01..LX-15 + direct source reading; MEDIUM on two OKX/ccxt externals called out below)
+
+---
+
+## Executive Summary
+
+iTrader v1.7 adds live OKX trading to a proven event-driven backtest engine — paper-first, with a correctness gate anchored to the byte-exact oracle (`134 trades / 46189.87730727451`). The defining structural insight from all four researchers is that **v1.5's BarFeed ABC and MatchingEngine were built for this**: the engine above the feed already speaks one contract, and switching the backing store from a precomputed frame to a ring buffer is the bulk of Phase 3's work. Similarly, the `PortfolioReadModel` Protocol seam means the Phase 1 Account abstraction extraction does not ripple into the order domain at all — it is code-motion, not re-architecture. The headline stack finding is equally reassuring: **almost nothing new is strictly required**. ccxt.pro is already inside the free `ccxt` package you ship; the asyncio bridge is stdlib; `pytest-asyncio` is the only real addition. OkxSettings and the order-arm secrets module are deferred to Phase 5.
+
+The six-phase structure is load-bearing: Phase 1 is the universal oracle-gated gate (everything live depends on Account abstraction being behavior-preserving), Phase 3 is where complexity concentrates on the data path (monotonic-forward-only delivery + reconnect gap-fill + warmup-through-update), and Phase 5 is the reconciliation cluster (partial fills, broker-side restart, write-through ordering, VenueAccount drift policy). Phase 4 (PaperConnector + paper-parity gate) is the milestone DoD and is reachable with only the data arm of the connector — no live order I/O required.
+
+The dominant risk is the forming-bar / confirm-flag problem: ccxt's unified `watchOHLCV` does not surface OKX's `confirm` field (ccxt issue #21885), so a native escape hatch at the connector edge is mandatory before the feed can safely emit `BarEvent`s. This single fact — verified against the OKX v5 docs and ccxt tracker — is the anchor for LX-05/LX-08 and must be plumbed in Phase 2 before Phase 3 can close. The second dominant risk is the Phase 5 reconciliation cluster, where broker-side restart, partial fills, fee ingest, and write-through ordering converge and interact; that phase warrants its own plan-time research sprint.
+
+---
+
+## Key Findings
+
+### Recommended Stack
+
+The existing stack needs only a minor ccxt bump (`^4.5.56` -> `^4.5.62`), stdlib `asyncio` for the bridge (no new library), and `pytest-asyncio ^1.4.0` in the dev group. ccxt.pro is free, in-package, and already shipped; `import ccxt.pro as ccxtpro` unlocks `watch_ohlcv`, `watch_orders`, `watch_balance`, and `create_order_ws` with zero additional install. The asyncio bridge follows a proven, dependency-free pattern: connector owns `asyncio.new_event_loop()` on a daemon thread; `run_coroutine_threadsafe` submits work into the loop; outbound `global_queue.put(event)` is thread-safe stdlib. OkxSettings (`ITRADER_OKX_*` env prefix, `SecretStr` for all three credentials including the mandatory passphrase, `sandbox: bool`) is deferred to Phase 5.
+
+**Core technologies:**
+- `ccxt ^4.5.62` (bump existing pin): ccxt.pro live data + order arm via in-package async/WS surface — no new install, no license key
+- Python stdlib `asyncio` (3.13): connector event loop on daemon thread, `run_coroutine_threadsafe` bridge — zero new dependencies
+- `pytest-asyncio ^1.4.0`: async test driver — required; must be configured with `asyncio_mode` + `asyncio_default_fixture_loop_scope` or `filterwarnings=["error"]` escalates its deprecation warnings
+- `aiohttp` (transitive via ccxt async): verify it resolves in `poetry.lock`; do not pin explicitly
+- `python-okx 0.4.1` / `janus 2.0.0` / `redis ^5`: do NOT add up front — each is a flagged candidate only on a proven, documented gap
+
+**Critical version interaction:** `pytest-asyncio` emits `PytestDeprecationWarning` when `asyncio_default_fixture_loop_scope` is unset; under `filterwarnings=["error"]` this fails the suite. Set both `asyncio_mode = "auto"` and `asyncio_default_fixture_loop_scope = "function"` in `pyproject.toml`. Do not redefine the `event_loop` fixture.
+
+### Expected Features
+
+The 26 identified behaviors split cleanly across the six phases. The DoD is Phase 4 (paper-parity gate). Phase 5 is the "should-have in-milestone" cluster; Phase 6 is the lean poll seam only.
+
+**Must have — Phase 1 (gates everything):**
+- Account ABC + `SimulatedCashAccount` / `SimulatedMarginAccount` leaves (code-motion, byte-exact)
+- `Portfolio` receives injected `self.account`; `cash` -> `account.balance`
+- Margin/liq math moved from `PortfolioHandler` to `SimulatedMarginAccount`; liquidation *emission* stays in the handler (queue-only rule preserved)
+- `Portfolio.user_id` stripped (app-layer concern); `TradingInterface` deleted (replaced by typed engine command surface)
+- `LiveConnector` Protocol defined (interface-only in Phase 1)
+- Oracle re-confirmed byte-exact after extraction
+
+**Must have — Phases 2 + 3 (feed pipeline):**
+- `OkxConnector` data arm: `watch_ohlcv` via ccxt.pro + native OKX `confirm` flag via escape hatch (LX-05/LX-08) — the confirm field is the enabling prerequisite for the whole feed
+- `LiveBarFeed(BarFeed)` ring buffer: `deque(maxlen=cap)` per `(symbol, timeframe)`, capacity derived from `cache_capacity()` same as backtest
+- Bar-close detection emits `BarEvent` only on `confirm == 1`; bar `time` = venue bar-open stamp (not wall-clock)
+- Warmup/backfill: REST `fetch_ohlcv` last-K, replayed one-by-one through the identical `update(bar)` path (LX-09) — no bulk fast-path exists
+- Monotonic-forward-only delivery: gap -> REST-backfill-and-replay; duplicate -> drop; stale/OOO -> reject; reconnect -> gap-fill
+- WS reconnect with gap recovery; rate-limit handling coordinated across ccxt and native paths
+
+**Must have — Phase 4 (the DoD):**
+- `PaperConnector(LiveConnector)`: composes `MatchingEngine` + `apply_costs` helper (extracted from `_emit_fill`) + `SimulatedAccount` — no OKX I/O
+- Paper-parity gate: replay fixed dataset -> assert `134 / 46189.87730727451`; byte-exact, not tolerance-based
+- `TimeEvent` synthesized on each closed-bar arrival so existing `_routes` TIME-before-BAR ordering holds
+- Determinism seams: seeded RNG + business-time stamping thread through the paper path
+
+**Must have — Phase 5 (real/sandbox path):**
+- `OkxConnector` order arm: `create_order` (async REST) + `watch_orders` / `watch_fills`; single `sandbox: bool` routes both ccxt (`set_sandbox_mode`) and native (`x-simulated-trading` header)
+- `VenueAccount` impl: caches venue balance/margin/position streams, reconciles per-symbol drift (LX-04 1:1)
+- Partial-fill handling: accumulate by fill ID; terminalize only at full fill or venue-reported closed
+- Restart rehydration two-sided: store + broker reconcile (not store-only)
+- Write-through live-drive: create/terminalize sync-durable; append/metrics writes buffered only if profiled necessary
+- Halt-and-alert drift policy; auto-correct only within defined tolerance
+- `OkxSettings(BaseSettings)` with `SecretStr` for all three OKX credentials
+
+**Must have — Phase 6:**
+- Warmup-on-add (reuses Phase 3 `update(bar)` backfill path per-symbol)
+- Open-position-handling-on-remove (force-close vs orphan-and-track policy defined)
+- Lean universe membership poll seam only — not the production screener
+
+**Defer (explicitly out of scope — do not build):**
+- Tick-level local-paper fills (LX-13: bar-based only; sub-bar realism lives in OKX sandbox)
+- Bulk `warmup_from(series)` fast-path (LX-09: forbidden — opens parity audit)
+- Wall-clock bar-close inference (LX-08: always drive from `confirm`)
+- Perp realism Phase B (FUND-01..04): own future milestone
+- Full production screener: lean poll seam only
+- Multi-venue / multi-asset: connector interface *shaped* for a 2nd venue but only OKX implemented
+- Cross-margin pooling: deferred beyond N+2 Phase B
+- In-process engine inside FastAPI (LX-15: separate worker process)
+- Auto-correct-everything reconciliation: halt-and-alert is the safe default
+
+### Architecture Approach
+
+The integration spine is the `PortfolioReadModel` Protocol at the center: the order domain already reads through it, so re-homing balance/margin truth into an `Account` abstraction does not ripple into `OrderManager` or the validator. Phase 1 is pure code-motion behind an existing seam. The async->sync boundary is bottled entirely at the connector edge: the connector runs its own asyncio loop on its own daemon thread and only calls `global_queue.put(frozen_event)` — the existing D-19 single-writer contract is never crossed. All state mutation stays on the engine's dispatch thread.
+
+**Major new/modified components:**
+1. `Account` ABC + `portfolio_handler/account/` package — NEW; `SimulatedCashAccount` (CashManager code-motion), `SimulatedMarginAccount` (liq math from PortfolioHandler); `VenueAccount` interface-only in P1, implemented in P5
+2. `Portfolio` — MODIFIED: inject `self.account`; `cash` -> `account.balance`; `user_id` stripped
+3. `PortfolioHandler` — MODIFIED: margin/liq math moved out; `_run_liquidation_pass` emission stays (queue-only rule)
+4. `TradingInterface` — DELETED; replaced by typed engine command surface consuming from Postgres command channel
+5. `LiveConnector` Protocol — NEW: data arm (`watch_ohlcv` / `fetch_ohlcv`), order arm (`submit` / `cancel` / `watch_fills`), account arm (`fetch_balances` / `watch_balances` / `fetch_positions`)
+6. `OkxConnector` — NEW: ccxt.pro default + native OKX escape hatch behind the interface; single `sandbox: bool` routes both arms
+7. `LiveBarFeed(BarFeed)` — NEW: `price_handler/feed/live_bar_feed.py`; ring buffer; same ABC the engine already consumes
+8. `apply_costs` helper — NEW: extracted from `SimulatedExchange._emit_fill` (byte-exact); shared by both `SimulatedExchange` and `PaperConnector`; eliminates dual fill-pricing drift
+9. `PaperConnector(LiveConnector)` — NEW: `MatchingEngine` + `apply_costs` + `SimulatedAccount`; no OKX I/O; bar-based fills only
+10. `VenueAccount` impl — NEW (Phase 5): caches + reconciles connector balance/position/fill streams under LX-04
+11. Worker process + Postgres command/status channel — NEW (Phase 5): ships as (b) architected as (c) with N=1
+
+**Runtime topology recommendation (LX-15):** Ship option (b) — separate worker — architected as (c) per-portfolio with N=1. Rationale: (a) in-process couples FastAPI + connector asyncio + engine sync thread in one OS process; (b)/(c) activates the v1.6 store-as-truth investment; LX-04's 1:1 constraint makes per-portfolio process isolation natural from day one. Decide before Phase 4 wiring. Default IPC: Postgres LISTEN/NOTIFY (zero new dep, reuses v1.6).
+
+### Critical Pitfalls
+
+1. **Forming-bar acted on (confirm-flag gap in ccxt)** — ccxt's `watchOHLCV` does not surface OKX's `confirm` field (ccxt #21885); paper-parity fails immediately and silently. Prevention: `OkxConnector` reads native OKX candle `confirm` field via escape hatch; `LiveBarFeed` emits `BarEvent` only on `confirm == 1`. Plumbed in Phase 2; enforced in Phase 3.
+
+2. **ccxt returns floats — Decimal boundary violation** — every ccxt price/amount/fee/balance is a float; `Decimal(some_ccxt_float)` is binary-float poison. Prevention: all ccxt->Decimal conversion at connector edge through `to_money(x)` = `Decimal(str(x))` (D-04); string precision helpers for outbound quantities. Applies Phase 2 + Phase 5.
+
+3. **Wall-clock leaking into business `time`** — existing `LiveTradingSystem` already has multiple `datetime.now(UTC)` usages; the pattern is contagious. Prevention: connector stamps domain events from venue bar-open timestamps; audit every `datetime.now` on the live path before merge. Business time never equals wall clock.
+
+4. **Backfill divergence from a fast-path (LX-09 violation)** — a bulk `warmup_from(series)` alongside `update()` is a second state-building path; stateful indicators have no rewind. Prevention: LX-09 is absolute — one-by-one `update(bar)` only; never add `warmup_from`/`seed`/`prime` to any indicator or feed API.
+
+5. **Phase 5 reconciliation cluster — broker-side restart gap** — v1.6 restart rehydration was store-only; a live restart on store-only resurrects positions the venue closed. Prevention: two-sided restart: store rehydration + live venue fetch + idempotent downtime fill replay + bracket parent/child re-establishment from venue truth.
+
+---
+
+## Implications for Roadmap
+
+### Phase 1: Account Abstraction Extraction (Oracle-Gated Refactor)
+
+**Rationale:** The universal prerequisite. Every live component depends on `Account` being the stable truth surface. Behavior-preserving code-motion behind the existing `PortfolioReadModel` seam — does not ripple into the order domain. Must be oracle-confirmed byte-exact before any live code merges.
+
+**Delivers:** `Account` ABC + `SimulatedCashAccount` (CashManager code-motion) + `SimulatedMarginAccount` (liq math from PortfolioHandler); `Portfolio` receives `self.account`; `PortfolioHandler` emission path untouched; `Portfolio.user_id` stripped; `TradingInterface` deleted; `LiveConnector` Protocol defined (interface-only); oracle byte-exact confirmed (`134 / 46189.87730727451`).
+
+**Key constraint:** `_process_transaction_spot` is byte-exact site #2 — operand-for-operand identical Decimal ops, in order; `apply_fill_cash_flow` full-precision no-quantize contract preserved. Gate: oracle numbers + determinism double-run + `mypy --strict`.
+
+**Avoids:** Liquidation math left in PortfolioHandler (A6); user_id on Account (A5); downstream parity failures from mis-homed truth.
+
+**Research flag:** Skip — v1.2 MOD-01 OrderManager-decomposition playbook; well-established pattern.
+
+---
+
+### Phase 2: OKX Connector (Data Arm + Order Arm)
+
+**Rationale:** The connector supplies the closed-bar stream Phase 3 consumes and the order arm Phase 5 exercises. The data arm's native `confirm` flag read is the enabling prerequisite for the whole feed. Must precede Phase 3.
+
+**Delivers:** `OkxConnector(LiveConnector)` with ccxt.pro `watch_ohlcv` + native OKX `confirm` field; REST `fetch_ohlcv`; async REST `create_order` + `watch_orders`/`watch_fills` (order arm for Phase 5); single `sandbox: bool` routes both ccxt and native paths; `load_markets` lot/tick/contract-size validation; idempotent client order IDs via `idgen` UUIDv7; rate-limit coordination; `SecretStr` secret loading.
+
+**Architecture:** connector owns its asyncio loop on a daemon thread; only calls `global_queue.put(...)` on the engine side (D-19 preserved). `pytest-asyncio` unit tests use mocked transports.
+
+**Avoids:** Pitfalls 1 (forming bar), 6 (ccxt float), 7 (OKX rounding), 8 (async races), 9 (blocking loop), 15 (split-brain), 16 (secrets leakage), 18 (strict-suite warnings).
+
+**Research flag:** NEEDS PLAN-TIME RESEARCH — OKX `confirm` exact behavior + ccxt.pro gap list; `set_sandbox_mode` WS header verification; demo key requirements.
+
+---
+
+### Phase 3: LiveBarFeed (Real-Time Data Engine)
+
+**Rationale:** Most unique live complexity concentrates here. Monotonic-forward-only delivery with reconnect gap-fill has no backtest equivalent. Must follow Phase 2.
+
+**Delivers:** `LiveBarFeed(BarFeed)` ring buffer (`deque(maxlen=cap)` per symbol/tf, same capacity derivation as backtest); bar-close detection on `confirm == 1`; warmup/backfill through `update(bar)` one-by-one (LX-09); monotonic-forward-only enforcement; `TimeEvent` synthesized on each closed bar (recommended — preserves TIME-before-BAR route ordering); event-driven time source replaces `TimeGenerator` on the live path.
+
+**Key seam decision at plan time:** emit paired `TimeEvent` on bar close (recommended) vs. move metric recording to BAR route.
+
+**Avoids:** Pitfalls 1 (forming bar), 4 (backfill fast-path), 5 (backward indicator feed).
+
+**Research flag:** NEEDS PLAN-TIME RESEARCH — ring-buffer capacity with multiple timeframes/consumers; reconnect debounce strategy; after-the-fact venue bar correction policy (re-warm vs forward-only-and-log).
+
+---
+
+### Phase 4: Paper Path + Parity Gate (The DoD)
+
+**Rationale:** The milestone DoD. Requires Phase 1 + Phase 3 + connector data arm only — no order arm, no OKX credentials. The paper path is reachable without any live order I/O.
+
+**Delivers:** `PaperConnector(LiveConnector)` composing `MatchingEngine` + shared `apply_costs` helper (byte-exact extraction) + `SimulatedAccount`; bar-based fills only (LX-13); `FillEvent.time = T + tf_base` (next-bar-open via reused `MatchingEngine`); determinism seams throughout (seeded RNG + business-time stamping); paper-parity gate: `134 / 46189.87730727451`, `check_exact=True`.
+
+**Pre-wiring requirement:** LX-15 topology decision must be committed before Phase 4 wires the live runtime.
+
+**Avoids:** Pitfalls 2 (next-bar-open off-by-one), 3 (wall-clock in business time), A3 (dual fill pricing from two separate cost implementations).
+
+**Research flag:** NEEDS PLAN-TIME RESEARCH — parity harness design (offline replay of fixed dataset recommended); LX-15 topology decision + Postgres LISTEN/NOTIFY vs Redis; determinism seam threading in live runtime.
+
+---
+
+### Phase 5: Real/Sandbox Path + Reconciliation + Persistence Live-Drive
+
+**Rationale:** The reconciliation cluster — heaviest phase by unique live complexity. Five concerns converge: VenueAccount, partial fills, broker-side restart, write-through ordering, fee ingest. Warrants its own plan-time research sprint.
+
+**Delivers:** `OkxConnector` order arm vs OKX demo; `VenueAccount` implementation (per-symbol drift under LX-04 1:1); partial-fill handling (fill-ID dedup, `accFillSz` accumulation, terminalize on venue-closed); two-sided restart reconciliation; halt-and-alert drift policy; v1.6 SQL store driven by real feed (create/terminalize sync-durable; writes buffered only if profiled stalling); venue fee ingest via `to_money`; `OkxSettings` with three `SecretStr` credentials.
+
+**Avoids:** Pitfalls 6 (ccxt float in VenueAccount), 10 (engine as source of truth), 11 (partial/duplicate fills), 12 (fee drift), 13 (broker-side restart gap), 14 (write ordering / loop stall).
+
+**Research flag:** NEEDS PLAN-TIME RESEARCH — reconciliation drift/repair policy (tolerance thresholds, halt triggers, auto-correct scope); write-through transaction boundary design; OKX partial-fill field cadence; bracket restart from venue truth.
+
+---
+
+### Phase 6: Dynamic Universe (Lean Poll Seam)
+
+**Rationale:** Pairs with Phase 3 — warmup-on-add reuses the Phase 3 `update(bar)` backfill path. Cheap only if Phase 3 built the seam generically (per-symbol, not start-only).
+
+**Delivers:** Lean universe membership poll seam; warmup-on-add via `update(bar)` (reuses Phase 3 path); open-position-handling-on-remove policy defined. Does NOT deliver full screener, multi-venue, cross-margin, or perp funding.
+
+**Avoids:** Pitfall 17 (over-building screener/screener chains).
+
+**Research flag:** Skip — reuses Phase 3 backfill seam; standard patterns if Phase 3 is built generically.
+
+---
+
+### Phase Ordering Rationale
+
+- **Phase 1 is the hard gate** — oracle-gated; no live code may be written against Account until backtest re-confirmed byte-exact. Non-negotiable.
+- **Phase 2 before Phase 3** — `LiveBarFeed` consumes the connector's data arm + native `confirm` field. Cannot build the feed without the connector.
+- **Phase 4 DoD reachable at Phase 3 + data arm only** — critical sequencing insight: paper-parity requires no order arm, no OKX sandbox access, no live credentials. Fastest path to the milestone gate.
+- **Phase 5 after Phase 4** — order arm + VenueAccount + reconciliation require the paper path proven before real money is risked, even on sandbox.
+- **Phase 6 last** — pairs with Phase 3's backfill seam; no new hard dependencies beyond the live path being live.
+- **LX-15 topology decided before Phase 4 wiring** — worker process structure is cross-cutting; wiring Phase 4 without a topology decision creates rework.
+
+---
+
+### Watch Out For
+
+These are the failure modes all four researchers independently flagged:
+
+1. **Forming-bar / confirm-flag paper-parity risk** — the single most likely source of parity failure; the native escape hatch is mandatory. Plan-time: produce the OKX ccxt-vs-native gap list before Phase 2 design is locked.
+
+2. **ccxt returns floats everywhere** — no `to_money` call exists yet in any ccxt order/balance/fee path (existing providers only convert OHLCV rows). Every new connector method handling prices/amounts/fees/balances must route through `to_money`. The failure mode is invisible until reconciliation drift accumulates.
+
+3. **Wall-clock in business time is contagious** — the existing `LiveTradingSystem` has multiple `datetime.now(UTC)` usages. Audit every new `datetime.now` before merge; especially likely in error-handling paths.
+
+4. **Phase 5 reconciliation policy is the most under-specified area** — do not start Phase 5 without decisions on: (a) auto-correct tolerance thresholds, (b) halt-and-alert trigger conditions, (c) bracket parent/child restart re-establishment, (d) write-through transaction boundary. Build a research sprint into Phase 5 planning.
+
+5. **`filterwarnings=["error"]` + async tests** — any unclosed ccxt.pro session/transport or unset `asyncio_default_fixture_loop_scope` fails the entire suite. Use mocked/recorded connectors for unit tests. Never relax the global filter.
+
+6. **Scope creep is the second most likely derailer** — the connector interface invites generalization; sub-bar fills feel "more real"; screener seam looks half-built. The trimmed-N+4 posture is explicit: paper-parity DoD at Phase 4, one venue, bar-based only, lean screener. Every "while I'm here" must be deferred with a note, not absorbed.
+
+---
+
+### Research Flags
+
+**Needs plan-time research sprint:**
+- **Phase 2:** OKX `confirm` flag exact behavior + ccxt.pro gap list; `set_sandbox_mode` WS header; demo key requirements
+- **Phase 4:** Parity harness design (offline replay recommended); LX-15 topology decision; determinism seam in live runtime
+- **Phase 5:** Reconciliation drift/repair policy; write-through transaction boundary; OKX partial-fill field cadence; bracket restart from venue truth
+
+**Standard patterns (skip dedicated research phase):**
+- **Phase 1:** v1.2 MOD-01 playbook; `PortfolioReadModel` seam already in place; code-motion only
+- **Phase 3:** `BarFeed` ABC seam exists; ring buffer is bounded deque; monotonic enforcement mirrors BacktestBarFeed cursor discipline
+- **Phase 6:** Reuses Phase 3 backfill-through-update; lean membership seam is well-scoped
+
+---
+
+## Confidence Assessment
+
+| Area | Confidence | Notes |
+|------|------------|-------|
+| Stack | HIGH | ccxt.pro packaging verified (in-package, free, merged v1.95); asyncio bridge pattern (stdlib, dependency-free, canonical); `pytest-asyncio` filterwarnings interaction documented. MEDIUM: `python-okx`/`janus` as candidates — flagged, not selected |
+| Features | HIGH | All 26 behaviors grounded in locked design LX-01..LX-15 + existing engine code. LOW flag: OKX partial-fill field cadence (consistent across docs, not freshly re-verified live) |
+| Architecture | HIGH | Account layering read from source (`portfolio.py`, `portfolio_handler.py`, `cash/cash_manager.py`, `core/portfolio_read_model.py`); `TradingInterface` deletion grep-confirmed no production consumers; BarFeed ABC seam; MatchingEngine purity. MEDIUM: OKX confirm-flag exposure in ccxt.pro (web-sourced; verify at Phase 2 plan time) |
+| Pitfalls | HIGH (engine-internal) / MEDIUM-HIGH (OKX/ccxt) | Engine-internal pitfalls read directly from source. OKX/ccxt pitfalls verified against ccxt issues + OKX v5 docs; exact behavior confirmed at plan time |
+
+**Overall confidence:** HIGH on Phase 1 (pure internal refactor); HIGH on Phases 2-4 except confirm-flag gap-list detail (MEDIUM); MEDIUM-HIGH on Phase 5 (reconciliation policy and write-through boundary are the under-specified areas).
+
+### Gaps to Address
+
+The following five open questions were flagged independently by all four researchers (sketch §8 convergent open items):
+
+1. **OKX `confirm` flag reliability + native-vs-ccxt gap list** — determine the full list of OKX behaviors ccxt.pro does not surface; validate `set_sandbox_mode(True)` applies `x-simulated-trading` on both REST and WS. How to handle: Phase 2 plan-time research; block Phase 2 design until resolved.
+
+2. **Reconciliation drift/repair policy** — specific tolerance thresholds, halt-and-alert triggers, auto-correct scope, bracket parent/child re-establishment on restart. How to handle: Phase 5 plan-time research sprint; do not start Phase 5 coding until decided and documented.
+
+3. **Parity harness design** — offline replay of a fixed dataset (recommended: CI-runnable, deterministic) vs. record-a-live-session-then-replay (non-deterministic, network-bound). How to handle: decide in Phase 4 planning; offline replay strongly recommended, aligns with byte-exact oracle discipline.
+
+4. **Write-through transaction boundary** — which operations are sync-durable before the irreversible venue action (create, terminalize), which can be buffered (append, metrics), and when buffering is profile-gated vs. always-on. This is the v1.6 carried flag. How to handle: Phase 5 plan-time; default sync for create/terminalize, measure before buffering anything else.
+
+5. **LX-15 topology decision before Phase 4 wiring** — option (b) separate worker architected as (c) with N=1 is recommended; Postgres LISTEN/NOTIFY default (zero new dep). How to handle: decide in Phase 3/4 planning handoff; default to Postgres LISTEN/NOTIFY and revisit only if a concrete latency/durability gap is proven.
+
+---
+
+## Sources
+
+### Primary (HIGH confidence)
+- `docs/superpowers/specs/2026-06-30-live-trading-milestone-design.md` (LX-01..LX-15) — locked design, phase structure, parity spine
+- `itrader/portfolio_handler/portfolio.py`, `portfolio_handler.py`, `cash/cash_manager.py` — Account layering source analysis
+- `itrader/core/portfolio_read_model.py` — seam confirmation
+- `itrader/price_handler/feed/bar_feed.py` — 7-rule bar-timing contract; BacktestBarFeed cursor discipline; BarFeed ABC
+- `itrader/execution_handler/matching_engine.py`, `exchanges/simulated.py` — MatchingEngine purity; `_emit_fill` cost helper extraction site
+- `itrader/trading_system/live_trading_system.py`, `trading_interface.py` — `TradingInterface` no-consumer grep; existing `datetime.now` wall-clock usages
+- `itrader/core/money.py` — D-04 `to_money(x)` = `Decimal(str(x))`
+- https://docs.ccxt.com/docs/pro-manual — ccxt.pro `watch_*` surface, `createOrderWs`, import structure
+- https://pypi.org/project/ccxt/ — ccxt 4.5.62; in-package ccxt.pro (free, merged v1.95, issue #15171)
+- https://www.okx.com/docs-v5/en/ — OKX v5 WS candle `confirm` field; `x-simulated-trading` header; passphrase requirement
+- https://pypi.org/project/pytest-asyncio/ — `asyncio_default_fixture_loop_scope` config; `event_loop` fixture deprecation
+
+### Secondary (MEDIUM confidence)
+- https://github.com/ccxt/ccxt/issues/21885 — ccxt `watchOHLCV` does not surface `closed`/`confirm` flag; native escape hatch required
+- https://github.com/ccxt/ccxt/issues/17710 — OKX amount precision / contract-size multiple rejection
+- https://github.com/ccxt/ccxt/issues/7415 — OKX `create_order` `InvalidOperation` (float precision symptom)
+- https://github.com/ccxt/ccxt/issues/11923, /11855, /17295 — OKX `set_sandbox_mode` + demo header + WS demo caveats
+- https://pypi.org/project/python-okx/ (0.4.1), https://github.com/burakoner/okx-sdk (5.5.812) — native escape-hatch candidates (flagged, not selected)
+- https://pypi.org/project/janus/ (2.0.0) — sync/async queue candidate (flagged, not recommended)
+- Framework patterns (Nautilus 1.227.0, freqtrade, Hummingbot, QuantConnect LEAN) — table-stakes feature confirmation; iTrader's distinctive choices mapped against industry norms
+
+---
+*Research completed: 2026-06-30*
+*Ready for roadmap: yes*

--- a/.planning/todos/pending/off-vocabulary-halt-reason-baseline-residual-wr04.md
+++ b/.planning/todos/pending/off-vocabulary-halt-reason-baseline-residual-wr04.md
@@ -1,9 +1,10 @@
 ---
-status: open
+status: scheduled
 created: "2026-07-07"
 source: Phase 05.1 (v1.7) code review finding WR-04 — surfaced in the v1.7 milestone-audit review-file reconciliation (2026-07-07)
 tags: [live, halt, observability, operator, ui, halt-vocabulary, fastapi-control-plane]
 resolves_phase: ""
+folded_into: "v1.8 spec §18 — CF-8 (P8 SafetyController + P1 core/enums)"
 ---
 
 # Session-start baseline guard halts with an off-vocabulary reason `'baseline-residual'` (WR-04)

--- a/.planning/todos/pending/off-vocabulary-halt-reason-baseline-residual-wr04.md
+++ b/.planning/todos/pending/off-vocabulary-halt-reason-baseline-residual-wr04.md
@@ -3,8 +3,8 @@ status: scheduled
 created: "2026-07-07"
 source: Phase 05.1 (v1.7) code review finding WR-04 — surfaced in the v1.7 milestone-audit review-file reconciliation (2026-07-07)
 tags: [live, halt, observability, operator, ui, halt-vocabulary, fastapi-control-plane]
-resolves_phase: ""
-folded_into: "v1.8 spec §18 — CF-8 (P8 SafetyController + P1 core/enums)"
+resolves_phase: "P1"
+folded_into: "v1.8 spec §18 — CF-8 (P1 core/enums HaltReason [CFG-05] + P7 SafetyController consumes it); renumbered post-P4-merge"
 ---
 
 # Session-start baseline guard halts with an off-vocabulary reason `'baseline-residual'` (WR-04)

--- a/.planning/todos/pending/okx-markets-map-freshness-delisting-detection.md
+++ b/.planning/todos/pending/okx-markets-map-freshness-delisting-detection.md
@@ -4,7 +4,8 @@ created: "2026-07-07"
 source: Phase 07 CR-01 design discussion (tiziaco, 2026-07-07) — delisting-guard gap surfaced while scoping the CR-01 retry policy
 tags: [live, universe, okx, markets, delisting, validate_symbol, D-06, freshness, removal-path, universe-policy, next-milestone]
 milestone_target: "v1.8"
-folded_into: "v1.8 spec §18 — CF-9 (P6 venue registry / validate_symbol-on-exchange)"
+resolves_phase: "P5"
+folded_into: "v1.8 spec §18 — CF-9 (P5 venue registry / validate_symbol-on-exchange); renumbered post-P4-merge"
 ---
 
 # OKX markets-map freshness for mid-session delisting detection (validate_symbol / D-06)

--- a/.planning/todos/pending/okx-markets-map-freshness-delisting-detection.md
+++ b/.planning/todos/pending/okx-markets-map-freshness-delisting-detection.md
@@ -1,9 +1,10 @@
 ---
-status: deferred
+status: scheduled
 created: "2026-07-07"
 source: Phase 07 CR-01 design discussion (tiziaco, 2026-07-07) — delisting-guard gap surfaced while scoping the CR-01 retry policy
 tags: [live, universe, okx, markets, delisting, validate_symbol, D-06, freshness, removal-path, universe-policy, next-milestone]
-milestone_target: "next (post-v1.7)"
+milestone_target: "v1.8"
+folded_into: "v1.8 spec §18 — CF-9 (P6 venue registry / validate_symbol-on-exchange)"
 ---
 
 # OKX markets-map freshness for mid-session delisting detection (validate_symbol / D-06)

--- a/.planning/todos/pending/pair-strategy-live-reconfiguration.md
+++ b/.planning/todos/pending/pair-strategy-live-reconfiguration.md
@@ -1,9 +1,10 @@
 ---
-status: open
+status: scheduled
 created: "2026-07-07"
 source: surfaced in v1.7 Phase 7 07-REVIEW.md CR-01 discussion (StrategyCommandEvent vs PairStrategy 2-ticker contract)
-tags: [strategy, pair-strategy, universe, readiness, live-control-plane, operator-command, deferred, next-milestone, phase-7-tie-in]
-resolves_phase: ""
+tags: [strategy, pair-strategy, universe, readiness, live-control-plane, operator-command, next-milestone, phase-7-tie-in]
+resolves_phase: "P10"
+folded_into: "v1.8 STRAT-03 (P10 Strategies Registry) — atomic runtime param reconfiguration; brought in-scope by owner decision 2026-07-09 (was spec §18 'not folded / deferred to ★-trimmable P11')"
 ---
 
 # PairStrategy live reconfiguration — atomic ordered-pair leg swap (the "correct B" for CR-01)

--- a/.planning/todos/pending/v17-residual-carryforward.md
+++ b/.planning/todos/pending/v17-residual-carryforward.md
@@ -4,7 +4,7 @@ created: "2026-07-07"
 source: v1.7 milestone-close disposition sweep of the Phase-5 remediation roadmap (v17_bugs / v17_audit_results / v17_arch_decisions / v17_widen_audit_architecture)
 tags: [live, carry-forward, v1.8, circuit-breaker, resilience, observability, docs, refactor]
 resolves_phase: ""
-folded_into: "v1.8 spec §18 — CF-1…CF-7 (§1→P9, §2→P8, §3→P6, §4→P6/§8f, §5→P9, §6→P1, §7→P8)"
+folded_into: "v1.8 spec §18 — CF-1…CF-7, MULTI-PHASE (§1/CF-1→P8, §2/CF-2→P7, §3/CF-3→P5, §4/CF-4→P5§8f, §5/CF-5→P8, §6/CF-6→P1, §7/CF-7→P7); renumbered post-P4-merge — resolves_phase left empty (spans 5 phases; verify each CF item at its owning phase)"
 ---
 
 # v1.7 residual carry-forward — 7 open deliverable/refactor/doc gaps

--- a/.planning/todos/pending/v17-residual-carryforward.md
+++ b/.planning/todos/pending/v17-residual-carryforward.md
@@ -1,9 +1,10 @@
 ---
-status: open
+status: scheduled
 created: "2026-07-07"
 source: v1.7 milestone-close disposition sweep of the Phase-5 remediation roadmap (v17_bugs / v17_audit_results / v17_arch_decisions / v17_widen_audit_architecture)
 tags: [live, carry-forward, v1.8, circuit-breaker, resilience, observability, docs, refactor]
 resolves_phase: ""
+folded_into: "v1.8 spec §18 — CF-1…CF-7 (§1→P9, §2→P8, §3→P6, §4→P6/§8f, §5→P9, §6→P1, §7→P8)"
 ---
 
 # v1.7 residual carry-forward — 7 open deliverable/refactor/doc gaps

--- a/.planning/todos/pending/warmup-depth-max-concerned-strategy.md
+++ b/.planning/todos/pending/warmup-depth-max-concerned-strategy.md
@@ -1,9 +1,41 @@
+---
+status: scheduled
+created: "2026-07-06"
+source: Phase 7 (v1.7 Live Dynamic-Universe Hardening) plans 07-06 / 07-07 — deferred seam
+tags: [live, warmup, universe, bar-feed, depth-hint, strategies-handler, seam-only, phase-7-tie-in]
+folded_into: "v1.8 spec §18 — CF-10 (P7, seam-only — see 'What v1.8 P7 does now' below)"
+---
+
 # Deferred seam: max-across-concerned-strategies warmup depth (K)
 
 **Deferred from:** Phase 7 (Live Dynamic-Universe Hardening), plans 07-06 / 07-07.
 **Captured:** 2026-07-06
+**Folded into v1.8 as CF-10 (P7), seam-only — 2026-07-08.**
 
-## What
+## What v1.8 P7 does NOW (seam-only — resume point for later)
+
+**Scope locked at fold (CF-10, seam-only):** P7 is already rehoming `_LiveWarmupConsumer` →
+`StrategyWarmupConsumer` and rewriting `UniverseHandler` init (`_initialize_live_session` →
+`SessionInitializer`) — i.e. it rebuilds the exact wiring this seam plugs into. So P7 **shapes the
+depth-hint interface** while it is in that code, but does **NOT** change the behavioural K computation
+(no roster exercises it today — see "Why deferred" below).
+
+**P7 delivers (the seam):**
+- A depth-hint **interface** on `StrategiesHandler` — e.g. `warmup_depth_hint(symbol) ->
+  max(strategy.warmup for strategies concerned with symbol)` — designed but **not yet consumed** to
+  change fetch depth. Shape it so the future consumer is a one-line wire-up, not a re-plumb.
+- Thread that seam through `SessionInitializer` / `UniverseHandler` construction (the new composition
+  root), so the hint is *available* at the point the add-branch K is computed.
+- The add-branch K stays `cache_capacity() + _WARMUP_MARGIN` (unchanged, byte-for-byte behaviour).
+
+**P7 does NOT do (resume here when the trigger lands):**
+- Step 3 below — changing the K computation to `max(cache_capacity(), depth_hint(sym)) +
+  _WARMUP_MARGIN`. That is the only behavioural change and it waits for a real deeper-warmup roster.
+
+When you pick this up later, the seam + composition wiring already exist; you only implement the
+`max(...)` swap in the add-branch and add a test for a divergent-warmup roster.
+
+## What (original TODO — full deferred design)
 
 Phase 7's async warmup fetches `K = cache_capacity() + _WARMUP_MARGIN` bars per added symbol
 (`live_bar_feed.py:252-253`, `_WARMUP_MARGIN = 5`). When a single symbol is shared by MULTIPLE strategies

--- a/.planning/todos/pending/warmup-depth-max-concerned-strategy.md
+++ b/.planning/todos/pending/warmup-depth-max-concerned-strategy.md
@@ -3,7 +3,8 @@ status: scheduled
 created: "2026-07-06"
 source: Phase 7 (v1.7 Live Dynamic-Universe Hardening) plans 07-06 / 07-07 — deferred seam
 tags: [live, warmup, universe, bar-feed, depth-hint, strategies-handler, seam-only, phase-7-tie-in]
-folded_into: "v1.8 spec §18 — CF-10 (P7, seam-only — see 'What v1.8 P7 does now' below)"
+resolves_phase: "P6"
+folded_into: "v1.8 spec §18 — CF-10 (P6 LiveRunner/SessionInitializer, seam-only); renumbered post-P4-merge"
 ---
 
 # Deferred seam: max-across-concerned-strategies warmup depth (K)

--- a/docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md
+++ b/docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md
@@ -1,0 +1,641 @@
+# v1.8 — Live System Refactor & Live-Readiness Hardening — Milestone Design Spec
+
+- **Date:** 2026-07-07
+- **Status:** DRAFT (brainstorm output; seeds `/gsd:new-milestone`, not yet promoted to a roadmap)
+- **Milestone:** v1.8 — Live-Readiness Hardening (branch `v1.8/initialise-milestone`)
+- **Predecessor:** v1.7 — Live Trading Readiness (paper-first OKX live path around the same event graph)
+- **Deliverable of this doc:** a milestone-level design GSD can decompose into phases.
+
+> Decision tags are written `LR-NN` (Live-Readiness). They were **locked during the brainstorming
+> session that produced this doc** and are citable by downstream GSD plans. Per-phase specifics
+> (exact signatures, table columns, OKX API mechanics) firm up at `/gsd:plan-phase` time.
+
+---
+
+## 1. North Star & scope posture
+
+**Core value:** turn `itrader/trading_system/live_trading_system.py` — a 2,171-line God object owning
+~17 distinct concerns — into a **clean, decomposed, venue-parametrized, FastAPI-ready live engine**,
+without disturbing the byte-exact backtest oracle (`final_equity 46189.87730727451`) or the import
+inertness gate (`tests/integration/test_okx_inertness.py`).
+
+**End state (LR-00):** a thin `LiveTradingSystem` facade (~200 lines) over focused, independently
+testable collaborators; every venue/exchange/data-provider fully parametrized (zero
+`if self.exchange == ...`); one centralized config; storage owned by handlers; a two-tier priority
+event bus; a durable runtime-config platform; multi-portfolio-live; and all test-only replay
+machinery removed from production.
+
+### In scope
+- Full decomposition of `LiveTradingSystem` into a factory + shared `compose_engine` + `LiveRunner`
+  + focused controllers (Sections 5–11).
+- Config centralization into one `SystemConfig` (system-wide) + per-instance configs (Section 6).
+- Storage initialization moved into the handlers, for **both** live and backtest (Section 7).
+- Two-registry venue system (execution venue + data provider), venue bundles, plugins (Section 8).
+- Two-tier priority `EventBus` + a single-writer engine-thread threading contract (Section 4).
+- Full runtime-config platform: durable stores, scoped config-update events, allowlist (Section 6/9).
+- Strategies registry (durable, survives restart) (Section 9).
+- Multi-strategy / multi-portfolio live with per-`account_id` venue accounts (Section 10).
+- Safety subsystem extraction (halt/pause/status/reconciliation) (Section 11).
+- Error subsystem (`ErrorPolicy` + `ErrorHandler`) (Section 12).
+- Test migration: replay driver → `tests/` fixture; production replay-free (Section 13).
+
+### Explicitly out of scope (this milestone)
+- **The FastAPI application layer itself (LR-01).** This milestone makes the engine *interfacable* —
+  clean control/query seams, event-driven ingress, centralized config — but ships **no** FastAPI app,
+  routes, or ASGI code. FastAPI is a downstream consumer milestone.
+- Deferred/marked seams enumerated in Section 14 (multi-provider feed-router, shared-`account_id`
+  risk allocator, audit/history tables, single-connector-multi-account optimization).
+
+---
+
+## 2. Scope-shaping decisions locked this session
+
+| Tag | Decision | Rationale |
+|-----|----------|-----------|
+| LR-01 | **Prepare the surface only** — no FastAPI app built here | Decouples the engine hardening from web concerns; FastAPI consumes stable seams later. |
+| LR-02 | **Oracle may re-baseline if justified**, but byte-exact is the *default target* | Relocating config values must not change results; any real re-baseline is gated on external cross-validation (backtesting.py + backtrader), never silent. |
+| LR-03 | **Design for multi-strategy / multi-portfolio live now** | Pulls per-portfolio `VenueAccount` keying into scope; removes the "at most one active portfolio" guard. |
+| LR-04 | **Full runtime-config platform now** | Durable config table, scoped config-update events, validation/allowlist, stats persistence. |
+
+---
+
+## 3. Architectural decisions locked this session
+
+| Tag | Decision |
+|-----|----------|
+| LR-10 | **Decomposition approach A + the threading-safe slice of C**: mirror the proven backtest 4-layer split (`SystemSpec` → factory → shared `compose_engine` → `LiveRunner` → thin facade), extract live concerns into focused controllers, and event-ify the control plane only where threading-safe. |
+| LR-11 | **Two-tier priority `EventBus`** (`CONTROL` > `BUSINESS`), single consumer, unbounded-but-monitored; the connector→engine flag side-channel is folded into `CONTROL` events. |
+| LR-12 | **Single-writer engine-thread contract** (Section 4b) governs all state mutation. |
+| LR-13 | **Handler-owns storage init** from `(environment, sql_spine)` with an optional `storage=` override — following the existing `PortfolioHandler` pattern — for **both** live and backtest. |
+| LR-14 | **`EngineContext`** carries the shared infra (`bus`, `config`, `environment`, `sql_spine`), threaded once into `compose_engine`. Infra-only; never a god-parameter. |
+| LR-15 | Environment is a **factory constant** (`build_live_system` vs `build_backtest_system`), not a global read; handlers keep an explicit `environment` param for test isolation. |
+| LR-16 | **No `LiveEventHandler` subclass.** Keep the single data-driven `EventHandler`; add live routes via a declarative `LiveRouteRegistrar` (no runtime `routes` mutation). |
+| LR-17 | **Two registries** — `ExecutionVenueRegistry` + `DataProviderRegistry` — paired by the spec; connectors memoized by `(venue, account_id)`. |
+| LR-18 | **`SqlBackend` → `SqlSpine`** rename; param/field name `sql_spine`. Migrations relocate to the project-root `migrations/` (out of the shipped package). |
+| LR-19 | **`clOrdId` → `client_order_id`** (venue↔engine correlation), distinct from `portfolio_id` (attribution). |
+| LR-20 | **`account_id`** is the account key (drop "sub-account" jargon); each `account_id` is a full venue account with its own credentials/balance/positions. |
+| LR-21 | Config lives with the thing it configures, **at that thing's cardinality**; per-instance configs persist via the instance's own store. |
+| LR-22 | **One `system_store`** (key-value) for system-wide config overrides + operational state + latest stats. A separate `VenueStore` and `StrategyRegistryStore` for the cardinality-N concerns. No audit table (deferred). |
+
+---
+
+## 4. Event bus & threading model
+
+### 4a. The bus (LR-11)
+
+A small `EventBus` Protocol (`itrader/events_handler/bus.py`) with two implementations sharing one
+`.put(event)` surface so `compose_engine` is bus-agnostic:
+
+- **`FifoEventBus`** — thin wrapper over `queue.Queue`. Used by **backtest** → byte-exact, zero oracle
+  risk. Backtest keeps its synchronous `process_events()` drain unchanged.
+- **`PriorityEventBus`** — `queue.PriorityQueue` keyed `(tier, seq, event)`:
+  - `tier ∈ {CONTROL=0, BUSINESS=1}`, assigned by `.put()` from a declarative `_CONTROL_EVENT_TYPES`
+    frozenset (handlers still just call `bus.put(event)`; the bus assigns the tier — no `.put`
+    call-site changes across handlers).
+  - `seq` = monotonic `itertools.count()` (thread-safe). **The unique `seq` guarantees the tuple
+    comparison never falls through to the event** (frozen event dataclasses aren't orderable) and
+    preserves strict FIFO *within* a tier.
+
+Protocol surface: `put`, `get(timeout)`, `get_nowait`, `qsize`, `empty`, `depth_by_tier` (for
+monitoring — unbounded-but-watched).
+
+**Tier assignment** (finalize in P2):
+- **CONTROL** (preempts market data): `STREAM_STATE`, `CONNECTOR_FATAL`, `CONFIG_UPDATE`,
+  `STRATEGY_COMMAND` — safety + operator/config, low volume, latency-sensitive.
+- **BUSINESS** (causal trading flow, strict FIFO): `BAR`, `SIGNAL`, `ORDER`, `FILL`, `UNIVERSE_*`,
+  `BARS_*`, `ERROR`, `PORTFOLIO_UPDATE`. Externally-injected `SIGNAL`s stay BUSINESS (they must
+  interleave in order with bars/fills to keep position state consistent — control priority is for
+  *operational* commands, not trading intents).
+
+**Determinism note:** determinism is a *backtest* concern; live events already arrive in
+non-deterministic wall-clock order. Backtest byte-exactness comes from `BacktestRunner` +
+`process_events()` over a `FifoEventBus`, which never touches the live bus. So the priority bus
+carries **zero oracle risk**.
+
+### 4b. Single-writer engine-thread contract (LR-12)
+
+1. **All engine/handler state mutation happens on the one engine thread** (the `LiveRunner` drain).
+2. **The connector asyncio loop does only venue I/O and `bus.put()`** — never touches handler state,
+   never blocks. Fills/bars → BUSINESS; stream-up/down + connector-fatal → CONTROL events (this is
+   where the old flag side-channel goes).
+3. **External/web threads never call handler methods** — they either `bus.put()` (trading intents,
+   config, commands) or call thin thread-safe facade methods that are pure status-latch/lifecycle
+   (`halt/pause/reset/get_status/start/stop`).
+4. **Blocking venue I/O triggered by a stream event** (resume snapshot, reconcile, durable halt
+   write) runs on the **engine thread**, inside the CONTROL-event handler — never on the connector
+   loop.
+
+### 4c. The two loops (kept) and the third mechanism (deleted)
+
+- The **connector asyncio loop** (its own daemon thread) stays — `ccxt.pro` streaming is async and
+  must never block. The **engine thread** stays — synchronous single-writer business logic. The
+  **queue is the bulkhead** between them. Collapsing to one loop (all-async or all-sync) is a
+  high-risk rewrite that breaks backtest/live parity — rejected.
+- The **flag side-channel** (`_pending_stream_resume`, `_pending_connector_halt`,
+  `_maybe_resume_after_reconnect`, `_maybe_halt_after_connector_fatal`, and the `queue.Empty`-branch
+  polling) is **deleted** — replaced by CONTROL-plane events that wake `bus.get()` naturally.
+
+---
+
+## 5. Module topology & layering (LR-10)
+
+```
+SystemSpec  (declarative, mode-agnostic)                         [exists]
+    │
+build_live_system(spec)  — live factory / composition root       [NEW]
+    │   reads centralized SystemConfig; builds the ONE sql_spine (live only);
+    │   resolves venue plugin(s); assembles EngineContext; calls compose_engine;
+    │   builds venue bundle(s); registers exchange + provider; builds LiveRunner + controllers
+    ▼
+compose_engine(ctx, spec)  — shared seam         [MODIFIED: takes EngineContext]
+    │   builds the component graph (handlers own their storage) → Engine holder
+    ▼
+LiveRunner  — the live driver                    [NEW: replaces _event_processing_loop]
+    │   owns the drain loop + injected ErrorPolicy + worker supervision
+    ▼
+LiveTradingSystem  — thin facade                 [SHRUNK ~200 lines]
+        lifecycle (start/stop), status/read-model, add_event; delegates everything else
+```
+
+**New live-only collaborators** (each independently testable):
+
+| Collaborator | Owns | Extracted from |
+|---|---|---|
+| `EventBus` (`FifoEventBus`/`PriorityEventBus`) | tiered `.put()` routing | the raw `global_queue` |
+| `LiveRunner` | drain loop + publish-and-continue + workers | `_event_processing_loop` |
+| `ExecutionVenueRegistry` + `DataProviderRegistry` + `VenuePlugin` | venue bundles (lazy) | every `if self.exchange==...` |
+| `SafetyController` | status latch, halt/pause, deferred-protective queue, dispatch gate | `halt/pause/resume/_update_status/_dispatch_live` |
+| `StreamRecoveryHandler` | reconnect resume I/O (catch-up + snapshot + health gate) | `_maybe_resume_after_reconnect` |
+| `ReconciliationCoordinator` | rehydrate → reconcile → baseline guard | the `start()` reconcile block |
+| `WorkerSupervisor` | timer workers (poll timer, future) | `_run_poll_timer` |
+| `SessionInitializer` (+ shared `UniverseWiring`) | membership/universe/route wiring | `_initialize_live_session` |
+| `ErrorPolicy` + `ErrorHandler` | handler-failure policy + ERROR-route consumer | `_publish_and_continue`/`_log_error_event` |
+| `SystemStore` / `VenueStore` / `StrategyRegistryStore` | new durable tables | (new) |
+| `LiveDataProvider` Protocol | formal provider contract | reconciles OKX/Replay asymmetry |
+
+**Route registration (LR-16):** each handler/controller declares the routes it owns; the live
+factory composes them into the single `EventHandler` via `LiveRouteRegistrar` at construction. No
+runtime `routes` mutation, no subclass. Backtest's `EventHandler` gets base routes only (inertness).
+
+**Exchange sub-registry:** `ExecutionHandler` stays the exchange register (`register_exchange(name,
+exchange)`; `on_order` already routes by `event.exchange`). The `VenueRegistry` owns the full 4-way
+bundle and distributes the exchange into `ExecutionHandler` and the provider into the feed.
+
+---
+
+## 6. Config centralization & the config platform (points 21–24, LR-04/LR-21/LR-22)
+
+### 6a. Centralized `SystemConfig` (import-safety split)
+
+`SystemConfig` today aggregates only `performance`+`monitoring`. Extend it, split by import-safety:
+
+- **Eager fields** (plain `BaseModel`, safe defaults, no env I/O): `performance`, `monitoring`,
+  `runtime` (`Settings`), plus **default templates** for the per-instance configs.
+- **Lazy accessor**: `sql` (`SqlSettings`) — its Postgres arm *raises* without a credential, so it is
+  resolved on **first access** (cached property/method), never at import → inertness stays green.
+- **Stays out of global config**: `OkxSettings` and any venue credentials — **per-venue,
+  credential-required, per-`account_id`**, owned by the venue plugin (constructed only when the venue
+  is selected). Never persisted to any store.
+
+### 6b. Config lives with its owner, at its cardinality (LR-21)
+
+- **System-wide singletons (cardinality 1)** → `SystemConfig`: `performance` (rng_seed),
+  `monitoring`, `runtime`, `sql`, and `order` (one `OrderHandler`).
+- **Per-instance configs (cardinality N)** → owned by the instance, **seeded from a default
+  template**, **persisted via that instance's own store**:
+  - `PortfolioConfig` → `Portfolio` → **portfolio store** (extend `portfolio_account_state`).
+  - `ExchangeConfig` (per venue) → `VenueStore` under `venue.<name>.*`.
+
+### 6c. Two config objects (LR-14)
+
+- `itrader.config` (root `__init__.py`) = **immutable base defaults** — import-safe; what modules read
+  via `from itrader import config`; what backtest uses unchanged.
+- A per-system **`RuntimeConfig` overlay** the live factory builds = `defaults ← YAML ← env ←
+  persisted runtime overrides`, injected as `EngineContext.config`. **Engine-thread-write,
+  snapshot-read.** Handlers read this so they see runtime changes.
+
+### 6d. The `system_store` (LR-22)
+
+One key-value table `(key, value_json, updated_at)`, namespaced keys, upsert:
+
+```
+config.monitoring.poll_cadence   state.last_started_at   stats.snapshot
+order.trail_type                 state.last_error        state.status / state.halt_reason
+```
+
+Holds system-wide config overrides + operational state + the **latest** stats snapshot (doubles as
+the UI read model — the UI reads `state.*`/`stats.*` without touching hot-path locks). Distinct from
+`halt_records` (which keeps its specialized latch semantics). **No `system_config_audit`** (deferred).
+
+### 6e. Runtime-mutation flow (scoped)
+
+```
+POST /config/{scope}/{key}  (FastAPI, later)
+  → validate against ALLOWLIST of runtime-mutable keys  +  type/range check
+  → ConfigUpdateEvent(scope, key, value)  →  CONTROL plane
+  → engine-thread handler:  route to owner (system→SystemStore, portfolio:{id}→that Portfolio +
+        portfolio store, venue:{name}→VenueStore, order→SystemStore); apply to RuntimeConfig overlay
+        + relevant handler.update_config(...); persist
+  → on restart: build_live_system layers persisted overrides over defaults  ⇒ survives restart
+```
+
+`scope ∈ {system, portfolio:{id}, venue:{name}, order}`. **Immutable-at-runtime**: `rng_seed`, money
+precision, SQL credentials, `environment`, IDs. **Mutable (examples)**: fee/slippage params, poll
+cadence, `universe_remove_policy`, idle/timeout knobs, risk limits, strategy enable/disable.
+
+### 6f. Cleanup (point 21)
+
+Fold scattered module constants into their domain config: triple-duplicated `_STREAM_RECONNECT_*` →
+a `StreamSettings`/`ConnectionSettings` block (consumed by the shared `StreamSupervisor`);
+`_WARMUP_MARGIN`/`_BACKFILL_PAGE` → feed/provider config; `_OKX_*`/`_PAPER_*` deleted. Dead-config
+audit (remove unused settings + stale `__pycache__`). Normalize `extra` policy.
+
+---
+
+## 7. Storage-in-handler, `EngineContext` & durable stores (point 20, LR-13/LR-14)
+
+### 7a. `EngineContext`
+
+```python
+@dataclass(frozen=True)
+class EngineContext:
+    bus:         EventBus
+    config:      RuntimeConfig            # the overlay (6c)
+    environment: str                      # resolved by the factory (LR-15)
+    sql_spine:   Optional[SqlSpine]       # None on the in-memory path (LR-18)
+```
+
+Infra-only, threaded once into `compose_engine`, which hands each handler only what it needs.
+
+### 7b. Handler-owns init (LR-13)
+
+```python
+OrderHandler(..., *, environment='backtest', sql_spine=None, storage=None)
+    → self.storage = storage or OrderStorageFactory.create(environment, backend=sql_spine)
+```
+
+Order + Strategies handlers adopt `PortfolioHandler`'s existing shape. `compose_engine` reads the
+concrete instance back off `.storage` for the `portfolio_handler.set_order_storage(...)` wiring.
+Backtest (`environment='backtest', sql_spine=None`) → same in-memory instances → byte-exact. Factory
+SQL imports stay lazy → inertness green.
+
+### 7c. Two storage tiers
+
+- **Handler working-set storage** (order/signal/portfolio) → **handler-owned** (this is what point 20
+  was about).
+- **System-level registry/state stores** (halt, system, venue, strategy-registry) → **composition-root
+  infrastructure** over the shared `sql_spine` (exactly like `HaltRecordStore` today); built by the
+  factory and handed to the controllers that use them.
+
+### 7d. Cardinality-aligned stores (LR-22)
+
+| Store | Cardinality | Holds | Secrets |
+|---|---|---|---|
+| `SystemStore` | 1 | system-wide config overrides + operational state + latest stats | — |
+| `VenueStore` *(new)* | N venues | per-venue config + which venues are enabled | **never** (creds in env) |
+| `StrategyRegistryStore` *(new)* | N strategies | which strategies trade + per-strategy config | — |
+| Portfolio store | N portfolios | per-portfolio config + account state | — |
+| Order / Signal / Halt | — | (exist) | — |
+
+Each new store follows the `HaltRecordStore` template (composes `sql_spine`, own `build_*_table`
+registrar, chained Alembic migration). Chain: `d10_halt_records → system_store → venue_config →
+strategy_registry`.
+
+### 7e. Rename + migrations relocation (LR-18)
+
+`SqlBackend → SqlSpine` (mechanical: `storage/backend.py`, the three `storage_factory.py`,
+`migrations/env.py`, live wiring). Relocate `itrader/storage/migrations/` → project-root
+`migrations/` (update `alembic.ini` `script_location`; `env.py` keeps importing the `build_*_table`
+registrars + `NAMING_CONVENTION` from `itrader.storage`). Stays out of the shipped wheel; test-path
+`create_all` unaffected.
+
+---
+
+## 8. Venue registry & the 4-collaborator bundle (points 1, 6, 13, 14, 15, 16, 17, LR-17)
+
+### 8a. Bundle & plugin
+
+A venue is up to 4 collaborators sharing one connector; some are optional:
+
+```python
+@dataclass(frozen=True)
+class VenueBundle:
+    connector:     Optional[LiveConnector]     # okx: OkxConnector; paper/replay: None
+    exchange:      AbstractExchange            # okx: OkxExchange; paper/replay: the shared SimulatedExchange
+
+class ExecutionVenuePlugin(Protocol):
+    name: str
+    connector_key: Optional[str]               # for connector memoization by (venue, account_id)
+    def build_bundle(self, *, ctx, spec, connector, simulated_exchange) -> VenueBundle: ...
+    def new_account(self, *, portfolio_ref, config) -> Account: ...        # MANDATORY per-portfolio factory
+```
+
+- Each plugin **lazy-imports its concretions inside `build_bundle`** → registering `'okx'` never
+  pulls `ccxt.pro` until built (inertness).
+- **Account factory (mandatory, per-portfolio)** — not a single Optional instance. `okx` → a
+  `VenueAccount` keyed by `portfolio.account_id`; `paper`/`replay` → a fresh
+  `SimulatedCashAccount`/`SimulatedMarginAccount` per portfolio. (See Section 10.)
+- **Precision + validation are exchange capabilities** — `resolve_precision(symbol)` and
+  `validate_symbol(symbol)` on `AbstractExchange` (OKX implements over ccxt markets; `SimulatedExchange`
+  → `None`/accept-all). `_OkxPrecisionResolver` / `_PrecisionResolver` / the passed-around resolver
+  **vanish**; `_precision_to_scale` → a shared money util.
+
+### 8b. `DataProviderRegistry` + `LiveDataProvider` Protocol
+
+- The data provider is a **separate selection** from the execution venue (`SystemSpec` names both:
+  `execution_venue` + `data_provider`). Enables `paper`+`okx-data`, `paper`+`replay`, `okx`+`okx-data`,
+  or an existing provider backing a Simulated venue.
+- **`LiveDataProvider` Protocol**: required core (`set_bar_sink`, `fetch_ohlcv_backfill`) + optional
+  streaming seams (`set_global_queue`, `set_halt_signal`, `set_stream_state_listener`,
+  `subscribe`/`unsubscribe`, `spawn_warmup`). A `BaseLiveDataProvider` gives **no-op defaults** for the
+  optional seams so the factory wires every provider uniformly (no `hasattr` sprinkling). OKX overrides
+  all; Replay overrides only core.
+
+### 8c. Connector memoization (LR-17/LR-20)
+
+A lazy `dict[(venue, account_id), LiveConnector]` at the composition root: any collaborator declaring
+it needs a given `(venue, account_id)` connector gets the same one. Handles sharing (okx-exec +
+okx-data share one) and decoupling (paper-exec + okx-data uses a data-only connector; paper+replay =
+no connector) without a combinatorial matrix. Credentials are per-`account_id` (env-sourced).
+
+### 8d. Uniform seam-wiring + lifecycle orchestrator (points 6, 11, 12)
+
+- **Uniform wiring**: every bundle member exposing `set_halt_signal` → the CONTROL `ConnectorFatalEvent`
+  emitter; every stream arm exposing `set_stream_state_listener` → the CONTROL `StreamStateEvent`
+  emitter. No per-venue hand-wiring block.
+- **One `VenueLifecycle` orchestrator** encodes the fixed order and **None-guards absent members** (so
+  paper/replay skip connector/account steps naturally — no `exchange=='okx'` branching):
+
+```
+start:  connector.connect?  →  per member symbol: feed.warmup → provider.subscribe?
+     →  exchange.connect (check .success)
+     →  account.snapshot? → account.start_streaming? → link account→portfolio(s)
+     →  ReconciliationCoordinator: rehydrate → reconcile? → baseline guard
+stop:   connector.disconnect?  →  sql_spine.dispose?
+```
+
+The reconcile step keys on **account *kind*** (`VenueAccount` = venue-truth → reconcile;
+`SimulatedAccount` = compute → restore-only), not `exchange=='okx'`.
+
+### 8e. Paper vs replay
+
+- **`paper` = first-class production venue plugin**: `SimulatedExchange` (simulated fills) + a *live*
+  market-data provider (real streaming bars). The registry **aliases** the built-in `SimulatedExchange`
+  under `paper` (like `csv` aliases `simulated` today).
+- **`replay` = test-only plugin**: `SimulatedExchange` + `ReplayDataProvider` (golden CSV), registered
+  **only** by a test fixture. `run_paper_replay` + `PAPER_PARITY_*`/`_PAPER_*` leave production
+  (Section 13).
+
+### 8f. Shared `StreamSupervisor`
+
+Extract the reconnect supervisor (`_run_stream_supervisor` + `_STREAM_RECONNECT_*` duplicated verbatim
+in `okx.py`, `okx_provider.py`, `venue.py`) into one shared implementation the three arms compose.
+
+---
+
+## 9. Strategies registry (point 18)
+
+`StrategyRegistryStore` (cardinality N) persists which strategies are **active** + config +
+subscriptions (which portfolios). On restart `build_live_system` rehydrates it → re-registers active
+strategies (survives restart). Runtime add/remove/enable/disable via `STRATEGY_COMMAND` (CONTROL) →
+`StrategiesHandler` applies + persists. The strategy analog of venue enablement.
+
+---
+
+## 10. Multi-strategy / multi-portfolio-live (LR-03/LR-19/LR-20)
+
+### 10a. Cardinality model
+
+```
+strategy ⇄ portfolios   (M:N — a strategy drives many portfolios; a portfolio hosts many strategies)
+portfolio ──has one──▶ Account (keyed by account_id)   ;   venue-truth account_id = one venue account
+```
+
+- **Many strategies → one portfolio → one account**: supported (shared buying power, engine-side,
+  deterministic; existing `subscribe_portfolio`).
+- **Many portfolios → many accounts, each a distinct `account_id`**: supported. A signal **fans out**
+  to each subscribed portfolio; each sizes/orders **independently against its own account** (so one
+  strategy can trade across multiple accounts at once). The venue partitions balance/positions/fills
+  by `account_id`.
+- **Not supported (deferred, fail-loud)**: multiple portfolios sharing one venue `account_id` (pooled
+  buying power the venue can't split back out — needs a risk-allocator subsystem). Express "many
+  strategies, shared account" as many strategies on **one** portfolio.
+
+### 10b. Per-portfolio account minting
+
+The venue plugin's `new_account(portfolio_ref, config)` mints per portfolio: venue-truth →
+`VenueAccount` scoped to `portfolio.account_id`; compute → a fresh `SimulatedAccount`.
+`_link_venue_account_to_portfolios` + its `RuntimeError(>1)` guard are **deleted**, replaced by
+per-portfolio minting + a **distinct-`account_id` invariant** (fail loud). `PortfolioSpec` gains
+`account_id`.
+
+### 10c. Attribution & reconciliation
+
+- `client_order_id` (LR-19) does venue↔engine correlation; `portfolio_id` does attribution. Every
+  submitted order is tagged with its portfolio; fills route via
+  `client_order_id`/`venue_order_id` → engine order → `FillEvent(portfolio_id)` → the right
+  `Portfolio.on_fill`. Each per-`account_id` `VenueAccount` holds *its* portfolio's balance/position
+  truth.
+- The `ReconciliationCoordinator` **iterates active portfolios**, reconciling each against its own
+  `VenueAccount`/`account_id` (rehydrate → `VenueReconciler` → baseline guard).
+
+---
+
+## 11. Safety subsystem & reconciliation (points 11, 12)
+
+### 11a. `SafetyController` (pure state machine)
+
+Owns everything with no venue I/O (unit-testable in isolation): the status latch (`_status` +
+`_status_lock` + `VALID_STATUS_TRANSITIONS` + the single `update_status` seam, `force=` reserved for
+`reset_halt`); `halt(reason)` (winner-only check-and-set → CRITICAL `ErrorEvent` → durable
+`HaltRecordStore.record_halt`); `is_halted`/`reset_halt`; `pause_submission`/`resume_submission`; the
+bounded deferred-protective queue + `replay_on_resume`; and the **dispatch gate**
+`gate_and_dispatch(event, dispatch_fn)` (the `_dispatch_live` logic with `dispatch_fn` =
+`event_handler._dispatch` injected by the `LiveRunner`).
+
+### 11b. Durable halt & startup refusal
+
+`safety.check_durable_halt_on_start()` runs **first** (before any venue I/O), refuses RUNNING inert on
+an unresolved durable record, and re-latches in-process from the persisted reason via `update_status`
+(not `halt()` — no second durable write).
+
+### 11c. Connector handoff → CONTROL routes (flag machinery deleted)
+
+| CONTROL event | Route → | Runs on |
+|---|---|---|
+| `StreamStateEvent(down)` | `SafetyController.pause_submission` | engine thread |
+| `StreamStateEvent(up)` | `StreamRecoveryHandler.on_reconnect` | engine thread |
+| `ConnectorFatalEvent(reason)` | `SafetyController.halt(reason)` | engine thread |
+
+`StreamRecoveryHandler` owns the I/O-heavy resume orchestration (which SafetyController must not do):
+`catch_up_missed_fills()` + `account.snapshot()` (engine thread) + all-streams-healthy gate (None arms
+= healthy) → `safety.resume_submission()` (triggers deferred-protective replay). Failed snapshot →
+stays paused.
+
+### 11d. `ReconciliationCoordinator`
+
+Owns the startup sequence (rehydrate → venue reconcile for venue-truth accounts → baseline guard),
+invoked by the `VenueLifecycle` orchestrator; iterates portfolios (Section 10c).
+
+### 11e. Facade cleanup (points 8, 25)
+
+Drop legacy `print_status` and `get_statistics`. `LiveTradingSystem.__init__` sheds most params
+(`exchange`/`to_sql`/`queue_timeout`/`max_idle_time` come from config/spec now); the facade delegates
+`halt/pause/reset/status` to `SafetyController`.
+
+---
+
+## 12. Error handling (point 19)
+
+### 12a. `ErrorPolicy` — injected, not monkeypatched
+
+Inject the handler-failure policy into `EventHandler` at construction (removes the
+`event_handler._on_handler_error = ...  # type: ignore` reassignment): backtest/replay → **fail-fast**
+(re-raise; the parity gate can't false-green); live → **publish-and-continue**. Keeps **per-handler
+granularity** (a route is a list — one failing handler doesn't skip the rest). Carries the **WR-06
+source guard** (don't republish an `ErrorEvent` if the failing event was itself an `ERROR`).
+
+### 12b. `ErrorHandler` — the formalized ERROR-route consumer
+
+Severity-mapped structured logging; CRITICAL → the pluggable alert sink; persist latest error →
+`SystemStore state.last_error`; **WR-06 consumer guard** (swallows its own failures, never re-raises).
+Two-guard terminal safety (source guard + consumer guard). One error funnel: handler failures,
+`halt()` (CRITICAL), `PortfolioErrorEvent`, `ConnectorFatalEvent` → all through the ERROR route. A
+full errors-history table is a **marked seam** (deferred).
+
+---
+
+## 13. Session init & route registration (points 4, 10, 26)
+
+### 13a. `SessionInitializer` (+ shared `UniverseWiring`)
+
+Extract `_initialize_live_session` (the Trap-4 ordering). Pull the common
+`derive_membership → derive_instruments → build Universe → inject into exchange/order/portfolio/
+strategies → feed.bind` into a **shared `UniverseWiring` helper both modes call**, so the critical
+ordering lives once. **Oracle-sensitive** (see Section 15).
+
+### 13b. `UniverseHandler` proper init (point 10)
+
+Construct it at the **live composition root** as a first-class handler with explicit deps
+(`bus`, `universe`, `feed`, `config`) — not lazily at `start()`. **Zero OKX coupling**: symbol
+validation + precision come from the venue bundle's exchange via `set_venue_metadata(exchange)`
+(the Section 8a capabilities); the data-plane provider comes via the `LiveDataProvider` Protocol;
+timeframe/`remove_policy` from config; freeze gate from `SafetyController`.
+
+### 13c. `LiveRouteRegistrar` (LR-16)
+
+Declarative route composition (list order = execution order), no runtime mutation. The live route set
+includes `UNIVERSE_POLL`, `UNIVERSE_UPDATE`, `STRATEGY_COMMAND`, `BARS_LOADED` (strategies first,
+then universe), `BARS_LOAD_FAILED`, `FILL` (portfolio → order → universe), and the new CONTROL routes
+(`STREAM_STATE`, `CONNECTOR_FATAL`, `CONFIG_UPDATE`).
+
+### 13d. `_LiveWarmupConsumer` explained & rehomed (point 26)
+
+It's a minimal frozen `RawBarConsumer` (`required_history_depth`) that sizes the live feed's ring +
+warmup to the max strategy warmup; without it the ring collapses to the newest-bar floor (1),
+indicators never warm, and the run yields **zero trades**. Rehome to
+`price_handler/feed/cache_registration.py` as a reusable `StrategyWarmupConsumer`; `SessionInitializer`
+registers it sized to `max(s.warmup for strategies)`.
+
+---
+
+## 14. Deferred / marked seams (carried, not built)
+
+- **Multi-provider feed-router** — running multiple providers concurrently (crypto aggregator +
+  forex feed) needs the feed's `set_provider` to become a provider-router keyed by symbol/asset-class.
+  Single active provider per run for now; the two-registry decoupling *enables* the router.
+- **Single-connector-multi-`account_id` optimization** — OKX master key + per-account routing on one
+  session (vs one connector per `account_id`).
+- **Shared-`account_id` risk allocator** — multiple portfolios pooling one venue account.
+- **Config audit-trail table** (`system_config_audit`).
+- **Errors-history table**.
+- **Stats-history table split** (if periodic `stats.snapshot` upserts contend with config writes).
+
+---
+
+## 15. Constraints & risks
+
+- **Backtest oracle (LR-02)** — byte-exact (`46189.87730727451`) is the **blocking gate for every
+  foundational + universe-wiring phase** (P1–P4, P7's `UniverseWiring`). Any re-baseline is explicit
+  and cross-validated (backtesting.py + backtrader), never silent.
+- **Universe is shared with backtest** — the `Universe` value object + the `UniverseWiring` helper are
+  used by `BacktestRunner._initialise_backtest_session`. The refactor may only *extract* them if the
+  backtest path stays byte-identical. Only `UniverseHandler` (dynamic poll host + routes) is live-only;
+  its routes stay explicit-empty on the backtest `EventHandler` (proven by `test_okx_inertness`).
+- **Inertness gate** — `test_okx_inertness.py` stays green: registering venues imports no `ccxt.pro`
+  until a venue is *built*; `SystemConfig` never constructs Postgres `SqlSettings` at import (lazy
+  `sql`); `FifoEventBus`/`EngineContext(sql_spine=None)` pull nothing heavy on the backtest path.
+- **Indentation hazard** — handler modules use **tabs**; `config/`, `core/`, `price_handler/feed/`,
+  and `events_handler/events/` use **4 spaces**. Match the file; never normalize (a mixed-indentation
+  diff breaks a tab file).
+- **Money/determinism** — Decimal end-to-end; `rng_seed` immutable-at-runtime; injected clock.
+- **Secrets** — venue credentials stay in env-sourced `OkxSettings` (per `account_id`), never written
+  to any store; alert sink binds only declared `ErrorEvent` fields.
+
+---
+
+## 16. Phasing for GSD
+
+Sequenced by dependency. **Oracle-gated** = must stay byte-exact. **★** = the ambitious feature-adds
+(LR-03/LR-04) — the trim boundary; everything else is the core refactor.
+
+### Foundation — oracle-gated
+| # | Phase | Delivers | Depends |
+|---|---|---|---|
+| **P1** | Config centralization | `SystemConfig` aggregation (eager/lazy/templates), constant migration, dead-config audit, `extra` normalization | — |
+| **P2** | Event bus | `EventBus` Protocol + `FifoEventBus`/`PriorityEventBus`, injected into `compose_engine` (backtest→Fifo) | — |
+| **P3** | `EngineContext` + storage-in-handler | `EngineContext`, handler-owns init (Order/Strategies), `compose_engine` signature | P1 |
+| **P4** | `SqlSpine` rename + migrations relocation | `SqlBackend→SqlSpine`; `migrations/`→project root | P3 |
+
+### Durable stores — live-only (in-memory fallback keeps backtest untouched)
+| **P5** | New stores | `SystemStore`, `VenueStore`, `StrategyRegistryStore` (tables + registrars + migrations + rehydrate) | P4 |
+
+### Live decomposition — the core God-object teardown
+| **P6** | Venue registry + bundle | two registries, `VenuePlugin`/`VenueBundle`, `LiveDataProvider` Protocol, connector memoization, precision/validate on exchange, account factory, shared `StreamSupervisor` — kills every `if exchange==` | P2, P3 |
+| **P7** | `LiveRunner` + factory + facade shrink | `build_live_system`, `LiveRunner`, `SessionInitializer` + shared `UniverseWiring` *(oracle-sensitive)*, `LiveRouteRegistrar`, `UniverseHandler` proper init (pt 10), `StrategyWarmupConsumer` rehome, drop legacy `print_status`/`get_statistics`/`__init__` params (pts 8, 25) | P5, P6 |
+| **P8** | Safety + reconciliation + stream recovery | `SafetyController`, `ReconciliationCoordinator`, `StreamRecoveryHandler`, CONTROL routes — flag machinery deleted | P7 |
+| **P9** | Error subsystem | `ErrorPolicy` injected, `ErrorHandler` formalized, two-guard terminal safety | P7 |
+
+### Feature-adds — ★ trimmable
+| **P10 ★** | Runtime-config platform | SystemStore-backed overrides, scoped `ConfigUpdateEvent`, allowlist, restart layering, `RuntimeConfig` overlay, stats snapshot | P5, P8 |
+| **P11 ★** | Strategies registry | `StrategyRegistryStore` rehydrate, enable/disable via `STRATEGY_COMMAND`, survives restart | P5, P7 |
+| **P12 ★** | Multi-portfolio-live | per-`account_id` account factory, drop single-portfolio guard + distinct-`account_id` invariant, per-portfolio reconcile, connector keyed `(venue, account_id)`, `PortfolioSpec.account_id`, `clOrdId→client_order_id` | P6, P8 |
+
+### Test migration — essential, lands last
+| **P13** | Replay→fixture + gates | `run_paper_replay`→`ReplayRunner` in `tests/`, `replay` plugin fixture-registered, production replay-free; add live-smoke / config-restart / multi-portfolio gates | P7, P12 |
+
+**Trim boundary:** P1–P9 + P13 = the core refactor. P10–P12 (★) are the feature-adds — deferrable at
+milestone-init without destabilizing the core.
+
+---
+
+## 17. Mapping of the original 26 concerns
+
+| # | Concern | Addressed in |
+|---|---|---|
+| 1 | Exchange register + data-provider register | §8 (two registries; `ExecutionHandler` exchange sub-registry), P6 |
+| 2 | Remove `_okx_*` Optional attrs / different init | §8 (venue bundle), §5, P6/P7 |
+| 3 | Remove imports from `__init__`/methods | §8 lazy plugins, §13b, P6/P7 |
+| 4 | Live event handler | §5/§13c — `LiveRouteRegistrar`, no subclass (LR-16) |
+| 5 | Event loop elsewhere + kill cascading try/except | §4c/§5 `LiveRunner`, P7 |
+| 6 | Kill `if exchange=='okx'` | §8d `VenueLifecycle` None-guards, P6 |
+| 7 | Timer workers elsewhere | §5 `WorkerSupervisor`, P7 |
+| 8 | Remove `print_status`/`get_statistics` | §11e, P7 |
+| 9 | `run_paper_replay` → test fixture | §8e/§13, P13 |
+| 10 | `UniverseHandler` proper init, no OKX ref | §13b, P7 |
+| 11 | Stream up/down via events | §4b/§11c CONTROL events, P8 |
+| 12 | Halt logic elsewhere | §11a `SafetyController`, P8 |
+| 13 | `elif exchange=='paper'` gone | §8e paper plugin, P6/P13 |
+| 14 | Bar-sink logic mess | §8b `LiveDataProvider` + bundle wiring, P6 |
+| 15 | `_OkxPrecisionResolver` gone | §8a precision on exchange, P6 |
+| 16 | `_PAPER_*` vars gone | §8e/§13, P13 |
+| 17 | `_OKX_*` vars parametrized | §6f/§8a from config+membership, P1/P6 |
+| 18 | Strategies registry (survives restart) | §9, P11 |
+| 19 | Proper error handling | §12, P9 |
+| 20 | Storage init in the handler (both systems) | §7, P3 |
+| 21 | Centralized config, remove unused/global | §6, P1 |
+| 22 | Runtime config from UI via event, survives restart | §6d/§6e, P10 |
+| 23 | System stats in the store | §6d (`stats.snapshot`), P10 |
+| 24 | Centralized config importable from root | §6a/§6c, P1 |
+| 25 | Live `__init__` params not needed | §11e, P7 |
+| 26 | What is `_LiveWarmupConsumer` | §13d — rehomed `StrategyWarmupConsumer`, P7 |

--- a/docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md
+++ b/docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md
@@ -66,12 +66,12 @@ machinery removed from production.
 | LR-10 | **Decomposition approach A + the threading-safe slice of C**: mirror the proven backtest 4-layer split (`SystemSpec` → factory → shared `compose_engine` → `LiveRunner` → thin facade), extract live concerns into focused controllers, and event-ify the control plane only where threading-safe. |
 | LR-11 | **Two-tier priority `EventBus`** (`CONTROL` > `BUSINESS`), single consumer, unbounded-but-monitored; the connector→engine flag side-channel is folded into `CONTROL` events. |
 | LR-12 | **Single-writer engine-thread contract** (Section 4b) governs all state mutation. |
-| LR-13 | **Handler-owns storage init** from `(environment, sql_spine)` with an optional `storage=` override — following the existing `PortfolioHandler` pattern — for **both** live and backtest. |
-| LR-14 | **`EngineContext`** carries the shared infra (`bus`, `config`, `environment`, `sql_spine`), threaded once into `compose_engine`. Infra-only; never a god-parameter. |
+| LR-13 | **Handler-owns storage init** from `(environment, sql_engine)` with an optional `storage=` override — following the existing `PortfolioHandler` pattern — for **both** live and backtest. |
+| LR-14 | **`EngineContext`** carries the shared infra (`bus`, `config`, `environment`, `sql_engine`), threaded once into `compose_engine`. Infra-only; never a god-parameter. |
 | LR-15 | Environment is a **factory constant** (`build_live_system` vs `build_backtest_system`), not a global read; handlers keep an explicit `environment` param for test isolation. |
 | LR-16 | **No `LiveEventHandler` subclass.** Keep the single data-driven `EventHandler`; add live routes via a declarative `LiveRouteRegistrar` (no runtime `routes` mutation). |
 | LR-17 | **Two registries** — `ExecutionVenueRegistry` + `DataProviderRegistry` — paired by the spec; connectors memoized by `(venue, account_id)`. |
-| LR-18 | **`SqlBackend` → `SqlSpine`** rename; param/field name `sql_spine`. Migrations relocate to the project-root `migrations/` (out of the shipped package). |
+| LR-18 | **`SqlBackend` → `SqlEngine`** rename (`storage/backend.py` → `storage/engine.py`); param/field name `sql_engine`. Migrations relocate to the project-root `migrations/` (out of the shipped package). |
 | LR-19 | **`clOrdId` → `client_order_id`** (venue↔engine correlation), distinct from `portfolio_id` (attribution). |
 | LR-20 | **`account_id`** is the account key (drop "sub-account" jargon); each `account_id` is a full venue account with its own credentials/balance/positions. |
 | LR-21 | Config lives with the thing it configures, **at that thing's cardinality**; per-instance configs persist via the instance's own store. |
@@ -143,7 +143,7 @@ carries **zero oracle risk**.
 SystemSpec  (declarative, mode-agnostic)                         [exists]
     │
 build_live_system(spec)  — live factory / composition root       [NEW]
-    │   reads centralized SystemConfig; builds the ONE sql_spine (live only);
+    │   reads centralized SystemConfig; builds the ONE sql_engine (live only);
     │   resolves venue plugin(s); assembles EngineContext; calls compose_engine;
     │   builds venue bundle(s); registers exchange + provider; builds LiveRunner + controllers
     ▼
@@ -262,7 +262,7 @@ class EngineContext:
     bus:         EventBus
     config:      RuntimeConfig            # the overlay (6c)
     environment: str                      # resolved by the factory (LR-15)
-    sql_spine:   Optional[SqlSpine]       # None on the in-memory path (LR-18)
+    sql_engine:   Optional[SqlEngine]       # None on the in-memory path (LR-18)
 ```
 
 Infra-only, threaded once into `compose_engine`, which hands each handler only what it needs.
@@ -270,13 +270,13 @@ Infra-only, threaded once into `compose_engine`, which hands each handler only w
 ### 7b. Handler-owns init (LR-13)
 
 ```python
-OrderHandler(..., *, environment='backtest', sql_spine=None, storage=None)
-    → self.storage = storage or OrderStorageFactory.create(environment, backend=sql_spine)
+OrderHandler(..., *, environment='backtest', sql_engine=None, storage=None)
+    → self.storage = storage or OrderStorageFactory.create(environment, backend=sql_engine)
 ```
 
 Order + Strategies handlers adopt `PortfolioHandler`'s existing shape. `compose_engine` reads the
 concrete instance back off `.storage` for the `portfolio_handler.set_order_storage(...)` wiring.
-Backtest (`environment='backtest', sql_spine=None`) → same in-memory instances → byte-exact. Factory
+Backtest (`environment='backtest', sql_engine=None`) → same in-memory instances → byte-exact. Factory
 SQL imports stay lazy → inertness green.
 
 ### 7c. Two storage tiers
@@ -284,7 +284,7 @@ SQL imports stay lazy → inertness green.
 - **Handler working-set storage** (order/signal/portfolio) → **handler-owned** (this is what point 20
   was about).
 - **System-level registry/state stores** (halt, system, venue, strategy-registry) → **composition-root
-  infrastructure** over the shared `sql_spine` (exactly like `HaltRecordStore` today); built by the
+  infrastructure** over the shared `sql_engine` (exactly like `HaltRecordStore` today); built by the
   factory and handed to the controllers that use them.
 
 ### 7d. Cardinality-aligned stores (LR-22)
@@ -297,14 +297,14 @@ SQL imports stay lazy → inertness green.
 | Portfolio store | N portfolios | per-portfolio config + account state | — |
 | Order / Signal / Halt | — | (exist) | — |
 
-Each new store follows the `HaltRecordStore` template (composes `sql_spine`, own `build_*_table`
+Each new store follows the `HaltRecordStore` template (composes `sql_engine`, own `build_*_table`
 registrar, chained Alembic migration). Chain: `d10_halt_records → system_store → venue_config →
 strategy_registry`.
 
 ### 7e. Rename + migrations relocation (LR-18)
 
-`SqlBackend → SqlSpine` (mechanical: `storage/backend.py`, the three `storage_factory.py`,
-`migrations/env.py`, live wiring). Relocate `itrader/storage/migrations/` → project-root
+`SqlBackend → SqlEngine`, `storage/backend.py → storage/engine.py` (mechanical: the three
+`storage_factory.py`, `migrations/env.py`, live wiring). Relocate `itrader/storage/migrations/` → project-root
 `migrations/` (update `alembic.ini` `script_location`; `env.py` keeps importing the `build_*_table`
 registrars + `NAMING_CONVENTION` from `itrader.storage`). Stays out of the shipped wheel; test-path
 `create_all` unaffected.
@@ -371,7 +371,7 @@ start:  connector.connect?  →  per member symbol: feed.warmup → provider.sub
      →  exchange.connect (check .success)
      →  account.snapshot? → account.start_streaming? → link account→portfolio(s)
      →  ReconciliationCoordinator: rehydrate → reconcile? → baseline guard
-stop:   connector.disconnect?  →  sql_spine.dispose?
+stop:   connector.disconnect?  →  sql_engine.dispose?
 ```
 
 The reconcile step keys on **account *kind*** (`VenueAccount` = venue-truth → reconcile;
@@ -564,7 +564,7 @@ registers it sized to `max(s.warmup for strategies)`.
   its routes stay explicit-empty on the backtest `EventHandler` (proven by `test_okx_inertness`).
 - **Inertness gate** — `test_okx_inertness.py` stays green: registering venues imports no `ccxt.pro`
   until a venue is *built*; `SystemConfig` never constructs Postgres `SqlSettings` at import (lazy
-  `sql`); `FifoEventBus`/`EngineContext(sql_spine=None)` pull nothing heavy on the backtest path.
+  `sql`); `FifoEventBus`/`EngineContext(sql_engine=None)` pull nothing heavy on the backtest path.
 - **Indentation hazard** — handler modules use **tabs**; `config/`, `core/`, `price_handler/feed/`,
   and `events_handler/events/` use **4 spaces**. Match the file; never normalize (a mixed-indentation
   diff breaks a tab file).
@@ -585,7 +585,7 @@ Sequenced by dependency. **Oracle-gated** = must stay byte-exact. **★** = the 
 | **P1** | Config centralization | `SystemConfig` aggregation (eager/lazy/templates), constant migration, dead-config audit, `extra` normalization | — |
 | **P2** | Event bus | `EventBus` Protocol + `FifoEventBus`/`PriorityEventBus`, injected into `compose_engine` (backtest→Fifo) | — |
 | **P3** | `EngineContext` + storage-in-handler | `EngineContext`, handler-owns init (Order/Strategies), `compose_engine` signature | P1 |
-| **P4** | `SqlSpine` rename + migrations relocation | `SqlBackend→SqlSpine`; `migrations/`→project root | P3 |
+| **P4** | `SqlEngine` rename + migrations relocation | `SqlBackend→SqlEngine`; `migrations/`→project root | P3 |
 
 ### Durable stores — live-only (in-memory fallback keeps backtest untouched)
 | **P5** | New stores | `SystemStore`, `VenueStore`, `StrategyRegistryStore` (tables + registrars + migrations + rehydrate) | P4 |

--- a/docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md
+++ b/docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md
@@ -607,6 +607,10 @@ Sequenced by dependency. **Oracle-gated** = must stay byte-exact. **★** = the 
 **Trim boundary:** P1–P9 + P13 = the core refactor. P10–P12 (★) are the feature-adds — deferrable at
 milestone-init without destabilizing the core.
 
+**Backlog TODOs folded into these phases:** ten pending `.planning/todos/` items are absorbed into
+P1/P6/P7/P8/P9 because the refactor already rewrites the file/seam each one touches — see **§18**.
+All land in **core (non-★) phases**, so the trim boundary above is unaffected.
+
 ---
 
 ## 17. Mapping of the original 26 concerns
@@ -639,3 +643,46 @@ milestone-init without destabilizing the core.
 | 24 | Centralized config importable from root | §6a/§6c, P1 |
 | 25 | Live `__init__` params not needed | §11e, P7 |
 | 26 | What is `_LiveWarmupConsumer` | §13d — rehomed `StrategyWarmupConsumer`, P7 |
+
+---
+
+## 18. Folded-in backlog TODOs (v1.7 carry-forward + adjacent seams)
+
+Ten pending `.planning/todos/` items are folded into this milestone because the refactor already
+rewrites the exact file/seam each one touches — bundling them avoids a second edit pass and a
+re-discovery cost. **All are live-only / backtest-dark**: none touches the SMA_MACD oracle path, so
+none affects the **LR-02 byte-exact gate** or the **inertness gate** (this is asserted once here so it
+is not re-litigated per item). Each carries a stable **`CF-NN`** tag so downstream GSD plans can cite
+it in `must_haves`/`truths`/`objective` (the decision-coverage gate needs the tag in those fields, not
+body prose).
+
+| Tag | Source TODO | Phase | Priority | Why it belongs here / ready-to-paste source |
+|---|---|---|---|---|
+| **CF-1** | `v17-residual-carryforward.md` §1 | **P9** | **HIGH (safety)** | ERROR-route **circuit breaker** on the `_publish_and_continue` seam P9 rebuilds as `ErrorPolicy`/`ErrorHandler`. Without it, a money route failing every event runs infinitely green. Spec drafted in `v17_audit_results.md §3b` (route-classified ring: SETTLEMENT halt-on-first, ORDER-IO N=3/60s, ADMISSION N=3/300s, LOOP-BACKSTOP N=5/60s). **Preserve:** WR-06 terminal swallow; backtest fail-fast unchanged (an aggregate tripwire *on top of* publish-and-continue, not a per-event change). Unblocked by the landed HALTED latch (V17-03). |
+| **CF-2** | `v17-residual-carryforward.md` §2 | **P8** | MED | Wire `LiveBarFeed.backfill_on_resume` (`live_bar_feed.py:395`) into P8's `StreamRecoveryHandler.on_reconnect`. Must land **loop-native** (connector loop, via the reconnect callback), **NOT** the engine thread (would be a second concurrent ring writer). Safe now that V17-15 `spawn_gap_backfill` landed. |
+| **CF-3** | `v17-residual-carryforward.md` §3 | **P6** | LOW | Add the §4c CONTRACT docstrings to `connectors/base.py:53-92` (`call`/`spawn`/`disconnect`) — P6 already touches the connector contract for `(venue, account_id)` memoization. Ready-to-paste verbatim in `v17_audit_results.md §4c`. |
+| **CF-4** | `v17-residual-carryforward.md` §4 | **P6** | LOW→MED | **Already in scope as §8f** — the triplicated `_run_stream_supervisor` (`okx.py:708` / `venue.py:356` / `okx_provider.py:462`) collapses into the shared `StreamSupervisor`. Listed here so the carry-forward set is complete and cross-referenced. |
+| **CF-5** | `v17-residual-carryforward.md` §5 | **P9** (partial) | LOW | Alert egress is log-only (`live_trading_system.py:668` sink routes only to the ERROR log). P9 formalizes the pluggable alert sink (§12b) — thread the seam so a CRITICAL halt *can* reach a real sink; the substantive egress impl stays the FastAPI milestone. |
+| **CF-6** | `v17-residual-carryforward.md` §6 | **P1** | LOW (doc) | Apply the D-03a dual-validator paragraph to `.planning/codebase/CONVENTIONS.md` during P1's dead-config/cleanup pass. Ready-to-paste in `v17_audit_results.md §6d`. |
+| **CF-7** | `v17-residual-carryforward.md` §7 | **P8** | LOW | Guard the bare `str(matched["id"])` at `venue_reconciler.py:411` (KeyError on a fallback-matched resting order with no `id`) — P8's `ReconciliationCoordinator` owns this file. Fail-loud → typed error. |
+| **CF-8** | `off-vocabulary-halt-reason-baseline-residual-wr04.md` | **P8 + P1** | MED | Replace the free-string `self.halt('baseline-residual')` (`live_trading_system.py:810`) with a typed `HaltReason` vocabulary entry in `core/enums/system.py`. **Self-nominated**: the TODO's own deferral note names *this* milestone's `live_trading_system.py` refactor + halt-vocabulary review as its home. P8 `SafetyController` owns `halt()`; P1 owns the enum/config. Also closes the FastAPI control-plane's "unclassified halt" gap. |
+| **CF-9** | `okx-markets-map-freshness-delisting-detection.md` | **P6** | MED | Keep the OKX markets map fresh so a mid-session delisting exits via the existing `validate_symbol` → `delta.removed` removal path (do **not** add a parallel drop inside the retry loop). P6 moves `validate_symbol`/precision onto the exchange and owns the connector `load_markets` lifecycle — the seam to add a cadence/lazy refresh and close the fail-open-before-load window. |
+| **CF-10** | `warmup-depth-max-concerned-strategy.md` | **P7** | LOW (seam-only) | No roster needs it today (SMA_MACD `cache_capacity()=100` ≥ deepest declared warmup), but P7 rehomes `StrategyWarmupConsumer` and rewrites `UniverseHandler` init (`_initialize_live_session` → `SessionInitializer`) — the exact wiring this needs. **Shape the depth-hint seam** (`max(strategy.warmup for concerned strategies)`) correctly now so it is not re-touched; the K-computation change itself stays deferred until a deeper-warmup strategy lands. |
+
+**Notes for planning:**
+
+- **CF-1 is the one with teeth** — the only HIGH-priority safety item and the only fold that *adds an
+  acceptance criterion* to its phase (P9 must ship the aggregate tripwire, not merely refactor the
+  error seam). The other nine are low-risk co-located cleanups.
+- **Housekeeping on fold** — set each source TODO's front-matter `resolves_phase: P#` (and
+  `status: scheduled`) at milestone-init so it is not double-tracked against the live backlog; migrate
+  to `.planning/todos/completed/` only when the owning phase verifies it.
+- **Ready-to-paste debt** — CF-1/CF-3/CF-6 have implementations already written in
+  `v17_audit_results.md` (§3b/§4c/§6d); planners should paste, not re-derive.
+- **Not folded (tracked, deliberately kept separate):** `livebarfeed-depandas-time-model-datetime.md`
+  (large look-ahead-safety-critical own-refactor of the same file — flag as a co-located follow-on),
+  `mutable-instrument-refactor.md` (margin/carry-model concern), `margin-equity-double-counts-notional-wr01.md`
+  (gated on re-freezing 6 goldens + cross-validation), `unify-backtest-direct-bar-generation.md`
+  (oracle-risky backtest-loop rewrite — conflicts with LR-02), and `pair-strategy-live-reconfiguration.md`
+  (a net-new operator feature; its natural home is the ★-trimmable P11, so it is excluded from the
+  core fold).

--- a/docs/webapp-design-prompt.md
+++ b/docs/webapp-design-prompt.md
@@ -1,0 +1,123 @@
+# iTrader Web App — Design Prompt
+
+Prompt for Claude's design/Artifact feature to draft the operator console UI.
+
+**Locked decisions behind this prompt:** live/paper trading only (no backtest
+surface), single operator (no team/auth), clean theme-aware SaaS aesthetic.
+Pages map onto the v1.8 two-registry architecture (execution accounts + data
+providers) and the safety-latch lifecycle.
+
+**Open question (not yet resolved):** the authoritative account↔portfolio bind
+control — put it on the Portfolio drawer (recommended) and make Accounts
+read-only about it, or expose it on both.
+
+---
+
+```
+Design a web app: the operator console for "iTrader," a live algorithmic-trading
+engine. Single operator (me), live/paper trading only — NO backtesting surface,
+NO team/auth/org switching. The app's one job: make operating and monitoring a
+running trading engine calm, legible, and safe.
+
+What the engine is (use its real vocabulary — it drives the design):
+It's an event-driven system. A FIFO stream flows SIGNAL → ORDER → FILL →
+PORTFOLIO UPDATE. Strategies emit signals; orders rest on a venue (OKX, paper-
+first); fills update Decimal-precise cash and positions. The whole system sits
+behind one safety LATCH with three states: RUNNING, PAUSED, HALTED. HALTED is
+terminal — it only clears when I explicitly reset it. Money is exact to the cent;
+prices, quantities, order IDs, and timestamps are precision data, not prose.
+
+── AESTHETIC DIRECTION ──
+Clean, theme-aware SaaS (light + dark), airy and card-based, Linear/Vercel-grade
+restraint. Precision-instrument feel, not terminal-dense and not a marketing
+dashboard. Spend boldness in ONE place (the signature below); keep everything
+else quiet. Do NOT use the AI-default looks (cream + serif + terracotta;
+near-black + acid-green; broadsheet hairlines).
+
+── COLOR SYSTEM (small, deliberate — light / dark) ──
+The accent must never blur with gain-green or loss-red, because P&L color is
+load-bearing. So brand lives in the violet band, far from both.
+  --brand    (iris, interactive/primary/focus)  #5E5CE6 / #7B79F0
+  --bg       (app background)                    #F7F8FA / #0D1117
+  --surface  (cards)                             #FFFFFF / #161B22
+  --border                                        #E4E7EC / #232A33
+  --ink      (primary text)                       #1A1D21 / #E6EAF0
+  --ink-muted                                     #5B6470 / #8B95A3
+Semantic (financial + status — keep these three visually distinct):
+  --positive (gain)          #16A34A / #3FB950   (emerald)
+  --negative (loss)          #E5484D / #F0616D   (rose)
+  --warning  (PAUSED)        #D98A00 / #E3A008   (amber)
+  --halt     (HALTED/CRITICAL, deeper than loss) #C4292E / #F85149
+Status latch → color: RUNNING=positive, PAUSED=warning, HALTED=halt.
+
+── TYPE SYSTEM ──
+Artifacts can't fetch external fonts, so: a strong system-ui stack for all UI/
+display text (tight tracking, heavier weights for page titles and the hero
+equity number). The typographic SIGNATURE is that EVERY numeric — money, P&L,
+quantity, order ID, timestamp — is set in a monospace with TABULAR figures
+(ui-monospace, "SF Mono", "JetBrains Mono"). Numbers align in columns and never
+reflow. This is true to a Decimal-precise engine, and it's the type personality.
+
+── SIGNATURE ELEMENT ──
+A persistent "status latch rail": a thin full-width bar pinned to the top of the
+app shell whose color and micro-copy reflect the engine's latched state. It docks
+the lifecycle controls (Start / Pause / Stop). When HALTED it turns deep-red with
+a subtle pulse, shows the halt reason string, and is the ONLY place "Reset halt"
+lives (behind a typed confirmation). This encodes the single most important truth
+about a live engine — what state the safety latch is in — and it's visible on
+every page.
+
+── PAGES & WHERE EACH UI ELEMENT LIVES ──
+Persistent chrome: left nav (sections) · top status-latch rail (signature) ·
+global ⌘K command palette (operator actions: start/stop/pause, jump to portfolio,
+cancel order) · a global right SLIDE-OVER for the live alerts/event stream,
+reachable from anywhere.
+
+Component-placement rules to apply consistently:
+  • DEDICATED PAGE  → surfaces I scan or return to (monitoring, browsing lists).
+  • RIGHT DRAWER    → create / edit / inspect ONE item of an N-item collection
+                      without losing the list behind it (non-destructive).
+  • MODAL           → short, blocking, decision-forcing: destructive or safety
+                      confirms, and secure credential entry.
+  • SLIDE-OVER      → the always-available event/alert stream.
+
+1.  Live Console (home) — PAGE. Hero: aggregate equity as a large mono number +
+    delta. Grids/cards: open positions, recent fills, recent signals, and a live
+    event-stream feed. The daily driver.
+2.  Portfolios — list PAGE → detail PAGE (multi-portfolio). Detail shows cash,
+    positions, transactions, metrics, bound account. Create/edit a portfolio and
+    its per-instance config → right DRAWER.
+3.  Orders — dense PAGE with two tabs: "Orders" (pending / resting / filled /
+    cancelled / rejected, with bracket parent→child grouping) and "Fills"
+    (executed-fill log). Row → right DRAWER (order detail + lifecycle timeline +
+    modify). Cancel → confirm MODAL.
+4.  Signals — PAGE: strategy signal-record stream. Row → DRAWER showing the
+    order(s) that signal produced.
+5.  Strategies — registry PAGE. Inline enable/disable toggle. Per-strategy config
+    + portfolio assignment → right DRAWER.
+6.  Accounts — PAGE (the money side): per-portfolio trading accounts. Each shows
+    account_id, type (simulated cash/margin vs venue-truth), bound execution
+    venue, sandbox badge, balances, and reconcile status. Add/edit account →
+    DRAWER; API CREDENTIALS entered in a dedicated secure MODAL (masked, never
+    shown again after save). Disconnect → confirm MODAL.
+7.  Data Providers — PAGE (the data side): market-data feeds (OKX candle stream,
+    replay, etc.), connection status, symbols fed, health check. Add/edit → DRAWER.
+8.  Markets — PAGE with tabs, screener-ready. Tab "Universe": current tracked
+    symbols (membership) + manual add/remove + poll-timer status. Tab "Screeners"
+    (placeholder for a future subsystem: the rules that auto-populate the
+    universe). Add/remove ticker → small MODAL.
+9.  Reconciliation & Halt Center — safety-critical PAGE: venue reconcile drift
+    (stored intent vs venue truth) and durable halt-record history. "Halt" and
+    "Reset halt" are confirm MODALs (typed confirmation for reset).
+10. System Settings — sectioned PAGE (substantial, not a modal): system-wide
+    config only (RNG seed, performance, monitoring, storage, logging). Per-
+    instance configs do NOT live here — they live in each entity's drawer.
+11. Events — PAGE for full history/filtering of the event & error stream (the
+    global slide-over is the live tail; this page is the archive).
+
+── QUALITY FLOOR ──
+Responsive to mobile; visible keyboard focus; reduced-motion respected; light and
+dark both first-class. Copy is operator-facing and active-voice ("Pause trading,"
+not "Submit"); an action keeps its name through its whole flow. Empty and error
+states give direction, not mood.
+```


### PR DESCRIPTION
This pull request updates the project planning documentation to define and describe the new v1.8 milestone, which focuses on a major refactor of the live trading system for improved modularity, testability, and live-readiness. The milestone sets out a multi-phase roadmap to break down the large `LiveTradingSystem` class into smaller, independently-testable components, centralize configuration, and prepare the system for FastAPI integration—while maintaining strict backward compatibility for backtests and ensuring no premature dependencies are loaded. The summary and status section at the end of the document is also updated to reflect the start of v1.8.

**Major milestone and roadmap update:**

* Added a detailed section for the new v1.8 milestone, outlining the goal to refactor the `LiveTradingSystem` God object into a thin facade over focused collaborators, with configuration centralization, venue parametrization, and FastAPI readiness, without breaking backtest or inertness gates.
* Enumerated the 12 target features/phases (P1–P12) for v1.8, covering config centralization, event bus, storage schema, venue registry, live runner, safety/reconciliation, error subsystem, runtime config, strategies registry, multi-portfolio support, and test migration.
* Provided key context and design references for the refactor, including requirements for byte-exact backtest compatibility and inertness, and mapping pending tasks (CF-1..CF-10, LR-00..LR-22) to the roadmap.

**Project status and summary update:**

* Updated the project status at the end of the file to mark v1.8 as started (2026-07-09), summarize its scope, and reference the design document and requirements process.
* Clarified the archival of previous milestones (v1.0–v1.7) and updated the "last updated" timestamp and summary.