### PR TITLE
V1.8/phase 2 event bus

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -785,11 +785,29 @@ the oracle** (drops `ta` on the runtime path); its lock is cross-validation + a 
 v1.0/v1.1/v1.2/v1.3/v1.4 SHIPPED — archived under `milestones/`.*
 
 ---
-*Last updated: 2026-07-09 — **v1.8 — Live System Refactor & Live-Readiness Hardening STARTED.**
+*Last updated: 2026-07-09 — **v1.8 Phase 2 (Event Bus) COMPLETE.** 3 plans; goal verified `passed`
+(12/12 must-haves, `02-VERIFICATION.md`). Delivered the stdlib two-tier `EventBus` Protocol
+(`FifoEventBus` + `PriorityEventBus`, CONTROL > BUSINESS behind one `.put()` surface, `itertools.count()`
+seq keying so the priority heap never dereferences the non-orderable `Event`), the three CONTROL
+`EventType` members (`STREAM_STATE`/`CONNECTOR_FATAL`/`CONFIG_UPDATE`, registered as explicit-empty
+backtest routes so the dispatch-registry conformance holds), a frozen `EngineContext` (4 loose infra
+fields), and the `compose_engine` fold to its **end-state `(ctx, spec)` signature** — internal
+`queue.Queue()` deleted, `FifoEventBus` injected into BOTH backtest arms, handler-owned storage
+(Order/Strategies own their store init) read back for wiring. Zero-backtest-impact held: SMA_MACD oracle
+**byte-exact** (134 / `46189.87730727451`, determinism double-run identical), inertness green + extended
+(register-vs-build: `FifoEventBus`/`EngineContext(sql_engine=None)` pull no sqlalchemy/ccxt), `mypy
+--strict` clean (237 files), full unit suite 1792 passed, `live_trading_system.py` UNCHANGED (D-11) +
+`poetry.lock` byte-unchanged. CTX-01/02/03 pulled forward from P3 (D-03 Option B); CTX-04
+(`SqlBackend→SqlEngine`) stays P3. Advisory `02-REVIEW`: 0 blockers / 2 warnings (WR-01 `PortfolioHandler`
+mode-agnosticism gap → deferred P3/P6, backtest-dark; WR-02 four dead `from queue import Queue` imports →
+hygiene-only). Phase 1 (Config Centralization) previously complete. Next: Phase 3 — EngineContext +
+Storage-in-Handler.*
+
+*Earlier: 2026-07-09 — **v1.8 — Live System Refactor & Live-Readiness Hardening STARTED.**
 Decomposes the 2,171-line `LiveTradingSystem` God object into a thin facade over focused collaborators
 (factory + shared `compose_engine` + `LiveRunner` + controllers), venue-parametrized and
 config-centralized, FastAPI-ready — without disturbing the byte-exact backtest oracle
-(`134 / 46189.87730727451`) or the OKX inertness gate. Full scope (13 phases, P1–P13, incl. the three ★
+(`134 / 46189.87730727451`) or the OKX inertness gate. Full scope (12 phases, P1–P12, incl. the three ★
 feature-adds LR-03/LR-04). Design source:
 `docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md` (LR-00..LR-22, CF-1..CF-10).
 Defining requirements → roadmap via `/gsd:new-milestone`. v1.0–v1.7 SHIPPED — archived under

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -72,7 +72,7 @@ pre-trade throttle folded in (SAFE-06); fee/slippage runtime-mutation gated to s
   added; backtest uses `FifoEventBus` so the oracle stays byte-exact (zero priority-bus on the backtest
   path) (arch refinement 3).
 
-- [ ] **BUS-04**: A minimal `EngineContext` skeleton is introduced in P2 so `compose_engine`'s signature
+- [x] **BUS-04**: A minimal `EngineContext` skeleton is introduced in P2 so `compose_engine`'s signature
   settles once rather than being double-edited across P2/P3 (arch refinement 2).
 
 ### EngineContext + Storage-in-Handler (CTX-01/02/03 → P2, CTX-04 → P3)
@@ -83,14 +83,14 @@ pre-trade throttle folded in (SAFE-06); fee/slippage runtime-mutation gated to s
 > forward into P2.** Only **CTX-04** (the mechanical `SqlBackend→SqlEngine` rename) remains in P3, which is
 > now a single-requirement phase. Downstream must NOT "fix" this back — see `phases/02-event-bus/02-CONTEXT.md`.
 
-- [ ] **CTX-01** *(→ P2)*: `EngineContext` (frozen: `bus`, `config`, `environment`, `sql_engine`) is threaded
+- [x] **CTX-01** *(→ P2)*: `EngineContext` (frozen: `bus`, `config`, `environment`, `sql_engine`) is threaded
   once into `compose_engine(ctx, spec)`; infra-only, never a god-parameter (LR-14/§7a).
 
 - [x] **CTX-02** *(→ P2)*: Order + Strategies handlers own their storage init from `(environment, sql_engine)`
   with an optional `storage=` override (following `PortfolioHandler`'s shape); `compose_engine` reads the
   concrete instance back off `.storage` for wiring (LR-13/§7b, concern 20).
 
-- [ ] **CTX-03** *(→ P2)*: Backtest (`environment='backtest', sql_engine=None`) yields the same in-memory
+- [x] **CTX-03** *(→ P2)*: Backtest (`environment='backtest', sql_engine=None`) yields the same in-memory
   storage instances → oracle byte-exact; factory SQL imports stay lazy → inertness green (§7b).
 
 - [ ] **CTX-04** *(P3)*: `SqlBackend` is renamed to `SqlEngine` (`storage/backend.py` → `storage/engine.py`;
@@ -363,10 +363,10 @@ Each requirement maps to exactly one phase. As of 2026-07-09 the roadmap is crea
 | BUS-01 | P2 | Complete |
 | BUS-02 | P2 | Complete |
 | BUS-03 | P2 | Complete |
-| BUS-04 | P2 | Pending |
-| CTX-01 | P2 | Pending |
+| BUS-04 | P2 | Complete |
+| CTX-01 | P2 | Complete |
 | CTX-02 | P2 | Complete |
-| CTX-03 | P2 | Pending |
+| CTX-03 | P2 | Complete |
 | CTX-04 | P3 | Pending |
 | SQL-01 | P4 | Pending |
 | SQL-02 | P4 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -75,19 +75,25 @@ pre-trade throttle folded in (SAFE-06); fee/slippage runtime-mutation gated to s
 - [ ] **BUS-04**: A minimal `EngineContext` skeleton is introduced in P2 so `compose_engine`'s signature
   settles once rather than being double-edited across P2/P3 (arch refinement 2).
 
-### EngineContext + Storage-in-Handler (P3)
+### EngineContext + Storage-in-Handler (CTX-01/02/03 → P2, CTX-04 → P3)
 
-- [ ] **CTX-01**: `EngineContext` (frozen: `bus`, `config`, `environment`, `sql_engine`) is threaded once
-  into `compose_engine(ctx, spec)`; infra-only, never a god-parameter (LR-14/§7a).
+> **Phase reassignment (Phase 2 D-03, 2026-07-09):** the owner chose the end-state
+> `compose_engine(ctx, spec)` signature in P2 (Option B), which requires handler-owned storage — so
+> **CTX-01, CTX-02, and CTX-03 (the byte-exact/inertness gate inseparable from that change) are pulled
+> forward into P2.** Only **CTX-04** (the mechanical `SqlBackend→SqlEngine` rename) remains in P3, which is
+> now a single-requirement phase. Downstream must NOT "fix" this back — see `phases/02-event-bus/02-CONTEXT.md`.
 
-- [ ] **CTX-02**: Order + Strategies handlers own their storage init from `(environment, sql_engine)` with
-  an optional `storage=` override (following `PortfolioHandler`'s shape); `compose_engine` reads the
+- [ ] **CTX-01** *(→ P2)*: `EngineContext` (frozen: `bus`, `config`, `environment`, `sql_engine`) is threaded
+  once into `compose_engine(ctx, spec)`; infra-only, never a god-parameter (LR-14/§7a).
+
+- [ ] **CTX-02** *(→ P2)*: Order + Strategies handlers own their storage init from `(environment, sql_engine)`
+  with an optional `storage=` override (following `PortfolioHandler`'s shape); `compose_engine` reads the
   concrete instance back off `.storage` for wiring (LR-13/§7b, concern 20).
 
-- [ ] **CTX-03**: Backtest (`environment='backtest', sql_engine=None`) yields the same in-memory storage
-  instances → oracle byte-exact; factory SQL imports stay lazy → inertness green (§7b).
+- [ ] **CTX-03** *(→ P2)*: Backtest (`environment='backtest', sql_engine=None`) yields the same in-memory
+  storage instances → oracle byte-exact; factory SQL imports stay lazy → inertness green (§7b).
 
-- [ ] **CTX-04**: `SqlBackend` is renamed to `SqlEngine` (`storage/backend.py` → `storage/engine.py`;
+- [ ] **CTX-04** *(P3)*: `SqlBackend` is renamed to `SqlEngine` (`storage/backend.py` → `storage/engine.py`;
   field/param `sql_engine`); all importers updated (LR-18, rename folded into P3 per arch refinement 4).
 
 ### SqlEngine Migrations Relocation (P4)
@@ -358,9 +364,9 @@ Each requirement maps to exactly one phase. As of 2026-07-09 the roadmap is crea
 | BUS-02 | P2 | Pending |
 | BUS-03 | P2 | Pending |
 | BUS-04 | P2 | Pending |
-| CTX-01 | P3 | Pending |
-| CTX-02 | P3 | Pending |
-| CTX-03 | P3 | Pending |
+| CTX-01 | P2 | Pending |
+| CTX-02 | P2 | Pending |
+| CTX-03 | P2 | Pending |
 | CTX-04 | P3 | Pending |
 | SQL-01 | P4 | Pending |
 | SQL-02 | P4 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -86,7 +86,7 @@ pre-trade throttle folded in (SAFE-06); fee/slippage runtime-mutation gated to s
 - [ ] **CTX-01** *(→ P2)*: `EngineContext` (frozen: `bus`, `config`, `environment`, `sql_engine`) is threaded
   once into `compose_engine(ctx, spec)`; infra-only, never a god-parameter (LR-14/§7a).
 
-- [ ] **CTX-02** *(→ P2)*: Order + Strategies handlers own their storage init from `(environment, sql_engine)`
+- [x] **CTX-02** *(→ P2)*: Order + Strategies handlers own their storage init from `(environment, sql_engine)`
   with an optional `storage=` override (following `PortfolioHandler`'s shape); `compose_engine` reads the
   concrete instance back off `.storage` for wiring (LR-13/§7b, concern 20).
 
@@ -365,7 +365,7 @@ Each requirement maps to exactly one phase. As of 2026-07-09 the roadmap is crea
 | BUS-03 | P2 | Complete |
 | BUS-04 | P2 | Pending |
 | CTX-01 | P2 | Pending |
-| CTX-02 | P2 | Pending |
+| CTX-02 | P2 | Complete |
 | CTX-03 | P2 | Pending |
 | CTX-04 | P3 | Pending |
 | SQL-01 | P4 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -59,16 +59,16 @@ pre-trade throttle folded in (SAFE-06); fee/slippage runtime-mutation gated to s
 
 ### Event Bus (P2)
 
-- [ ] **BUS-01**: An `EventBus` Protocol (`put`/`get`/`get_nowait`/`qsize`/`empty`/`depth_by_tier`) with
+- [x] **BUS-01**: An `EventBus` Protocol (`put`/`get`/`get_nowait`/`qsize`/`empty`/`depth_by_tier`) with
   two implementations — `FifoEventBus` (backtest) + `PriorityEventBus` (live) — shares one `.put(event)`
   surface; no handler `.put` call-site changes (LR-11/§4a).
 
-- [ ] **BUS-02**: `PriorityEventBus` orders `(tier, seq, event)` with `tier ∈ {CONTROL=0, BUSINESS=1}`
+- [x] **BUS-02**: `PriorityEventBus` orders `(tier, seq, event)` with `tier ∈ {CONTROL=0, BUSINESS=1}`
   assigned from a declarative `_CONTROL_EVENT_TYPES` frozenset and a globally-unique monotonic `seq`; a
   test asserts the tuple comparison never dereferences the (non-orderable) frozen event and preserves
   strict within-tier FIFO (§4a).
 
-- [ ] **BUS-03**: New CONTROL `EventType` members (`STREAM_STATE`, `CONNECTOR_FATAL`, `CONFIG_UPDATE`) are
+- [x] **BUS-03**: New CONTROL `EventType` members (`STREAM_STATE`, `CONNECTOR_FATAL`, `CONFIG_UPDATE`) are
   added; backtest uses `FifoEventBus` so the oracle stays byte-exact (zero priority-bus on the backtest
   path) (arch refinement 3).
 
@@ -360,9 +360,9 @@ Each requirement maps to exactly one phase. As of 2026-07-09 the roadmap is crea
 | CFG-04 | P1 | Complete |
 | CFG-05 | P1 | Complete |
 | CFG-06 | P1 | Complete |
-| BUS-01 | P2 | Pending |
-| BUS-02 | P2 | Pending |
-| BUS-03 | P2 | Pending |
+| BUS-01 | P2 | Complete |
+| BUS-02 | P2 | Complete |
+| BUS-03 | P2 | Complete |
 | BUS-04 | P2 | Pending |
 | CTX-01 | P2 | Pending |
 | CTX-02 | P2 | Pending |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -140,29 +140,29 @@ below, not strict numeric order (P4 waits on P3; P5 on P2+P3; P6 on P4+P5; etc.)
 
 ### Phase 2: Event Bus
 
-**Goal**: Introduce a stdlib two-tier `EventBus` (CONTROL > BUSINESS) with FIFO and priority implementations behind one `.put()` surface, add the new CONTROL `EventType` members, and settle the `compose_engine` signature via a minimal `EngineContext` skeleton — backtest wiring `FifoEventBus` at zero oracle risk.
+**Goal**: Introduce a stdlib two-tier `EventBus` (CONTROL > BUSINESS) with FIFO and priority implementations behind one `.put()` surface, add the new CONTROL `EventType` members, and settle the `compose_engine` signature to its **end-state `(ctx, spec)` form** via a frozen `EngineContext` with **handler-owned storage** — backtest wiring `FifoEventBus` at zero oracle risk. *(Phase 2 D-03: the owner chose Option B — the end-state signature now — so **CTX-01/CTX-02/CTX-03 are pulled forward from P3 into P2**; only the `SqlBackend→SqlEngine` rename (CTX-04) stays in P3.)*
 **Depends on**: Nothing
-**Requirements**: BUS-01, BUS-02, BUS-03, BUS-04
+**Requirements**: BUS-01, BUS-02, BUS-03, BUS-04, CTX-01, CTX-02, CTX-03
 **Success Criteria** (what must be TRUE):
 
   1. `FifoEventBus` (backtest) and `PriorityEventBus` (live) satisfy one `EventBus` Protocol (`put`/`get`/`get_nowait`/`qsize`/`empty`/`depth_by_tier`) sharing a single `.put(event)` surface with no handler call-site changes; backtest wires `FifoEventBus` and the oracle stays byte-exact (per-PLAN gate).
   2. A test proves `PriorityEventBus` orders `(tier, seq, event)` by a globally-unique monotonic `seq` (`itertools.count`) — the comparison never dereferences the non-orderable frozen event — and preserves strict within-tier FIFO.
   3. New CONTROL `EventType` members (`STREAM_STATE`, `CONNECTOR_FATAL`, `CONFIG_UPDATE`) exist and are assigned CONTROL tier from a declarative `_CONTROL_EVENT_TYPES` frozenset; backtest uses `FifoEventBus` (zero priority-bus on the backtest path).
-  4. A minimal `EngineContext` skeleton settles `compose_engine`'s signature once; `test_okx_inertness.py` stays green (`FifoEventBus`/`EngineContext(sql_engine=None)` pull nothing heavy; extended register-vs-build assertion).
+  4. A frozen `EngineContext` (`bus`/`config`/`environment`/`sql_engine`, loose types where P4/P9 tighten) settles `compose_engine(ctx, spec)` in its end-state form (CTX-01), with Order + Strategies handlers owning their storage init following `PortfolioHandler`'s shape (CTX-02) — backtest (`environment='backtest', sql_engine=None`) yields the same in-memory instances → oracle byte-exact (CTX-03, per-PLAN gate); `test_okx_inertness.py` stays green (`FifoEventBus`/`EngineContext(sql_engine=None)` pull nothing heavy; extended register-vs-build assertion).
 
 **Plans**: TBD
 
 ### Phase 3: EngineContext + Storage-in-Handler
 
-**Goal**: Thread a frozen `EngineContext` once into `compose_engine(ctx, spec)`, move storage initialization into the Order and Strategies handlers (following `PortfolioHandler`'s shape), and rename `SqlBackend` to `SqlEngine` — with backtest yielding the same in-memory instances.
+**Goal**: Rename `SqlBackend` to `SqlEngine` (`storage/backend.py` → `storage/engine.py`; field/param `sql_engine`) and update all importers — `mypy --strict` clean. *(Phase 2 D-03: `EngineContext` + `compose_engine(ctx, spec)` + storage-in-handler (CTX-01/02/03) were pulled forward into P2, so P3 now carries only the mechanical `SqlBackend→SqlEngine` rename. Review at close whether this single-requirement phase folds into P2 or P4.)*
 **Depends on**: Phase 1, Phase 2
-**Requirements**: CTX-01, CTX-02, CTX-03, CTX-04
+**Requirements**: CTX-04
 **Success Criteria** (what must be TRUE):
 
-  1. `compose_engine(ctx, spec)` takes the frozen `EngineContext` (`bus`, `config`, `environment`, `sql_engine`); backtest (`environment='backtest', sql_engine=None`) yields the same in-memory storage instances and the oracle stays byte-exact (per-PLAN gate).
-  2. Order + Strategies handlers own their storage init from `(environment, sql_engine)` with an optional `storage=` override; `compose_engine` reads the concrete instance back off `.storage` for the `set_order_storage(...)` wiring.
-  3. `SqlBackend` is renamed to `SqlEngine` (`storage/backend.py` → `storage/engine.py`, field/param `sql_engine`); all importers are updated and `mypy --strict` is clean.
-  4. Factory SQL imports stay lazy, so `test_okx_inertness.py` stays green on the backtest path.
+  1. `SqlBackend` is renamed to `SqlEngine` (`storage/backend.py` → `storage/engine.py`, field/param `sql_engine`); all importers are updated and `mypy --strict` is clean. *(EngineContext.sql_engine — loose-typed in P2 — tightens to the concrete `SqlEngine` type here.)*
+  2. The backtest oracle stays byte-exact (per-PLAN gate) and factory SQL imports stay lazy, so `test_okx_inertness.py` stays green on the backtest path.
+
+  *(CTX-01/CTX-02/CTX-03 — `compose_engine(ctx, spec)`, handler-owned storage, and the byte-exact/inertness gate — were delivered in Phase 2 per Phase 2 D-03; they are no longer P3 criteria.)*
 
 **Plans**: TBD
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -100,7 +100,7 @@ INSERTED). ★ = trimmable feature-add (in scope this milestone). Execution foll
 below, not strict numeric order (P4 waits on P3; P5 on P2+P3; P6 on P4+P5; etc.).
 
 - [x] **Phase 1: Config Centralization** - One import-safe `SystemConfig` (eager/lazy split), module-constant migration, dead-config audit, typed `HaltReason` (CFG-01..06) (completed 2026-07-09)
-- [ ] **Phase 2: Event Bus** - Two-tier `EventBus` Protocol (`FifoEventBus`/`PriorityEventBus`) + CONTROL EventTypes + minimal `EngineContext` skeleton (BUS-01..04)
+- [x] **Phase 2: Event Bus** - Two-tier `EventBus` Protocol (`FifoEventBus`/`PriorityEventBus`) + CONTROL EventTypes + minimal `EngineContext` skeleton (BUS-01..04) (completed 2026-07-09)
 - [ ] **Phase 3: EngineContext + Storage-in-Handler** - `EngineContext` threaded into `compose_engine(ctx, spec)`, handler-owns storage init, `SqlBackend→SqlEngine` rename (CTX-01..04)
 - [ ] **Phase 4: Storage Schema: Migrations Relocation + New Durable Stores** - `migrations/` → project root FIRST, then `SystemStore`/`VenueStore`/`StrategyRegistryStore` chained on the `HaltRecordStore` template; single-head + parity Alembic gate over the FULL chain + rehydrate (SQL-01..02, STORE-01..05)
 - [ ] **Phase 5: Venue Registry + Bundle** - Two registries, `VenuePlugin`/`VenueBundle`, precision/validate on the exchange, connector memoization, shared `StreamSupervisor` — kills every `if exchange==` (VENUE-01..07)
@@ -317,7 +317,7 @@ P1 and P2 have no dependencies and can start in parallel.
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
 | 1. Config Centralization | v1.8 | 4/4 | Complete    | 2026-07-09 |
-| 2. Event Bus | v1.8 | 3/3 | Complete   | 2026-07-09 |
+| 2. Event Bus | v1.8 | 3/3 | Complete    | 2026-07-09 |
 | 3. EngineContext + Storage-in-Handler | v1.8 | 0/TBD | Not started | - |
 | 4. Storage Schema: Migrations Relocation + New Durable Stores | v1.8 | 0/TBD | Not started | - |
 | 5. Venue Registry + Bundle | v1.8 | 0/TBD | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -154,7 +154,7 @@ below, not strict numeric order (P4 waits on P3; P5 on P2+P3; P6 on P4+P5; etc.)
 
 **Wave 1** *(parallel — zero file overlap, no deps)*
 
-- [ ] 02-01-PLAN.md — Bus substrate: `EventBus` Protocol + `FifoEventBus`/`PriorityEventBus` + `_CONTROL_EVENT_TYPES` + 3 CONTROL `EventType`s + BUS-01/02/03 unit suite (BUS-01/02/03)
+- [x] 02-01-PLAN.md — Bus substrate: `EventBus` Protocol + `FifoEventBus`/`PriorityEventBus` + `_CONTROL_EVENT_TYPES` + 3 CONTROL `EventType`s + BUS-01/02/03 unit suite (BUS-01/02/03)
 - [ ] 02-02-PLAN.md — Handler-owned storage: `OrderHandler`/`StrategiesHandler` own storage init from `(environment, sql_engine)`, backtest slice = in-memory concretes (CTX-02)
 
 **Wave 2** *(blocked on Wave 1 — depends on 02-01 + 02-02)*
@@ -317,7 +317,7 @@ P1 and P2 have no dependencies and can start in parallel.
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
 | 1. Config Centralization | v1.8 | 4/4 | Complete    | 2026-07-09 |
-| 2. Event Bus | v1.8 | 0/TBD | Not started | - |
+| 2. Event Bus | v1.8 | 1/3 | In Progress|  |
 | 3. EngineContext + Storage-in-Handler | v1.8 | 0/TBD | Not started | - |
 | 4. Storage Schema: Migrations Relocation + New Durable Stores | v1.8 | 0/TBD | Not started | - |
 | 5. Venue Registry + Bundle | v1.8 | 0/TBD | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -155,7 +155,7 @@ below, not strict numeric order (P4 waits on P3; P5 on P2+P3; P6 on P4+P5; etc.)
 **Wave 1** *(parallel — zero file overlap, no deps)*
 
 - [x] 02-01-PLAN.md — Bus substrate: `EventBus` Protocol + `FifoEventBus`/`PriorityEventBus` + `_CONTROL_EVENT_TYPES` + 3 CONTROL `EventType`s + BUS-01/02/03 unit suite (BUS-01/02/03)
-- [ ] 02-02-PLAN.md — Handler-owned storage: `OrderHandler`/`StrategiesHandler` own storage init from `(environment, sql_engine)`, backtest slice = in-memory concretes (CTX-02)
+- [x] 02-02-PLAN.md — Handler-owned storage: `OrderHandler`/`StrategiesHandler` own storage init from `(environment, sql_engine)`, backtest slice = in-memory concretes (CTX-02)
 
 **Wave 2** *(blocked on Wave 1 — depends on 02-01 + 02-02)*
 
@@ -317,7 +317,7 @@ P1 and P2 have no dependencies and can start in parallel.
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
 | 1. Config Centralization | v1.8 | 4/4 | Complete    | 2026-07-09 |
-| 2. Event Bus | v1.8 | 1/3 | In Progress|  |
+| 2. Event Bus | v1.8 | 2/3 | In Progress|  |
 | 3. EngineContext + Storage-in-Handler | v1.8 | 0/TBD | Not started | - |
 | 4. Storage Schema: Migrations Relocation + New Durable Stores | v1.8 | 0/TBD | Not started | - |
 | 5. Venue Registry + Bundle | v1.8 | 0/TBD | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -150,7 +150,16 @@ below, not strict numeric order (P4 waits on P3; P5 on P2+P3; P6 on P4+P5; etc.)
   3. New CONTROL `EventType` members (`STREAM_STATE`, `CONNECTOR_FATAL`, `CONFIG_UPDATE`) exist and are assigned CONTROL tier from a declarative `_CONTROL_EVENT_TYPES` frozenset; backtest uses `FifoEventBus` (zero priority-bus on the backtest path).
   4. A frozen `EngineContext` (`bus`/`config`/`environment`/`sql_engine`, loose types where P4/P9 tighten) settles `compose_engine(ctx, spec)` in its end-state form (CTX-01), with Order + Strategies handlers owning their storage init following `PortfolioHandler`'s shape (CTX-02) — backtest (`environment='backtest', sql_engine=None`) yields the same in-memory instances → oracle byte-exact (CTX-03, per-PLAN gate); `test_okx_inertness.py` stays green (`FifoEventBus`/`EngineContext(sql_engine=None)` pull nothing heavy; extended register-vs-build assertion).
 
-**Plans**: TBD
+**Plans**: 3 plans
+
+**Wave 1** *(parallel — zero file overlap, no deps)*
+
+- [ ] 02-01-PLAN.md — Bus substrate: `EventBus` Protocol + `FifoEventBus`/`PriorityEventBus` + `_CONTROL_EVENT_TYPES` + 3 CONTROL `EventType`s + BUS-01/02/03 unit suite (BUS-01/02/03)
+- [ ] 02-02-PLAN.md — Handler-owned storage: `OrderHandler`/`StrategiesHandler` own storage init from `(environment, sql_engine)`, backtest slice = in-memory concretes (CTX-02)
+
+**Wave 2** *(blocked on Wave 1 — depends on 02-01 + 02-02)*
+
+- [ ] 02-03-PLAN.md — Compose seam settle: `EngineContext` + retype-not-rename bus swap + `compose_engine(ctx, spec)` (internal queue deleted) + both backtest arms inject `EngineContext(FifoEventBus, backtest, sql_engine=None)` + extended inertness gate (BUS-01/BUS-04/CTX-01/CTX-03)
 
 ### Phase 3: EngineContext + Storage-in-Handler
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -159,7 +159,7 @@ below, not strict numeric order (P4 waits on P3; P5 on P2+P3; P6 on P4+P5; etc.)
 
 **Wave 2** *(blocked on Wave 1 — depends on 02-01 + 02-02)*
 
-- [ ] 02-03-PLAN.md — Compose seam settle: `EngineContext` + retype-not-rename bus swap + `compose_engine(ctx, spec)` (internal queue deleted) + both backtest arms inject `EngineContext(FifoEventBus, backtest, sql_engine=None)` + extended inertness gate (BUS-01/BUS-04/CTX-01/CTX-03)
+- [x] 02-03-PLAN.md — Compose seam settle: `EngineContext` + retype-not-rename bus swap + `compose_engine(ctx, spec)` (internal queue deleted) + both backtest arms inject `EngineContext(FifoEventBus, backtest, sql_engine=None)` + extended inertness gate (BUS-01/BUS-04/CTX-01/CTX-03)
 
 ### Phase 3: EngineContext + Storage-in-Handler
 
@@ -317,7 +317,7 @@ P1 and P2 have no dependencies and can start in parallel.
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
 | 1. Config Centralization | v1.8 | 4/4 | Complete    | 2026-07-09 |
-| 2. Event Bus | v1.8 | 2/3 | In Progress|  |
+| 2. Event Bus | v1.8 | 3/3 | Complete   | 2026-07-09 |
 | 3. EngineContext + Storage-in-Handler | v1.8 | 0/TBD | Not started | - |
 | 4. Storage Schema: Migrations Relocation + New Durable Stores | v1.8 | 0/TBD | Not started | - |
 | 5. Venue Registry + Bundle | v1.8 | 0/TBD | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,13 +2,13 @@
 gsd_state_version: 1.0
 milestone: v1.8
 milestone_name: — Live System Refactor & Live-Readiness Hardening
-current_phase: 02
-current_phase_name: Event Bus
+current_phase: 3
+current_phase_name: EngineContext + Storage-in-Handler
 status: verifying
 stopped_at: Completed 02-03-PLAN.md
-last_updated: "2026-07-09T13:30:30.403Z"
+last_updated: "2026-07-09T13:45:39.640Z"
 last_activity: 2026-07-09
-last_activity_desc: Phase 02 execution started
+last_activity_desc: Phase 02 complete, transitioned to Phase 3
 progress:
   total_phases: 9
   completed_phases: 2
@@ -33,10 +33,10 @@ disturbing the byte-exact oracle or the OKX import-inertness gate**. FastAPI its
 
 ## Current Position
 
-Phase: 02 (Event Bus) — EXECUTING
-Plan: 3 of 3
+Phase: 3 — EngineContext + Storage-in-Handler
+Plan: Not started
 Status: Phase complete — ready for verification
-Last activity: 2026-07-09 — Phase 02 execution started
+Last activity: 2026-07-09 — Phase 02 complete, transitioned to Phase 3
 
 Progress: [░░░░░░░░░░] 0%
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -6,14 +6,14 @@ current_phase: 02
 current_phase_name: Event Bus
 status: executing
 stopped_at: Phase 2 context gathered
-last_updated: "2026-07-09T13:02:16.329Z"
+last_updated: "2026-07-09T13:08:13.264Z"
 last_activity: 2026-07-09
 last_activity_desc: Phase 02 execution started
 progress:
   total_phases: 9
   completed_phases: 1
   total_plans: 7
-  completed_plans: 5
+  completed_plans: 6
   percent: 11
 ---
 
@@ -34,7 +34,7 @@ disturbing the byte-exact oracle or the OKX import-inertness gate**. FastAPI its
 ## Current Position
 
 Phase: 02 (Event Bus) — EXECUTING
-Plan: 2 of 3
+Plan: 3 of 3
 Status: Ready to execute
 Last activity: 2026-07-09 — Phase 02 execution started
 
@@ -130,6 +130,7 @@ P1/P5/P6/P7/P8 (all live-only / backtest-dark).
 - [Phase ?]: P1-04: live_trading_system.py is 4-space not tabs (od-verified); _OKX_*/_PAPER_* retired, PAPER_PARITY_* anchor preserved byte-identical (Pitfall 4)
 - [Phase 02]: D-09/D-10: event-bus substrate (EventBus Protocol + FifoEventBus + PriorityEventBus) landed in itrader/events_handler/bus.py, import-inert (Event TYPE_CHECKING-only), wired into nothing — Plan 02-01: pure substrate, oracle-dark
 - [Phase 02]: Typed bus internal queues concretely (queue.Queue[Event] / PriorityQueue[tuple]) not [Any] to satisfy mypy --strict verification gate (byte-identical at runtime) — Rule 3 blocking fix during 02-01 Task 2
+- [Phase 02]: D-02/CTX-02: OrderHandler + StrategiesHandler own storage init from keyword-only (environment=backtest, sql_engine=None), exposing the concrete on .storage/.signal_store for the plan-02-03 compose back-read; purely additive, backtest slice = same in-memory concretes, oracle byte-exact (Plan 02-02)
 
 ### Pending Todos
 
@@ -189,6 +190,7 @@ substantive owner-gated item is `margin-equity-double-counts-notional-wr01`.
 | Phase 01 P03 | 4m | 1 tasks | 1 files |
 | Phase 01 P04 | 25min | 3 tasks | 15 files |
 | Phase 02 P01 | 3min | 3 tasks | 3 files |
+| Phase 02 P02 | 6min | 3 tasks | 4 files |
 
 ## Bookkeeping
 
@@ -200,7 +202,7 @@ substantive owner-gated item is `margin-equity-double-counts-notional-wr01`.
 
 ## Session Continuity
 
-Last session: 2026-07-09T13:02:16.321Z
+Last session: 2026-07-09T13:07:26.915Z
 Stopped at: Phase 2 context gathered
 success criteria + dependencies + 64/64 coverage); STATE.md refreshed for 12 phases; REQUIREMENTS.md
 traceability + category tags + gates renumbered.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,17 +4,17 @@ milestone: v1.8
 milestone_name: — Live System Refactor & Live-Readiness Hardening
 current_phase: 02
 current_phase_name: Event Bus
-status: executing
-stopped_at: Phase 2 context gathered
-last_updated: "2026-07-09T13:08:13.264Z"
+status: verifying
+stopped_at: Completed 02-03-PLAN.md
+last_updated: "2026-07-09T13:30:30.403Z"
 last_activity: 2026-07-09
 last_activity_desc: Phase 02 execution started
 progress:
   total_phases: 9
-  completed_phases: 1
+  completed_phases: 2
   total_plans: 7
-  completed_plans: 6
-  percent: 11
+  completed_plans: 7
+  percent: 22
 ---
 
 # Project State
@@ -35,7 +35,7 @@ disturbing the byte-exact oracle or the OKX import-inertness gate**. FastAPI its
 
 Phase: 02 (Event Bus) — EXECUTING
 Plan: 3 of 3
-Status: Ready to execute
+Status: Phase complete — ready for verification
 Last activity: 2026-07-09 — Phase 02 execution started
 
 Progress: [░░░░░░░░░░] 0%
@@ -131,6 +131,9 @@ P1/P5/P6/P7/P8 (all live-only / backtest-dark).
 - [Phase 02]: D-09/D-10: event-bus substrate (EventBus Protocol + FifoEventBus + PriorityEventBus) landed in itrader/events_handler/bus.py, import-inert (Event TYPE_CHECKING-only), wired into nothing — Plan 02-01: pure substrate, oracle-dark
 - [Phase 02]: Typed bus internal queues concretely (queue.Queue[Event] / PriorityQueue[tuple]) not [Any] to satisfy mypy --strict verification gate (byte-identical at runtime) — Rule 3 blocking fix during 02-01 Task 2
 - [Phase 02]: D-02/CTX-02: OrderHandler + StrategiesHandler own storage init from keyword-only (environment=backtest, sql_engine=None), exposing the concrete on .storage/.signal_store for the plan-02-03 compose back-read; purely additive, backtest slice = same in-memory concretes, oracle byte-exact (Plan 02-02)
+- [Phase ?]: 02-03: compose_engine folded to two-arg (ctx, spec) end-state; internal queue deleted, ctx.bus owns transport (D-01/CTX-01)
+- [Phase 02]: 02-03: EngineContext = 4 loose fields (bus/config/environment/sql_engine); downstream only tightens types, never adds fields (D-05/BUS-04)
+- [Phase 02]: 02-03: global_queue retyped to EventBus (name unchanged) across 5 handlers + SimulatedExchange + BacktestBarFeed.bind; no call-site changes (D-07/D-08)
 
 ### Pending Todos
 
@@ -191,6 +194,7 @@ substantive owner-gated item is `margin-equity-double-counts-notional-wr01`.
 | Phase 01 P04 | 25min | 3 tasks | 15 files |
 | Phase 02 P01 | 3min | 3 tasks | 3 files |
 | Phase 02 P02 | 6min | 3 tasks | 4 files |
+| Phase 02 P03 | 18min | 3 tasks | 10 files |
 
 ## Bookkeeping
 
@@ -202,11 +206,11 @@ substantive owner-gated item is `margin-equity-double-counts-notional-wr01`.
 
 ## Session Continuity
 
-Last session: 2026-07-09T13:07:26.915Z
-Stopped at: Phase 2 context gathered
+Last session: 2026-07-09T13:30:30.397Z
+Stopped at: Completed 02-03-PLAN.md
 success criteria + dependencies + 64/64 coverage); STATE.md refreshed for 12 phases; REQUIREMENTS.md
 traceability + category tags + gates renumbered.
-Resume file: .planning/phases/02-event-bus/02-CONTEXT.md
+Resume file: None
 Carried todo: 14 pending todos in `todos/pending/` (10 fold into v1.8 as CF-1..CF-10; `v17-residual-carryforward.md`
 is the index; the substantive open item is `margin-equity-double-counts-notional-wr01`, owner-gated).
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,8 +5,8 @@ milestone_name: — Live System Refactor & Live-Readiness Hardening
 current_phase: 2
 current_phase_name: Event Bus
 status: verifying
-stopped_at: Phase 1 planned — 4 plans, verification passed, ready to execute
-last_updated: "2026-07-09T11:13:47.028Z"
+stopped_at: Phase 2 context gathered
+last_updated: "2026-07-09T11:56:25.404Z"
 last_activity: 2026-07-09
 last_activity_desc: Phase 01 complete, transitioned to Phase 2
 progress:
@@ -197,11 +197,11 @@ substantive owner-gated item is `margin-equity-double-counts-notional-wr01`.
 
 ## Session Continuity
 
-Last session: 2026-07-09T10:37:19.000Z
-Stopped at: Phase 1 planned — 4 plans, verification passed, ready to execute
+Last session: 2026-07-09T11:56:25.397Z
+Stopped at: Phase 2 context gathered
 success criteria + dependencies + 64/64 coverage); STATE.md refreshed for 12 phases; REQUIREMENTS.md
 traceability + category tags + gates renumbered.
-Resume file: .planning/phases/01-config-centralization/01-CONTEXT.md
+Resume file: .planning/phases/02-event-bus/02-CONTEXT.md
 Carried todo: 14 pending todos in `todos/pending/` (10 fold into v1.8 as CF-1..CF-10; `v17-residual-carryforward.md`
 is the index; the substantive open item is `margin-equity-double-counts-notional-wr01`, owner-gated).
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,9 +4,9 @@ milestone: v1.8
 milestone_name: — Live System Refactor & Live-Readiness Hardening
 current_phase: 2
 current_phase_name: Event Bus
-status: verifying
+status: executing
 stopped_at: Phase 2 context gathered
-last_updated: "2026-07-09T11:56:25.404Z"
+last_updated: "2026-07-09T12:48:30.536Z"
 last_activity: 2026-07-09
 last_activity_desc: Phase 01 complete, transitioned to Phase 2
 progress:
@@ -35,7 +35,7 @@ disturbing the byte-exact oracle or the OKX import-inertness gate**. FastAPI its
 
 Phase: 2 — Event Bus
 Plan: Not started
-Status: Phase complete — ready for verification
+Status: Ready to execute
 Last activity: 2026-07-09 — Phase 01 complete, transitioned to Phase 2
 
 Progress: [░░░░░░░░░░] 0%

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,18 +2,18 @@
 gsd_state_version: 1.0
 milestone: v1.8
 milestone_name: — Live System Refactor & Live-Readiness Hardening
-current_phase: 2
+current_phase: 02
 current_phase_name: Event Bus
 status: executing
 stopped_at: Phase 2 context gathered
-last_updated: "2026-07-09T12:48:30.536Z"
+last_updated: "2026-07-09T13:02:16.329Z"
 last_activity: 2026-07-09
-last_activity_desc: Phase 01 complete, transitioned to Phase 2
+last_activity_desc: Phase 02 execution started
 progress:
   total_phases: 9
   completed_phases: 1
-  total_plans: 4
-  completed_plans: 4
+  total_plans: 7
+  completed_plans: 5
   percent: 11
 ---
 
@@ -26,17 +26,17 @@ See: .planning/PROJECT.md (Current Milestone: v1.8 — Live System Refactor & Li
 **Core value:** A single backtest run of `SMA_MACD` on the golden BTCUSD CSV produces correct,
 deterministic, cross-validated numbers (oracle **134 / `46189.87730727451`**; v1.5 W1 baseline 15.7 s /
 152.8 MB). v1.7 shipped a live operating mode (paper-first on OKX) without disturbing that oracle.
-**Current focus:** Phase 01 — config-centralization
+**Current focus:** Phase 02 — Event Bus
 thin ~200-line facade over focused, venue-parametrized, FastAPI-ready collaborators — **without
 disturbing the byte-exact oracle or the OKX import-inertness gate**. FastAPI itself is out of scope
 (LR-01). Full scope: core refactor (P1–P8 + P12) + the three ★ feature-adds (P9–P11).
 
 ## Current Position
 
-Phase: 2 — Event Bus
-Plan: Not started
+Phase: 02 (Event Bus) — EXECUTING
+Plan: 2 of 3
 Status: Ready to execute
-Last activity: 2026-07-09 — Phase 01 complete, transitioned to Phase 2
+Last activity: 2026-07-09 — Phase 02 execution started
 
 Progress: [░░░░░░░░░░] 0%
 
@@ -128,6 +128,8 @@ P1/P5/P6/P7/P8 (all live-only / backtest-dark).
 - [Phase ?]: P1-03: CF-6 D-03a reconcile — folded §6d nuance (exchange-side layer real only where called = SimulatedExchange) into item 4 without regressing the post-V17-16 D-10 framing; CFG-06 closed (doc-only)
 - [Phase ?]: P1-04: live-only supervisor/feed constants folded into pure-pydantic StreamSettings + FeedProviderSettings (config/stream.py); reconnect fields float/int not Decimal; P1 seam = default-constructed instance, shared StreamSupervisor deferred to P5 (CFG-03/D-08)
 - [Phase ?]: P1-04: live_trading_system.py is 4-space not tabs (od-verified); _OKX_*/_PAPER_* retired, PAPER_PARITY_* anchor preserved byte-identical (Pitfall 4)
+- [Phase 02]: D-09/D-10: event-bus substrate (EventBus Protocol + FifoEventBus + PriorityEventBus) landed in itrader/events_handler/bus.py, import-inert (Event TYPE_CHECKING-only), wired into nothing — Plan 02-01: pure substrate, oracle-dark
+- [Phase 02]: Typed bus internal queues concretely (queue.Queue[Event] / PriorityQueue[tuple]) not [Any] to satisfy mypy --strict verification gate (byte-identical at runtime) — Rule 3 blocking fix during 02-01 Task 2
 
 ### Pending Todos
 
@@ -186,6 +188,7 @@ substantive owner-gated item is `margin-equity-double-counts-notional-wr01`.
 | Phase 01 P02 | 12 | 2 tasks | 4 files |
 | Phase 01 P03 | 4m | 1 tasks | 1 files |
 | Phase 01 P04 | 25min | 3 tasks | 15 files |
+| Phase 02 P01 | 3min | 3 tasks | 3 files |
 
 ## Bookkeeping
 
@@ -197,7 +200,7 @@ substantive owner-gated item is `margin-equity-double-counts-notional-wr01`.
 
 ## Session Continuity
 
-Last session: 2026-07-09T11:56:25.397Z
+Last session: 2026-07-09T13:02:16.321Z
 Stopped at: Phase 2 context gathered
 success criteria + dependencies + 64/64 coverage); STATE.md refreshed for 12 phases; REQUIREMENTS.md
 traceability + category tags + gates renumbered.

--- a/.planning/phases/02-event-bus/02-01-PLAN.md
+++ b/.planning/phases/02-event-bus/02-01-PLAN.md
@@ -1,0 +1,234 @@
+---
+phase: 02-event-bus
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - itrader/events_handler/bus.py
+  - itrader/core/enums/event.py
+  - tests/unit/events/test_event_bus.py
+autonomous: true
+requirements: [BUS-01, BUS-02, BUS-03]
+must_haves:
+  truths:
+    - "BUS-01/D-09: `FifoEventBus` and `PriorityEventBus` both satisfy the `EventBus` Protocol (`put`/`get`/`get_nowait`/`qsize`/`empty`/`depth_by_tier`); the Protocol is `@runtime_checkable` so `isinstance(bus, EventBus)` is True for both."
+    - "BUS-02/D-10: `PriorityEventBus` dequeues CONTROL (tier 0) before BUSINESS (tier 1) and preserves strict within-tier FIFO via one per-instance `itertools.count()` seq; the `(tier, seq, event)` tuple never dereferences the event, and a bare `Event < Event` raises `TypeError` (negative test proves the seq guarantee is load-bearing)."
+    - "BUS-03: `EventType` gains `STREAM_STATE`, `CONNECTOR_FATAL`, `CONFIG_UPDATE` string members; `_CONTROL_EVENT_TYPES` frozenset assigns CONTROL tier to those three plus the existing `STRATEGY_COMMAND`; every other `EventType` defaults BUSINESS."
+    - "D-07 drain contract: `FifoEventBus.get_nowait()` and `PriorityEventBus.get_nowait()` both raise `queue.Empty` on empty (inherited from the wrapped stdlib queue); priority `get*()` returns a BARE `Event`, never the tuple."
+    - "D-09 inertness discipline: `bus.py` imports only stdlib (`queue`/`itertools`/`enum`/`typing`/`collections`/`threading`) plus `itrader.core.enums.event`; `Event` is a `TYPE_CHECKING`-only import (no pandas/events-package runtime pull)."
+  artifacts:
+    - itrader/events_handler/bus.py
+    - itrader/core/enums/event.py
+    - tests/unit/events/test_event_bus.py
+  key_links:
+    - "`_CONTROL_EVENT_TYPES` references the 3 new members + the existing `EventType.STRATEGY_COMMAND`."
+    - "`PriorityEventBus.put(event)` reads `event.type`, maps it through `_CONTROL_EVENT_TYPES` to a tier, and enqueues `(tier, next(self._seq), event)`."
+    - "`PriorityEventBus.get()/get_nowait()` unwrap `self._pq.get(...)[2]` so the `EventHandler` drain receives a bare `Event`."
+---
+
+<objective>
+Build the pure, isolated two-tier event-bus substrate with ZERO wiring touch and ZERO oracle risk.
+Create `itrader/events_handler/bus.py` (the `EventBus` Protocol, an `EventTier` enum, the
+`_CONTROL_EVENT_TYPES` frozenset, a `FifoEventBus` thin `queue.Queue` wrapper, and a
+`PriorityEventBus` `queue.PriorityQueue` wrapper), add the three new CONTROL `EventType` members, and
+prove BUS-01/BUS-02/BUS-03 with a dedicated unit suite.
+
+Purpose: land the substrate the P2 compose seam (plan 02-03) wires `FifoEventBus` into, and the
+substrate P6/P7 will later wire `PriorityEventBus` into for CONTROL-plane preemption. This plan touches
+no run-path wiring, so it cannot move the oracle.
+
+Output: `bus.py`, three new `EventType` members, and `tests/unit/events/test_event_bus.py`.
+
+Locked decisions delivered here: D-09 (Protocol surface + `bus.py` 4-space home), D-10 (`PriorityEventBus`
+defined + unit-tested only, `itertools.count()` seq), and the BUS-03 CONTROL vocabulary. Per D-11 this
+plan wires nothing into `live_trading_system.py`.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/02-event-bus/02-CONTEXT.md
+@.planning/phases/02-event-bus/02-RESEARCH.md
+@.planning/phases/02-event-bus/02-PATTERNS.md
+@.planning/phases/02-event-bus/02-VALIDATION.md
+</context>
+
+## Artifacts this phase produces (do not treat as pre-existing / drift)
+
+New symbols introduced across Phase 2 (this plan creates the starred ones):
+- `EventBus` Protocol ★, `EventTier` enum ★, `_CONTROL_EVENT_TYPES` frozenset ★, `FifoEventBus` ★,
+  `PriorityEventBus` ★ — all in the new file `itrader/events_handler/bus.py` ★.
+- `EventType.STREAM_STATE`, `EventType.CONNECTOR_FATAL`, `EventType.CONFIG_UPDATE` ★ (new members).
+- `tests/unit/events/test_event_bus.py` ★ (new test file).
+- (plans 02-02 / 02-03) new handler ctor kwargs `environment` / `sql_engine` on `OrderHandler` and
+  `StrategiesHandler`; `OrderHandler.storage` attribute; `EngineContext` dataclass +
+  `itrader/trading_system/engine_context.py`; `compose_engine(ctx, spec)` two-arg signature.
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add the three CONTROL EventType members</name>
+  <files>itrader/core/enums/event.py</files>
+  <read_first>
+    - itrader/core/enums/event.py (the file being edited — **4-SPACE indent, verified**; do NOT use tabs)
+    - .planning/phases/02-event-bus/02-PATTERNS.md § "core/enums/event.py" (the exact member style)
+    - .planning/phases/02-event-bus/02-RESEARCH.md § Code Examples (the 3-member snippet + comments)
+  </read_first>
+  <action>
+    Add three string-valued members to the `EventType(Enum)` class, alongside the existing v1.7 members
+    (`UNIVERSE_POLL`/`STRATEGY_COMMAND`/`BARS_LOADED`/`BARS_LOAD_FAILED`), immediately before `ERROR`:
+    `STREAM_STATE = "STREAM_STATE"`, `CONNECTOR_FATAL = "CONNECTOR_FATAL"`, `CONFIG_UPDATE = "CONFIG_UPDATE"`.
+    Match the existing explicit-uppercase-string convention and add a one-line trailing comment on each
+    naming its CONTROL role (connector stream up/down; connector fatal → halt; scoped runtime config change).
+    Do NOT modify `_missing_` (it iterates all members). Do NOT touch `Side`. Keep 4-space indentation.
+  </action>
+  <verify>
+    <automated>poetry run python -c "from itrader.core.enums.event import EventType; assert {'STREAM_STATE','CONNECTOR_FATAL','CONFIG_UPDATE'} <= {m.name for m in EventType}; assert EventType('stream_state') is EventType.STREAM_STATE"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `EventType.STREAM_STATE`, `EventType.CONNECTOR_FATAL`, `EventType.CONFIG_UPDATE` exist with matching
+      string values, and case-insensitive `EventType('config_update')` resolves via `_missing_`.
+    - `grep -cP '^\t' itrader/core/enums/event.py` returns 0 (no tab lines introduced).
+  </acceptance_criteria>
+  <done>Three CONTROL members present and importable; enum parse round-trips; no tabs added.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Create the bus substrate (EventBus Protocol, EventTier, both buses)</name>
+  <files>itrader/events_handler/bus.py</files>
+  <read_first>
+    - itrader/core/enums/event.py (source of `EventType` + the new CONTROL members; **4-SPACE**)
+    - itrader/events_handler/full_event_handler.py:117-130 (the drain contract the buses must satisfy — `get_nowait()` + `except queue.Empty`)
+    - itrader/core/portfolio_read_model.py (the house `typing.Protocol` read-model seam to mirror)
+    - .planning/phases/02-event-bus/02-PATTERNS.md § "itrader/events_handler/bus.py (NEW)" (structure + priority invariant)
+    - .planning/phases/02-event-bus/02-RESEARCH.md § Code Examples + § Don't Hand-Roll (verified `itertools.count()`/`PriorityQueue` invariant)
+    - NOTE: bus.py is a NEW file — write it **4-SPACE** (the `events_handler/events/` package convention, D-09), NOT tabs.
+  </read_first>
+  <action>
+    Create `itrader/events_handler/bus.py` (4-space). Runtime imports: `queue`, `itertools`, `threading`,
+    `from collections import Counter`, `from enum import IntEnum`, `from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable`,
+    and `from itrader.core.enums.event import EventType`. Under `if TYPE_CHECKING:` import `Event`
+    from `itrader.events_handler.events` (annotation-only — the events package pulls pandas at runtime; keep it off this module).
+
+    Define, in order:
+    - `class EventTier(IntEnum): CONTROL = 0; BUSINESS = 1` — int-comparable so it sorts as the first tuple element.
+    - `_CONTROL_EVENT_TYPES: frozenset[EventType] = frozenset({EventType.STREAM_STATE, EventType.CONNECTOR_FATAL, EventType.CONFIG_UPDATE, EventType.STRATEGY_COMMAND})`.
+      Add a comment: BUSINESS is the default fall-through; only CONTROL is enumerated (robust to future `EventType` additions — never enumerate BUSINESS).
+    - `def _tier(event_type: EventType) -> EventTier:` returns `EventTier.CONTROL if event_type in _CONTROL_EVENT_TYPES else EventTier.BUSINESS`.
+    - `@runtime_checkable` `class EventBus(Protocol):` with method signatures only (`...` bodies):
+      `put(self, event: "Event") -> None`, `get(self, timeout: "float | None" = None) -> "Event"`,
+      `get_nowait(self) -> "Event"`, `qsize(self) -> int`, `empty(self) -> bool`,
+      `depth_by_tier(self) -> "dict[EventTier, int]"`.
+    - `class FifoEventBus:` wraps `self._q: "queue.Queue[Any]" = queue.Queue()`. `put`→`self._q.put(event)`;
+      `get`→`self._q.get(timeout=timeout)`; `get_nowait`→`self._q.get_nowait()` (delegates → raises `queue.Empty` unchanged);
+      `qsize`/`empty`→delegate; `depth_by_tier`→`{EventTier.BUSINESS: self._q.qsize()}` (FIFO is tierless — single-bucket, documented monitoring-only).
+    - `class PriorityEventBus:` wraps `self._pq: "queue.PriorityQueue[Any]" = queue.PriorityQueue()`, one
+      per-instance `self._seq = itertools.count()`, and a per-tier `self._depth: "Counter[EventTier]" = Counter()`
+      guarded by `self._depth_lock = threading.Lock()`. `put(event)`: compute `tier = _tier(event.type)`,
+      enqueue `self._pq.put((tier, next(self._seq), event))`, and under the lock `self._depth[tier] += 1`.
+      `get(timeout)`/`get_nowait()`: pull the tuple from `self._pq`, under the lock decrement `self._depth[tuple[0]]`,
+      and **return `tuple[2]`** (the bare `Event` — never the tuple). Empty behaviour is inherited (`queue.Empty`).
+      `qsize`/`empty`→delegate; `depth_by_tier`→a lock-guarded copy `{EventTier.CONTROL: self._depth[EventTier.CONTROL], EventTier.BUSINESS: self._depth[EventTier.BUSINESS]}`.
+
+    Do NOT add `__lt__`/`__eq__`/ordering guards to `Event` — the unique `seq` means events are never compared
+    (adding ordering would be dead code, per RESEARCH § Don't Hand-Roll). Do NOT wire this into any handler
+    or `live_trading_system.py` (D-10/D-11 — substrate only).
+  </action>
+  <verify>
+    <automated>poetry run python -c "from itrader.events_handler.bus import EventBus, EventTier, FifoEventBus, PriorityEventBus, _CONTROL_EVENT_TYPES; assert isinstance(FifoEventBus(), EventBus) and isinstance(PriorityEventBus(), EventBus); assert EventTier.CONTROL < EventTier.BUSINESS; import queue; b=FifoEventBus(); \nimport builtins\ntry:\n b.get_nowait(); assert False\nexcept queue.Empty: pass"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c 'class FifoEventBus' itrader/events_handler/bus.py` == 1 and `grep -c 'class PriorityEventBus' itrader/events_handler/bus.py` == 1.
+    - `isinstance(FifoEventBus(), EventBus)` and `isinstance(PriorityEventBus(), EventBus)` are both True (runtime_checkable Protocol conformance).
+    - `FifoEventBus().get_nowait()` raises `queue.Empty` on empty.
+    - `grep -v '^#' itrader/events_handler/bus.py | grep -Ec 'import (sqlalchemy|ccxt|pandas)'` == 0 (no heavy imports; `Event` is TYPE_CHECKING-only).
+    - `grep -cP '^\t' itrader/events_handler/bus.py` == 0 (4-space file, no tabs).
+  </acceptance_criteria>
+  <done>Both buses satisfy the Protocol, delegate empty→`queue.Empty`, and `bus.py` pulls nothing heavy.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Prove BUS-01/BUS-02/BUS-03 in a unit suite</name>
+  <files>tests/unit/events/test_event_bus.py</files>
+  <read_first>
+    - itrader/events_handler/bus.py (the substrate under test — created in Task 2)
+    - itrader/events_handler/events/base.py:1-40 (the real `Event` = `msgspec.Struct(frozen=True)`; a concrete event to construct)
+    - .planning/phases/02-event-bus/02-VALIDATION.md § Per-Task Verification Map (the -k filter names: `priority`, `control_types`)
+    - .planning/phases/02-event-bus/02-RESEARCH.md § Code Examples (the exact ordering assertion shape + the `Event < Event` TypeError negative test)
+    - PROJECT HAZARD: do NOT create `tests/unit/events/__init__.py` — an empty `__init__` triggers the package-collision that breaks full-suite collection (keep `tests/unit/*` package-less). Tests are 4-space.
+  </read_first>
+  <action>
+    Create `tests/unit/events/test_event_bus.py` (4-space, no `__init__.py` in the dir). Use a minimal
+    concrete event to enqueue — prefer a real lightweight event (e.g. construct a `SignalEvent`/`BarEvent`
+    via its factory) or a tiny `msgspec.Struct(frozen=True, kw_only=True)` local subclass carrying a `type`
+    attribute set to an `EventType`. Add tests:
+    - BUS-01 (`test_*_satisfies_protocol`): both `FifoEventBus` and `PriorityEventBus` pass `isinstance(bus, EventBus)`;
+      round-trip a `put` then `get_nowait` returns the SAME event object; `get_nowait()` on empty raises `queue.Empty` for both;
+      `qsize`/`empty`/`depth_by_tier` return the expected types.
+    - BUS-02 (`test_priority_*`): enqueue two BUSINESS events then one CONTROL event; assert the CONTROL event
+      dequeues FIRST, then the two BUSINESS events in strict FIFO (insertion) order; assert `get_nowait()` returns
+      a bare `Event` (has `.type`), NOT a tuple. Negative test (`test_priority_never_compares_events`): assert a
+      bare `event_a < event_b` raises `TypeError` (proves the shared `seq` guarantee is load-bearing). Also enqueue
+      many same-tier events and assert stable FIFO order (no `TypeError` under repeated puts).
+    - BUS-03 (`test_control_types_*`): assert `EventType.STREAM_STATE`/`CONNECTOR_FATAL`/`CONFIG_UPDATE` are in
+      `_CONTROL_EVENT_TYPES`; assert `_tier(EventType.STREAM_STATE) == EventTier.CONTROL` and
+      `_tier(EventType.BAR) == EventTier.BUSINESS`; assert `EventType.STRATEGY_COMMAND` is CONTROL.
+    Keep the suite pure-stdlib fast (no data load). Do NOT add markers by hand (the folder-derived `unit` marker auto-applies).
+  </action>
+  <verify>
+    <automated>poetry run pytest tests/unit/events/test_event_bus.py -x</automated>
+  </verify>
+  <acceptance_criteria>
+    - `poetry run pytest tests/unit/events/test_event_bus.py -x` exits 0.
+    - `poetry run pytest tests/unit/events/test_event_bus.py -k priority -x` and `-k control_types -x` each select ≥1 test and pass.
+    - `test -f tests/unit/events/__init__.py` is FALSE (no package `__init__` in the events test dir).
+    - A test asserts `event_a < event_b` raises `TypeError` (the load-bearing non-orderability proof).
+  </acceptance_criteria>
+  <done>BUS-01/02/03 proven green; CONTROL preempts BUSINESS; within-tier FIFO holds; events never compared.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| (none new) | Pure in-process stdlib queues, backtest-dark substrate, no external input, no I/O, no auth/secrets. The CONTROL/BUSINESS tiering is an operational-ordering mechanism, not a trust boundary — no untrusted input crosses the new seam in P2. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-02-01 | Tampering / Repudiation | `PriorityEventBus` tuple keying | medium | mitigate | Shared per-instance `itertools.count()` seq guarantees `(tier, seq, event)` is always unique on the first two elements → the heap never dereferences the non-orderable `Event`; the BUS-02 negative test locks the invariant (a duplicated seq would be a latent `TypeError` crash). |
+| T-02-02 | (availability/perf) | `bus.py` imports | high | mitigate | `bus.py` imports only stdlib + `core.enums.event`; `Event` is `TYPE_CHECKING`-only. Grep gate in Task 2 acceptance asserts no `sqlalchemy`/`ccxt`/`pandas` import — protects the recurring inertness failure mode. |
+| T-02-03 | Tampering (behavioral) | `PriorityEventBus` live ordering | low | accept | D-10/D-11: the priority bus is defined + unit-tested ONLY in P2 and wired into no live path; validated v1.7 live ordering is untouched until P6/P7 land a live-smoke gate (P12). No behavioral change ships this plan. |
+| T-02-SC | Tampering (supply chain) | package installs | low | accept | Zero package installs this phase (milestone gate forbids any `poetry` change P1–P12); `poetry.lock` byte-unchanged is a phase-gate check. No `[ASSUMED]`/`[SUS]` packages exist. |
+</threat_model>
+
+<verification>
+- `poetry run pytest tests/unit/events/test_event_bus.py -x` green (BUS-01/02/03).
+- `poetry run python -c "import itrader.events_handler.bus"` imports clean (no heavy pull).
+- `poetry run mypy itrader/events_handler/bus.py itrader/core/enums/event.py` clean (new code strict).
+- `git diff --stat` shows only `bus.py`, `event.py`, `test_event_bus.py` — NO wiring files touched (oracle cannot move).
+- `git diff --exit-code itrader/trading_system/live_trading_system.py` shows no changes (D-11).
+- `git diff --stat poetry.lock` empty (no dependency change).
+</verification>
+
+<success_criteria>
+- `EventBus` Protocol + `FifoEventBus` + `PriorityEventBus` + `EventTier` + `_CONTROL_EVENT_TYPES` exist in `bus.py`; both buses pass `isinstance(bus, EventBus)`.
+- The three CONTROL `EventType` members exist and are assigned CONTROL tier.
+- BUS-02 ordering + non-orderability proven; within-tier FIFO strict.
+- `bus.py` pulls nothing heavy; no wiring touched; `live_trading_system.py` unchanged; `poetry.lock` unchanged.
+</success_criteria>
+
+<output>
+Create `.planning/phases/02-event-bus/02-01-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/02-event-bus/02-01-PLAN.md
+++ b/.planning/phases/02-event-bus/02-01-PLAN.md
@@ -142,7 +142,7 @@ New symbols introduced across Phase 2 (this plan creates the starred ones):
     or `live_trading_system.py` (D-10/D-11 — substrate only).
   </action>
   <verify>
-    <automated>poetry run python -c "from itrader.events_handler.bus import EventBus, EventTier, FifoEventBus, PriorityEventBus, _CONTROL_EVENT_TYPES; assert isinstance(FifoEventBus(), EventBus) and isinstance(PriorityEventBus(), EventBus); assert EventTier.CONTROL < EventTier.BUSINESS; import queue; b=FifoEventBus(); \nimport builtins\ntry:\n b.get_nowait(); assert False\nexcept queue.Empty: pass"</automated>
+    <automated>poetry run python -c "from itrader.events_handler.bus import EventBus, EventTier, FifoEventBus, PriorityEventBus, _CONTROL_EVENT_TYPES; assert isinstance(FifoEventBus(), EventBus); assert isinstance(PriorityEventBus(), EventBus); assert EventTier.CONTROL < EventTier.BUSINESS"</automated>
   </verify>
   <acceptance_criteria>
     - `grep -c 'class FifoEventBus' itrader/events_handler/bus.py` == 1 and `grep -c 'class PriorityEventBus' itrader/events_handler/bus.py` == 1.

--- a/.planning/phases/02-event-bus/02-01-SUMMARY.md
+++ b/.planning/phases/02-event-bus/02-01-SUMMARY.md
@@ -1,0 +1,164 @@
+---
+phase: 02-event-bus
+plan: 01
+subsystem: infra
+tags: [event-bus, queue, priority-queue, protocol, msgspec, enum, itertools]
+
+# Dependency graph
+requires:
+  - phase: 01
+    provides: "EventType string-enum + msgspec.Struct Event base (frozen, non-orderable)"
+provides:
+  - "EventBus runtime_checkable Protocol (put/get/get_nowait/qsize/empty/depth_by_tier) in itrader/events_handler/bus.py"
+  - "FifoEventBus — thin queue.Queue wrapper (byte-exact backtest buffer, D-07)"
+  - "PriorityEventBus — queue.PriorityQueue keyed (tier, seq, event); CONTROL preempts BUSINESS, strict within-tier FIFO"
+  - "EventTier IntEnum (CONTROL=0, BUSINESS=1) + _CONTROL_EVENT_TYPES frozenset + _tier() mapper"
+  - "Three new CONTROL EventType members: STREAM_STATE, CONNECTOR_FATAL, CONFIG_UPDATE"
+affects: [02-02, 02-03, compose-seam, engine-context, priority-plane-P6-P7]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Protocol read-model seam reused as transport interface (EventBus mirrors PortfolioReadModel shape)"
+    - "PriorityQueue tuple keyed by one per-instance itertools.count() seq so the heap never dereferences the non-orderable Event"
+    - "Bus assigns tier from event.type via _CONTROL_EVENT_TYPES — handlers stay tier-unaware"
+    - "Import-inertness discipline: TYPE_CHECKING-only Event import keeps pandas off the substrate"
+
+key-files:
+  created:
+    - itrader/events_handler/bus.py
+    - tests/unit/events/test_event_bus.py
+  modified:
+    - itrader/core/enums/event.py
+
+key-decisions:
+  - "D-09: bus.py is 4-space, imports only stdlib + core.enums.event; Event is TYPE_CHECKING-only"
+  - "D-10: PriorityEventBus is defined + unit-tested ONLY in P2, wired into no live path"
+  - "D-11: no wiring touched — live_trading_system.py unchanged, poetry.lock byte-identical"
+  - "Typed queue element as queue.Queue[Event] / PriorityQueue[tuple[EventTier,int,Event]] to satisfy mypy --strict (no Any returns)"
+
+patterns-established:
+  - "Two-tier event transport: CONTROL(0) preempts BUSINESS(1); BUSINESS is the default fall-through — only CONTROL is enumerated"
+  - "get*() unwrap the priority tuple and return a BARE Event so the EventHandler drain contract is unchanged"
+
+requirements-completed: [BUS-01, BUS-02, BUS-03]
+
+coverage:
+  - id: D1
+    description: "EventBus Protocol + FifoEventBus + PriorityEventBus satisfy runtime_checkable isinstance; put/get round-trips same object; get_nowait raises queue.Empty on empty"
+    requirement: "BUS-01"
+    verification:
+      - kind: unit
+        ref: "tests/unit/events/test_event_bus.py#test_bus_satisfies_protocol / test_bus_put_get_roundtrips_same_object / test_get_nowait_raises_empty_on_empty"
+        status: pass
+    human_judgment: false
+  - id: D2
+    description: "PriorityEventBus dequeues CONTROL before BUSINESS, preserves strict within-tier FIFO, returns bare Event not tuple, and never compares events (event<event raises TypeError)"
+    requirement: "BUS-02"
+    verification:
+      - kind: unit
+        ref: "tests/unit/events/test_event_bus.py -k priority (9 tests)"
+        status: pass
+    human_judgment: false
+  - id: D3
+    description: "STREAM_STATE / CONNECTOR_FATAL / CONFIG_UPDATE EventType members exist, are in _CONTROL_EVENT_TYPES, and tier to CONTROL; BAR defaults BUSINESS"
+    requirement: "BUS-03"
+    verification:
+      - kind: unit
+        ref: "tests/unit/events/test_event_bus.py -k control_types (4 tests)"
+        status: pass
+      - kind: other
+        ref: "poetry run python -c \"EventType('stream_state') is EventType.STREAM_STATE\""
+        status: pass
+    human_judgment: false
+
+# Metrics
+duration: 3min
+completed: 2026-07-09
+status: complete
+---
+
+# Phase 2 Plan 01: Event Bus Substrate Summary
+
+**Pure two-tier event-bus substrate (EventBus Protocol + FifoEventBus + PriorityEventBus keyed by an itertools.count() seq) plus three CONTROL EventType members, proven by 18 stdlib-only unit tests — zero wiring touched, oracle-dark.**
+
+## Performance
+
+- **Duration:** ~3 min
+- **Started:** 2026-07-09T12:57:00Z
+- **Completed:** 2026-07-09T13:00:13Z
+- **Tasks:** 3
+- **Files modified:** 3 (2 created, 1 modified)
+
+## Accomplishments
+- Added `STREAM_STATE`, `CONNECTOR_FATAL`, `CONFIG_UPDATE` to `EventType` (4-space, string-valued, `_missing_` case-insensitive parse still works).
+- Created `itrader/events_handler/bus.py`: `EventBus` runtime_checkable Protocol, `EventTier` IntEnum, `_CONTROL_EVENT_TYPES` frozenset, `_tier()`, `FifoEventBus` (queue.Queue wrapper), `PriorityEventBus` (PriorityQueue keyed `(tier, seq, event)` with per-instance `itertools.count()` and lock-guarded per-tier depth Counter).
+- Proved BUS-01/02/03 with 18 pure-stdlib unit tests, including the load-bearing non-orderability negative test (`event < event` raises `TypeError`).
+- Kept the substrate import-inert: no pandas/sqlalchemy/ccxt pulled; `Event` is `TYPE_CHECKING`-only.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Add three CONTROL EventType members** - `af1a2b9c` (feat)
+2. **Task 2: Create the bus substrate** - `087a79f3` (feat)
+3. **Task 3: Prove BUS-01/02/03 in a unit suite** - `20d99ac2` (test)
+
+## Files Created/Modified
+- `itrader/events_handler/bus.py` - NEW (4-space): the EventBus Protocol + EventTier + `_CONTROL_EVENT_TYPES` + `FifoEventBus` + `PriorityEventBus` substrate.
+- `itrader/core/enums/event.py` - Added the three CONTROL EventType members before `ERROR`.
+- `tests/unit/events/test_event_bus.py` - NEW (4-space): 18-test BUS-01/02/03 proof suite (no `__init__.py` in the dir).
+
+## Decisions Made
+- Typed the internal queues concretely (`queue.Queue[Event]`, `queue.PriorityQueue[tuple[EventTier, int, Event]]`) rather than `[Any]`. The plan's action text suggested `[Any]`, but `mypy --strict` (a plan verification gate) rejected the resulting `Returning Any from function declared to return "Event"`. Concrete typing is byte-identical at runtime, satisfies the mypy gate, and is strictly better — treated as a Rule 3 blocking fix (see Deviations). `Any` was dropped from the typing import as it became unused.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Concrete queue element typing for mypy --strict**
+- **Found during:** Task 2 (Create the bus substrate)
+- **Issue:** The plan's `<action>` specified `self._q: "queue.Queue[Any]"` and `self._pq: "queue.PriorityQueue[Any]"`. Under `mypy --strict` (plan verification gate line: "mypy ... clean (new code strict)"), the `[Any]` element type made `get`/`get_nowait` return `Any`, producing four `no-any-return` errors returning from functions declared `-> "Event"`.
+- **Fix:** Typed the queues as `queue.Queue[Event]` and `queue.PriorityQueue[tuple[EventTier, int, Event]]` (string annotations, so `Event` stays `TYPE_CHECKING`-only). Removed the now-unused `Any` from the typing import.
+- **Files modified:** `itrader/events_handler/bus.py`
+- **Verification:** `poetry run mypy itrader/events_handler/bus.py itrader/core/enums/event.py` → "Success: no issues found in 2 source files"; runtime behaviour unchanged (all 18 tests pass, inertness gate green).
+- **Committed in:** `087a79f3` (Task 2 commit)
+
+---
+
+**Total deviations:** 1 auto-fixed (1 blocking)
+**Impact on plan:** Necessary to pass the plan's own mypy verification gate. Runtime semantics byte-identical; no scope creep. All other plan acceptance criteria met exactly as written.
+
+## Issues Encountered
+None beyond the mypy typing fix above.
+
+## Verification Evidence
+- `poetry run pytest tests/unit/events/test_event_bus.py -x` → 18 passed.
+- `-k priority` → 9 passed; `-k control_types` → 4 passed.
+- `poetry run python -c "import itrader.events_handler.bus"` → clean (no heavy pull; pandas/sqlalchemy/ccxt not in `sys.modules`).
+- `poetry run mypy itrader/events_handler/bus.py itrader/core/enums/event.py` → clean.
+- `git diff --stat` (vs `b3eb2d18`) shows only `bus.py`, `event.py`, `test_event_bus.py`.
+- `git diff --exit-code itrader/trading_system/live_trading_system.py` → no changes (D-11).
+- `git diff --stat poetry.lock` → empty (no dependency change).
+- No `tests/unit/events/__init__.py` created (package-collision hazard avoided).
+- No tabs introduced in any of the three files (`grep -cP '^\t'` == 0 each).
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- Substrate ready: plan 02-03 wires `FifoEventBus` into the compose seam (`EngineContext(bus=...)`); P6/P7 will later wire `PriorityEventBus` into the live CONTROL-plane.
+- No blockers. Oracle cannot have moved (no run-path wiring touched).
+
+## Self-Check: PASSED
+- FOUND: itrader/events_handler/bus.py
+- FOUND: tests/unit/events/test_event_bus.py
+- FOUND: itrader/core/enums/event.py (modified)
+- FOUND commit: af1a2b9c (Task 1)
+- FOUND commit: 087a79f3 (Task 2)
+- FOUND commit: 20d99ac2 (Task 3)
+
+---
+*Phase: 02-event-bus*
+*Completed: 2026-07-09*

--- a/.planning/phases/02-event-bus/02-02-PLAN.md
+++ b/.planning/phases/02-event-bus/02-02-PLAN.md
@@ -1,0 +1,218 @@
+---
+phase: 02-event-bus
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - itrader/order_handler/order_handler.py
+  - itrader/strategy_handler/strategies_handler.py
+  - tests/unit/order/test_order_handler_storage.py
+  - tests/unit/strategy/test_strategies_handler_storage.py
+autonomous: true
+requirements: [CTX-02]
+must_haves:
+  truths:
+    - "CTX-02/D-02: `OrderHandler` accepts keyword-only `environment='backtest'` + `sql_engine=None`, resolves `self.storage = order_storage or OrderStorageFactory.create(environment, backend=sql_engine)`, forwards that same instance to `OrderManager`, and exposes it on `.storage`."
+    - "CTX-02/D-02: `StrategiesHandler` makes `signal_store` optional and accepts keyword-only `environment='backtest'` + `sql_engine=None`, resolving `self.signal_store = signal_store or SignalStorageFactory.create(environment, backend=sql_engine)`."
+    - "CTX-03: with `environment='backtest', sql_engine=None` both handlers yield the SAME in-memory concretes as today (`InMemoryOrderStorage` / `InMemorySignalStore`) — no runtime change on the backtest path, so the SMA_MACD oracle stays byte-exact `134 / 46189.87730727451`."
+    - "D-02 layering: `OrderManager` still owns the storage for all read paths (D-18); `.storage` is a wiring seam for `compose_engine`'s `set_order_storage(...)` back-read (plan 02-03), not a new read path."
+    - "D-06 inertness: the `'backtest'` factory arm returns in-memory regardless of `backend`; the `'live'` arm's SQL imports stay lazy — importing these handlers pulls no SQLAlchemy."
+  artifacts:
+    - itrader/order_handler/order_handler.py
+    - itrader/strategy_handler/strategies_handler.py
+    - tests/unit/order/test_order_handler_storage.py
+    - tests/unit/strategy/test_strategies_handler_storage.py
+  key_links:
+    - "`OrderHandler.storage` is the concrete `compose_engine` reads back for `portfolio_handler.set_order_storage(...)` in plan 02-03."
+    - "`StrategiesHandler.signal_store` is the concrete `compose_engine` reads back onto the `Engine` holder in plan 02-03."
+    - "Both resolve through the existing `Factory.create(environment, backend=sql_engine)` seam — `PortfolioHandler.__init__` is the template."
+---
+
+<objective>
+Retrofit `OrderHandler` and `StrategiesHandler` to OWN their storage init from `(environment, sql_engine)`,
+mirroring the established `PortfolioHandler` shape (LR-13 / spec §7b). This is a purely additive change:
+new keyword-only params with backtest defaults, an internal `Factory.create(environment, backend=sql_engine)`
+resolution, and the concrete exposed on a public attribute for the plan-02-03 compose back-read.
+
+Purpose: this is the CTX-02 half of the P2 compose-seam settle (pulled forward from P3 per D-03). Doing it
+in its own Wave-1 plan (parallel with the bus substrate) keeps the oracle-risky compose fold (02-03) small.
+Because `compose_engine` still passes the storage/signal-store positionally until 02-03, this plan changes
+NOTHING at runtime on the backtest path — the same in-memory instances are constructed either way.
+
+Output: retrofitted handler ctors + new handler-storage unit cases proving the backtest slice yields
+in-memory concretes exposed on `.storage` / `.signal_store`.
+
+Locked decisions delivered: D-02 (handlers own storage init, `PortfolioHandler` template). Per D-11 no
+live wiring changes; per D-08 the `global_queue` param name/type is NOT touched here (the retype lands in 02-03).
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/02-event-bus/02-CONTEXT.md
+@.planning/phases/02-event-bus/02-RESEARCH.md
+@.planning/phases/02-event-bus/02-PATTERNS.md
+@.planning/phases/02-event-bus/02-VALIDATION.md
+@itrader/portfolio_handler/portfolio_handler.py
+</context>
+
+## Artifacts this phase produces (do not treat as pre-existing / drift)
+
+This plan creates the new ctor kwargs `environment` / `sql_engine` on `OrderHandler` and `StrategiesHandler`,
+the `OrderHandler.storage` attribute, and two new test files. See plan 02-01's artifacts section for the
+full Phase-2 symbol list (`EventBus`/`FifoEventBus`/`PriorityEventBus`/`EngineContext`/the 3 CONTROL EventTypes).
+
+<!-- planner-discipline-allow: self.storage -->
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: OrderHandler owns its storage init</name>
+  <files>itrader/order_handler/order_handler.py</files>
+  <read_first>
+    - itrader/order_handler/order_handler.py:43-98 (the ctor being edited — **TABS, verified**; note D-18 "manager owns storage, handler retains no reference" — we add a wiring seam, not a read path)
+    - itrader/portfolio_handler/portfolio_handler.py:68-81 (the D-02 template — `environment`/`backend` keyword params; **that file is 4-SPACE, but order_handler.py is TABS — do NOT copy indentation, only the shape**)
+    - itrader/order_handler/storage/storage_factory.py:23-69 (`OrderStorageFactory.create(environment, backend=)` — `'backtest'/'test'`→`InMemoryOrderStorage`, `'live'` lazy-SQL)
+    - .planning/phases/02-event-bus/02-PATTERNS.md § "order_handler.py" + § Shared Patterns "Handler-owns-storage"
+  </read_first>
+  <action>
+    In `OrderHandler.__init__`, add two keyword-only params after the existing ones:
+    `environment: str = "backtest"` and `sql_engine: "Optional[Any]" = None`. KEEP the existing
+    `order_storage: Optional[OrderStorage] = None` param as the explicit override (back-compat with current
+    callers/tests — do NOT rename it to `storage`). Resolve and RETAIN the concrete on a public attribute:
+    `self.storage = order_storage or OrderStorageFactory.create(environment, backend=sql_engine)`. Forward
+    `self.storage` into the `OrderManager(...)` construction in place of the current
+    `order_storage or OrderStorageFactory.create_in_memory()` fallback expression (so the manager receives
+    the exact same instance now referenced by `self.storage`). Add `Any` to the `typing` import if not present.
+    Do NOT change the `global_queue` param (name or type) — that is plan 02-03 (D-08). Do NOT change any
+    other behaviour. TABS indentation.
+
+    Byte-exactness note: `OrderStorageFactory.create('backtest', backend=None)` returns `InMemoryOrderStorage()`
+    — the same concrete `create_in_memory()` returns today. When `compose_engine` still passes `order_storage`
+    positionally (until 02-03), `self.storage` is that passed instance. Either way the manager gets an
+    `InMemoryOrderStorage` → oracle byte-exact.
+  </action>
+  <verify>
+    <automated>poetry run python -c "import queue; from unittest.mock import MagicMock; from itrader.order_handler.order_handler import OrderHandler; from itrader.order_handler.storage.in_memory_storage import InMemoryOrderStorage; h=OrderHandler(queue.Queue(), MagicMock(), environment='backtest', sql_engine=None); assert isinstance(h.storage, InMemoryOrderStorage)"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `OrderHandler(global_queue, portfolio_read_model, environment='backtest', sql_engine=None)` constructs and `h.storage` is an `InMemoryOrderStorage`.
+    - The existing `order_storage=` override still works and is the same instance forwarded to `OrderManager` and exposed on `.storage`.
+    - `grep -c 'self.storage' itrader/order_handler/order_handler.py` ≥ 1; `grep -cP '^    [^ ]' itrader/order_handler/order_handler.py` == 0 (no 4-space lines introduced into the TABS file).
+    - No import of `sqlalchemy` triggered by importing the handler (backtest arm is in-memory).
+  </acceptance_criteria>
+  <done>OrderHandler owns storage via `(environment, sql_engine)`, exposes `.storage`, backtest slice = InMemory.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: StrategiesHandler owns its signal-store init</name>
+  <files>itrader/strategy_handler/strategies_handler.py</files>
+  <read_first>
+    - itrader/strategy_handler/strategies_handler.py:39-94 (the ctor being edited — **TABS, verified**; `signal_store` is currently a required positional)
+    - itrader/strategy_handler/storage/storage_factory.py:35-92 (`SignalStorageFactory.create(environment, backend=)` — `'backtest'/'test'`→`InMemorySignalStore`, `'live'` lazy-SQL)
+    - itrader/portfolio_handler/portfolio_handler.py:68-81 (the D-02 shape template — 4-SPACE file, shape only)
+    - .planning/phases/02-event-bus/02-PATTERNS.md § "strategies_handler.py"
+  </read_first>
+  <action>
+    In `StrategiesHandler.__init__`, make `signal_store` optional: change its annotation to
+    `signal_store: "Optional[SignalStore]" = None` (import `Optional` if needed) and keep it in the same
+    positional slot (so the existing `compose_engine` positional call keeps working until 02-03). Add two
+    keyword-only params `environment: str = "backtest"` and `sql_engine: "Optional[Any]" = None` (import `Any`
+    if needed). Resolve: `self.signal_store = signal_store or SignalStorageFactory.create(environment, backend=sql_engine)`
+    (import `SignalStorageFactory` from `itrader.strategy_handler.storage` alongside the existing `SignalStore` import).
+    Do NOT change the `global_queue` param (name/type) — that is 02-03 (D-08). Preserve all other ctor
+    behaviour (the SHORT-01 flags, universe seam, logger). TABS indentation.
+
+    Byte-exactness note: `SignalStorageFactory.create('backtest', backend=None)` returns `InMemorySignalStore()`
+    — the same concrete the factory/legacy arm creates today; when `compose_engine` still passes `signal_store`
+    positionally (until 02-03), `self.signal_store` is that instance. Oracle byte-exact.
+  </action>
+  <verify>
+    <automated>poetry run python -c "import queue; from unittest.mock import MagicMock; from itrader.strategy_handler.strategies_handler import StrategiesHandler; from itrader.strategy_handler.storage.in_memory_storage import InMemorySignalStore; h=StrategiesHandler(queue.Queue(), MagicMock(), environment='backtest', sql_engine=None); assert isinstance(h.signal_store, InMemorySignalStore)"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `StrategiesHandler(global_queue, feed, environment='backtest', sql_engine=None)` constructs (no `signal_store` passed) and `h.signal_store` is an `InMemorySignalStore`.
+    - Passing `signal_store=<explicit>` still uses the explicit store (override wins).
+    - `grep -cP '^    [^ ]' itrader/strategy_handler/strategies_handler.py` == 0 (no 4-space lines in the TABS file).
+    - Importing the handler pulls no `sqlalchemy` (backtest arm in-memory / lazy-SQL live arm).
+  </acceptance_criteria>
+  <done>StrategiesHandler owns signal-store via `(environment, sql_engine)`; backtest slice = InMemorySignalStore.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Handler-storage unit cases</name>
+  <files>tests/unit/order/test_order_handler_storage.py, tests/unit/strategy/test_strategies_handler_storage.py</files>
+  <read_first>
+    - itrader/order_handler/order_handler.py (post-Task-1 ctor)
+    - itrader/strategy_handler/strategies_handler.py (post-Task-2 ctor)
+    - itrader/order_handler/storage/in_memory_storage.py + itrader/strategy_handler/storage/in_memory_storage.py (the concretes to assert on)
+    - PROJECT HAZARD: keep `tests/unit/order/` and `tests/unit/strategy/` package-less (do NOT add `__init__.py`). Tests are 4-space. Use a real `queue.Queue()` + `MagicMock()` collaborators (no data load).
+  </read_first>
+  <action>
+    Create `tests/unit/order/test_order_handler_storage.py`: assert `OrderHandler(queue.Queue(), MagicMock(),
+    environment='backtest', sql_engine=None).storage` is an `InMemoryOrderStorage`; assert an explicit
+    `order_storage=` override is exposed on `.storage` (override wins); assert the instance on `.storage` is the
+    same object the `OrderManager` received (wiring-seam identity — read `h.order_manager` storage handle or
+    assert object identity via a passed sentinel).
+
+    Create `tests/unit/strategy/test_strategies_handler_storage.py`: assert `StrategiesHandler(queue.Queue(),
+    MagicMock(), environment='backtest', sql_engine=None).signal_store` is an `InMemorySignalStore`; assert an
+    explicit `signal_store=` override wins.
+
+    Do NOT hand-add markers (folder-derived `unit` auto-applies). Keep both files fast and data-free.
+  </action>
+  <verify>
+    <automated>poetry run pytest tests/unit/order/test_order_handler_storage.py tests/unit/strategy/test_strategies_handler_storage.py -x</automated>
+  </verify>
+  <acceptance_criteria>
+    - Both new test files pass under `poetry run pytest ... -x`.
+    - `test -f tests/unit/order/__init__.py` FALSE and `test -f tests/unit/strategy/__init__.py` FALSE (package-less dirs preserved).
+    - The order test asserts `.storage` identity is the instance forwarded to `OrderManager` (the 02-03 back-read seam).
+  </acceptance_criteria>
+  <done>Backtest handler-owned storage proven: in-memory concretes exposed, overrides honoured.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| (none new) | Purely additive ctor params on backtest-path handlers; the `'backtest'` slice constructs in-memory stores only. No external input, no I/O, no auth/secrets crosses the seam in P2. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-02-04 | Tampering (behavioral) | backtest storage instance identity | high | mitigate | The `'backtest'` factory arm returns `InMemory*` regardless of `backend`; unit tests + the plan-02-03 oracle gate assert the same in-memory concretes → byte-exact. A silent switch to a persistent backend on the backtest slice would break the oracle and is prevented by the `environment='backtest'` default + the factory's in-memory arm. |
+| T-02-05 | (availability/perf) | handler import inertness | high | mitigate | `OrderStorageFactory`/`SignalStorageFactory` keep their SQL imports lazy inside the `'live'` arm; importing the retrofitted handlers pulls no SQLAlchemy. Acceptance greps assert no heavy import; the plan-02-03 inertness gate re-proves it end-to-end. |
+| T-02-06 | Repudiation | `OrderManager` storage ownership (D-18) | low | accept | `.storage` is a wiring-seam read of the SAME instance the manager owns; all read paths still route through the manager. Adding the attribute does not create a second read path — documented as a composition seam. |
+| T-02-SC | Tampering (supply chain) | package installs | low | accept | Zero package installs this phase; `poetry.lock` byte-unchanged is a gate. |
+</threat_model>
+
+<verification>
+- `poetry run pytest tests/unit/order/test_order_handler_storage.py tests/unit/strategy/test_strategies_handler_storage.py -x` green.
+- `poetry run pytest tests/unit/order tests/unit/strategy -x` green (no regression in the existing handler suites).
+- `poetry run mypy itrader/order_handler/order_handler.py itrader/strategy_handler/strategies_handler.py` clean.
+- Backtest oracle unchanged by this plan (compose still passes storage positionally): `poetry run pytest tests/integration/test_backtest_oracle.py -x` byte-exact `134 / 46189.87730727451`.
+- `git diff --exit-code itrader/trading_system/live_trading_system.py` shows no changes (D-11).
+- `git diff --stat poetry.lock` empty.
+</verification>
+
+<success_criteria>
+- Both handlers accept `(environment, sql_engine)` and own their storage init, exposing the concrete on `.storage` / `.signal_store`.
+- Backtest slice yields the same in-memory concretes as today; oracle byte-exact.
+- No live wiring touched; no SQLAlchemy pulled on import; `poetry.lock` unchanged.
+</success_criteria>
+
+<output>
+Create `.planning/phases/02-event-bus/02-02-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/02-event-bus/02-02-SUMMARY.md
+++ b/.planning/phases/02-event-bus/02-02-SUMMARY.md
@@ -1,0 +1,96 @@
+---
+phase: 02-event-bus
+plan: 02
+subsystem: order-handler, strategy-handler
+tags: [ctx-02, d-02, handler-owns-storage, compose-seam, oracle-dark]
+status: complete
+requires:
+  - "OrderStorageFactory.create(environment, backend=) — existing 05-xx seam"
+  - "SignalStorageFactory.create(environment, backend=) — existing 05-03 seam"
+  - "PortfolioHandler.__init__(environment, backend) — the D-02 shape template (LR-13)"
+provides:
+  - "OrderHandler.__init__(*, environment='backtest', sql_engine=None) + OrderHandler.storage attribute"
+  - "StrategiesHandler.__init__(*, environment='backtest', sql_engine=None); signal_store now optional"
+  - "Both handlers own their storage init and expose the concrete on .storage / .signal_store"
+affects:
+  - "plan 02-03 compose fold reads .storage / .signal_store back (set_order_storage + Engine holder)"
+tech-stack:
+  added: []
+  patterns: [handler-owns-storage-init, keyword-only-additive-ctor-params, factory-environment-seam]
+key-files:
+  created:
+    - tests/unit/order/test_order_handler_storage.py
+    - tests/unit/strategy/test_strategies_handler_storage.py
+  modified:
+    - itrader/order_handler/order_handler.py
+    - itrader/strategy_handler/strategies_handler.py
+decisions:
+  - "D-02: handlers own storage init from (environment, sql_engine), PortfolioHandler template (LR-13)"
+  - "D-08 honoured: global_queue param name/type untouched (retype deferred to 02-03)"
+  - "D-11 honoured: live_trading_system.py untouched"
+  - "D-18 preserved: OrderManager still owns storage for all read paths; .storage is a wiring seam, not a second read path"
+metrics:
+  duration: ~6min
+  completed: 2026-07-09
+  tasks: 3
+  files: 4
+---
+
+# Phase 02 Plan 02: Handler-Owns-Storage Retrofit Summary
+
+`OrderHandler` and `StrategiesHandler` now own their storage init from keyword-only
+`(environment='backtest', sql_engine=None)` params — mirroring the `PortfolioHandler`
+template (LR-13 / D-02) — and expose the resolved concrete on `.storage` / `.signal_store`
+for the plan-02-03 compose back-read. Purely additive: `compose_engine` still passes
+storage positionally until 02-03, so the backtest slice constructs the identical
+`InMemoryOrderStorage` / `InMemorySignalStore` concretes and the SMA_MACD oracle stays
+byte-exact `134 / 46189.87730727451`.
+
+## What Was Built
+
+- **Task 1 — `OrderHandler` (commit `46c50885`):** Added keyword-only `environment`/`sql_engine`
+  ctor params (after a bare `*`). Kept `order_storage=` as the explicit override (back-compat).
+  Resolved `self.storage = order_storage or OrderStorageFactory.create(environment, backend=sql_engine)`
+  and forwarded that exact instance into `OrderManager`. `Any` was already imported. TABS preserved.
+- **Task 2 — `StrategiesHandler` (commit `9eb3208c`):** Made `signal_store` optional
+  (`Optional[SignalStore] = None`) in the same positional slot; added keyword-only
+  `environment`/`sql_engine`; resolved `self.signal_store = signal_store or SignalStorageFactory.create(environment, backend=sql_engine)`.
+  Imported `Optional` (typing) and `SignalStorageFactory` (alongside the existing `SignalStore` import). TABS preserved.
+- **Task 3 — unit cases (commit `4a7609d6`):** `tests/unit/order/test_order_handler_storage.py`
+  (backtest slice → `InMemoryOrderStorage`; override wins; `.storage` identity == the instance
+  forwarded to `OrderManager` — the 02-03 back-read seam) and
+  `tests/unit/strategy/test_strategies_handler_storage.py` (backtest slice → `InMemorySignalStore`;
+  override wins). 4-space; dirs kept package-less (no `__init__.py`).
+
+## Verification Evidence
+
+- New test files: `5 passed`.
+- Existing handler suites `tests/unit/order tests/unit/strategy`: `439 passed` (no regression).
+- `mypy --strict` on both handlers: `Success: no issues found in 2 source files`.
+- Backtest oracle `tests/integration/test_backtest_oracle.py`: `3 passed` — byte-exact `134 / 46189.87730727451`.
+- `grep -cP '^    [^ ]'` == 0 on both TABS handler files (no 4-space lines introduced).
+- Importing either retrofitted handler pulls **no** `sqlalchemy` (backtest arm in-memory; `'live'` arm SQL imports stay lazy) — D-06 inertness held.
+- D-11: `git diff --exit-code itrader/trading_system/live_trading_system.py` — no changes.
+- `poetry.lock`: empty diff (zero new dependency).
+
+## Deviations from Plan
+
+None — plan executed exactly as written. No deviation rules triggered; all per-task
+`<verify>` commands and plan-level verification passed on first run.
+
+## Threat Surface
+
+No new trust boundary introduced (matches the plan's threat model). T-02-04 (backtest
+instance identity) and T-02-05 (import inertness) mitigations are proven by the oracle
+gate and the no-sqlalchemy import checks above; T-02-06 (D-18 storage ownership) is
+preserved — `.storage` reads the same instance the manager owns.
+
+## Self-Check: PASSED
+
+- FOUND: itrader/order_handler/order_handler.py (modified)
+- FOUND: itrader/strategy_handler/strategies_handler.py (modified)
+- FOUND: tests/unit/order/test_order_handler_storage.py
+- FOUND: tests/unit/strategy/test_strategies_handler_storage.py
+- FOUND commit: 46c50885 (OrderHandler)
+- FOUND commit: 9eb3208c (StrategiesHandler)
+- FOUND commit: 4a7609d6 (unit cases)

--- a/.planning/phases/02-event-bus/02-03-PLAN.md
+++ b/.planning/phases/02-event-bus/02-03-PLAN.md
@@ -1,0 +1,302 @@
+---
+phase: 02-event-bus
+plan: 03
+type: execute
+wave: 2
+depends_on: [02-01, 02-02]
+files_modified:
+  - itrader/trading_system/engine_context.py
+  - itrader/events_handler/full_event_handler.py
+  - itrader/order_handler/order_handler.py
+  - itrader/strategy_handler/strategies_handler.py
+  - itrader/portfolio_handler/portfolio_handler.py
+  - itrader/execution_handler/execution_handler.py
+  - itrader/trading_system/compose.py
+  - itrader/trading_system/backtest_trading_system.py
+  - tests/integration/test_okx_inertness.py
+autonomous: true
+requirements: [BUS-01, BUS-04, CTX-01, CTX-03]
+must_haves:
+  truths:
+    - "BUS-04/D-05: a frozen `EngineContext` dataclass carries exactly 4 fields `bus`/`config`/`environment`/`sql_engine` with loose types (`bus: EventBus`, `config: Any`, `environment: str`, `sql_engine: Optional[Any] = None`); P3/P4/P9 only tighten types, never add fields."
+    - "CTX-01/D-01: `compose_engine(ctx, spec)` is the two-arg end-state signature; the internal `queue.Queue()` (compose.py:164) is DELETED and replaced by `ctx.bus`; `grep -c 'queue.Queue()' itrader/trading_system/compose.py` == 0."
+    - "D-04/A1: `compose_engine` reads ONLY `{spec.data, spec.start, spec.end, spec.timeframe, spec.exchange, spec.results_store}` (empties mapped to None), never `spec.ticker`/`spec.starting_cash`/`spec.strategies`/`spec.portfolios`; `order_config` stays handler-owned via `OrderConfig.default()`."
+    - "D-07/D-08: every in-scope handler ctor's `global_queue` param is RETYPED to `EventBus` (name unchanged); no `.put()` call-site changed; `EventHandler` drains via `bus.get_nowait()` catching `queue.Empty`."
+    - "D-06: both backtest arms build `EngineContext(bus=FifoEventBus(), config=<the itrader SystemConfig>, environment='backtest', sql_engine=None)` and inject it; `compose_engine` reads `order_handler.storage` + `strategies_handler.signal_store` back for wiring."
+    - "CTX-03 (oracle): SMA_MACD stays byte-exact `134 / 46189.87730727451` (`check_exact=True`), determinism double-run identical."
+    - "CTX-03 (inertness): `test_okx_inertness.py` stays green + extended register-vs-build — constructing `FifoEventBus()` + `EngineContext(sql_engine=None)` pulls no SQLAlchemy/ccxt; import builds no `SqlSettings`."
+    - "D-11: `itrader/trading_system/live_trading_system.py` is UNCHANGED in P2 (checkable non-change — no diff)."
+  artifacts:
+    - itrader/trading_system/engine_context.py
+    - itrader/trading_system/compose.py
+    - itrader/trading_system/backtest_trading_system.py
+    - tests/integration/test_okx_inertness.py
+  key_links:
+    - "`EngineContext.bus` is imported as `EventBus` from `events_handler.bus`; `engine_context.py` pulls only stdlib + that Protocol (no cycle — bus.py imports only `core.enums.event`)."
+    - "`ctx.bus` replaces the deleted internal queue and is injected into ScreenersHandler/PortfolioHandler/ExecutionHandler/StrategiesHandler/OrderHandler/EventHandler."
+    - "legacy `BacktestTradingSystem.__init__` synthesizes a placeholder `SystemSpec` (RESEARCH Pitfall 1); factory arm `dataclasses.replace(spec, exchange=<seeded>)`; both call `compose_engine(ctx, spec)`."
+---
+
+<objective>
+Settle the compose seam to its END-STATE form in one atomic, oracle-gated change: introduce the frozen
+`EngineContext`, retype every in-scope handler's `global_queue` param to `EventBus` (name unchanged), fold
+`compose_engine` to the two-arg `(ctx, spec)` signature (deleting the internal `queue.Queue()` and reading
+handler-owned storage back), thread `EngineContext(bus=FifoEventBus(), environment='backtest', sql_engine=None)`
+through BOTH backtest call sites (the legacy `__init__` arm the oracle actually runs through AND the
+`build_backtest_system(spec)` factory), and extend the inertness gate with the register-vs-build assertion.
+
+Purpose: this is the CTX-01 + BUS-04 half of the P2 compose-seam settle (D-01 Option B — the end-state
+signature reached now so it is never re-edited downstream). The retype and the `FifoEventBus` injection are
+atomically coupled (the moment a param becomes `EventBus`, a raw `queue.Queue()` stops satisfying it), so they
+ship in one plan whose gate is the byte-exact oracle + inertness + `mypy --strict`.
+
+Output: `engine_context.py`, the folded `compose_engine`, the two rewired factory arms, and an extended
+inertness probe. Per D-11, `live_trading_system.py` stays on its raw queue — a checkable non-change.
+
+Locked decisions delivered: D-01 (two-arg signature, queue deleted), D-04 (kwargs→spec fold, order_config
+handler-owned), D-05 (EngineContext 4 fields, loose types), D-06 (backtest EngineContext + inertness),
+D-07/D-08 (retype-not-rename bus swap), D-11 (zero live wiring, verified by non-diff).
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/02-event-bus/02-CONTEXT.md
+@.planning/phases/02-event-bus/02-RESEARCH.md
+@.planning/phases/02-event-bus/02-PATTERNS.md
+@.planning/phases/02-event-bus/02-VALIDATION.md
+@itrader/trading_system/compose.py
+@itrader/trading_system/backtest_trading_system.py
+@itrader/trading_system/system_spec.py
+</context>
+
+## Artifacts this phase produces (do not treat as pre-existing / drift)
+
+This plan creates `EngineContext` (in the new `itrader/trading_system/engine_context.py`) and the two-arg
+`compose_engine(ctx, spec)` signature, and consumes the plan-02-01 substrate (`EventBus`/`FifoEventBus`) and
+the plan-02-02 handler-owned storage (`OrderHandler.storage` / `StrategiesHandler.signal_store`). See plan
+02-01's artifacts section for the full Phase-2 symbol list — none of these are pre-existing drift.
+
+## Verified pins (from the grounding pass — trust these over any stale doc line)
+
+- `compose.py`: signature at :116-127 (8 kwargs), internal `queue.Queue()` at :164, `Engine.global_queue` field at :92, `set_order_storage(order_storage)` at :234, `resolved_order_config = order_config or OrderConfig.default()` at :220.
+- `backtest_trading_system.py`: legacy arm compose call :131-140 (synthesizes storage inline, NO spec), factory arm `build_backtest_system` compose call :437-447 (already has `spec`); factory-mode holder reads `signal_store or engine.signal_store` at :117; `_seed_supported_symbols` at :58; `from itrader import config, idgen` at :29.
+- The ONLY in-scope handler construction sites are all five calls in `compose.py` (grounding grep confirmed); nothing else in `itrader/` (strict) constructs them. `live_trading_system.py` is `ignore_errors` (Pitfall 3); `screeners_handler.*` is `ignore_errors` (untyped param — leave untouched).
+- Oracle path: `scripts/run_backtest.py::main` → `BacktestTradingSystem(exchange="csv", start_date="2018-01-01", end_date="2026-06-03")`, `csv_paths=None`, `timeframe='1d'` (ctor default) → the **legacy arm**.
+- Retype annotation lines: full_event_handler.py:66; strategies_handler.py:41 + :74; order_handler.py:43; execution_handler.py:29; portfolio_handler.py:68 + :70.
+
+<!-- planner-discipline-allow: queue.Queue() -->
+<!-- planner-discipline-allow: compose_engine(ctx -->
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: EngineContext dataclass + retype-not-rename bus swap</name>
+  <files>itrader/trading_system/engine_context.py, itrader/events_handler/full_event_handler.py, itrader/order_handler/order_handler.py, itrader/strategy_handler/strategies_handler.py, itrader/portfolio_handler/portfolio_handler.py, itrader/execution_handler/execution_handler.py</files>
+  <read_first>
+    - itrader/events_handler/bus.py (the `EventBus` Protocol created in 02-01 — the retype target type)
+    - itrader/trading_system/system_spec.py:38-49,79-111 (the frozen `@dataclass(frozen=True)` + `Any`-typed field house style — the `EngineContext` template; TABS)
+    - .planning/phases/02-event-bus/02-PATTERNS.md § "EngineContext (NEW frozen dataclass)" + § "Retype-not-rename bus swap"
+    - .planning/phases/02-event-bus/02-RESEARCH.md § Open Questions #1 (EngineContext home; TYPE_CHECKING fallback if a cycle appears)
+    - INDENTATION (VERIFIED per file — match each, never normalize): `engine_context.py` NEW = TABS (trading_system/); `full_event_handler.py`/`order_handler.py`/`strategies_handler.py`/`execution_handler.py` = TABS; `portfolio_handler.py` = 4-SPACE (verified — the planning note's "portfolio = TABS" is WRONG for this file).
+  </read_first>
+  <action>
+    (a) Create `itrader/trading_system/engine_context.py` (TABS). Import `from dataclasses import dataclass`,
+    `from typing import Any, Optional`, and `from itrader.events_handler.bus import EventBus` (bus.py imports only
+    stdlib + `core.enums.event`, so no cycle; if a cycle ever appears, fall back to a `TYPE_CHECKING`-only import
+    of `EventBus` and annotate the field `"EventBus"`). Define `@dataclass(frozen=True)` `class EngineContext:`
+    with EXACTLY four fields in order — `bus: EventBus`, `config: Any`, `environment: str`,
+    `sql_engine: Optional[Any] = None`. Docstring: infra-only (LR-14); `config` carried but unread until P9;
+    loose types are only tightened (never widened, never added to) in P3/P4/P9 (D-05).
+
+    (b) Retype the `global_queue` parameter (and the `self.global_queue` attribute annotation where one exists)
+    from `"queue.Queue[Any]"` / `"Queue[Any]"` to `"EventBus"` — NAME UNCHANGED (D-08) — in each of:
+    full_event_handler.py (param :66; keep `import queue` for the `queue.Empty` catch; body unchanged),
+    order_handler.py (param :43), strategies_handler.py (param :41 + self attr :74),
+    execution_handler.py (param :29), portfolio_handler.py (param :68 + self attr :70 — 4-SPACE file).
+    Add `from itrader.events_handler.bus import EventBus` to each. Do NOT touch screeners_handler.py (untyped
+    param, `ignore_errors`, duck-typed at runtime). Do NOT touch live_trading_system.py (D-11). No `.put()` /
+    `.get_nowait()` call-site changes anywhere.
+
+    This task is intentionally NOT independently mypy-green — compose.py still passes the internal `queue.Queue()`
+    into these `EventBus` params until Task 2 folds it. Per-task verify is source-level; the plan-level gate runs
+    `mypy --strict` after Task 2.
+  </action>
+  <verify>
+    <automated>poetry run python -c "from dataclasses import fields; from itrader.trading_system.engine_context import EngineContext; from itrader.events_handler.bus import FifoEventBus; import itrader; c = EngineContext(bus=FifoEventBus(), config=itrader.config, environment='backtest', sql_engine=None); assert [f.name for f in fields(EngineContext)] == ['bus','config','environment','sql_engine']; assert c.sql_engine is None"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `EngineContext` is a frozen dataclass with exactly `['bus','config','environment','sql_engine']` (order + count), `sql_engine` defaulting to None.
+    - `grep -c 'global_queue: "EventBus"' itrader/events_handler/full_event_handler.py itrader/order_handler/order_handler.py itrader/strategy_handler/strategies_handler.py itrader/execution_handler/execution_handler.py itrader/portfolio_handler/portfolio_handler.py` shows the param retyped in all five (name unchanged — no `bus:` param appears).
+    - `grep -c 'def __init__' itrader/screeners_handler/screeners_handler.py` unchanged; `git diff --exit-code itrader/trading_system/live_trading_system.py` shows no changes.
+    - `grep -cP '^    [^ ]' itrader/order_handler/order_handler.py itrader/strategy_handler/strategies_handler.py itrader/execution_handler/execution_handler.py itrader/events_handler/full_event_handler.py itrader/trading_system/engine_context.py` == 0 (TABS files unpolluted) and `grep -cP '^\t' itrader/portfolio_handler/portfolio_handler.py` == 0 (4-SPACE file unpolluted).
+  </acceptance_criteria>
+  <done>`EngineContext` exists (4 loose fields); all five in-scope handler params retyped to `EventBus`; indentation matched per file; live system untouched.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Fold compose_engine to (ctx, spec) — delete internal queue, inject ctx.bus, read storage back</name>
+  <files>itrader/trading_system/compose.py</files>
+  <read_first>
+    - itrader/trading_system/compose.py (WHOLE file — TABS; signature :116, queue :164, handler ctors :180-246, `set_order_storage` :234, `Engine.global_queue` field :92, `resolved_order_config` :220)
+    - itrader/trading_system/engine_context.py (the `EngineContext` created in Task 1)
+    - itrader/trading_system/system_spec.py (the `SystemSpec` fields compose now reads)
+    - itrader/order_handler/order_handler.py + itrader/strategy_handler/strategies_handler.py (post-02-02 ctors exposing `.storage` / `.signal_store`, and post-Task-1 `EventBus` param)
+    - .planning/phases/02-event-bus/02-PATTERNS.md § "compose.py" (fold map + A1 spec-read constraint + storage back-read)
+    - .planning/phases/02-event-bus/02-RESEARCH.md § Pitfall 1 + Assumptions A1 (compose must NOT read spec.ticker/starting_cash)
+    - INDENTATION: compose.py = TABS.
+  </read_first>
+  <action>
+    Change the signature to `def compose_engine(ctx: "EngineContext", spec: "SystemSpec") -> Engine:` (import
+    `EngineContext` from `itrader.trading_system.engine_context` and `SystemSpec` from
+    `itrader.trading_system.system_spec`). DELETE the internal `global_queue: "queue.Queue[Any]" = queue.Queue()`
+    at :164 (and drop the now-unused `import queue` if nothing else needs it — verify first). Everywhere the body
+    previously used `global_queue`, use `ctx.bus`.
+
+    Map the deleted kwargs to spec reads, preserving today's exact values (D-04 / A1):
+    - `csv_paths = spec.data or None` (empty dict → None → the single-golden-ticker fallback, byte-identical to the legacy `csv_paths=None`).
+    - `start_date = spec.start or None`; `end_date = spec.end or None`.
+    - `timeframe = spec.timeframe`.
+    - `exchange_config = spec.exchange` (already a seeded `ExchangeConfig` by the time compose is called — the factory arm seeds it, see Task 3).
+    - `results_store = getattr(spec, "results_store", None)` (preserve the duck-typed getattr — the e2e `ScenarioSpec` has no such field).
+    - `order_config`: keep handler-owned — `resolved_order_config = OrderConfig.default()` (do NOT read a spec field; D-04 lean, P1 D-03).
+    DO NOT read `spec.ticker` / `spec.starting_cash` / `spec.strategies` / `spec.portfolios` anywhere in this body
+    (the legacy arm passes placeholders for ticker/starting_cash — A1).
+
+    Construct handlers with `ctx.bus` and handler-owned storage:
+    - `ScreenersHandler(ctx.bus, feed)` (keep the existing `# type: ignore[no-untyped-call]`).
+    - `PortfolioHandler(ctx.bus)`.
+    - `ExecutionHandler(ctx.bus, exchange_config=exchange_config)`.
+    - `StrategiesHandler(ctx.bus, feed, allow_short_selling=trading_rules.allow_short_selling, enable_margin=trading_rules.enable_margin, environment=ctx.environment, sql_engine=ctx.sql_engine)` — do NOT pass `signal_store` (handler owns it now, 02-02).
+    - `OrderHandler(ctx.bus, portfolio_handler, order_config=resolved_order_config, commission_estimator=commission_estimator, enable_margin=trading_rules.enable_margin, portfolio_max_leverage=trading_rules.max_leverage, environment=ctx.environment, sql_engine=ctx.sql_engine)` — do NOT pass `order_storage` (handler owns it now, 02-02).
+    - `EventHandler(strategies_handler, screeners_handler, portfolio_handler, order_handler, execution_handler, feed.generate_bar_event, ctx.bus)`.
+
+    Read the handler-owned storage back for wiring:
+    - `order_storage = order_handler.storage`; then `portfolio_handler.set_order_storage(order_storage)` (replaces the :234 param use).
+    - `signal_store = strategies_handler.signal_store`.
+
+    Return `Engine(global_queue=ctx.bus, ..., signal_store=strategies_handler.signal_store, ...,
+    results_store=results_store)`. Retype the `Engine.global_queue` dataclass field (:92) from `"queue.Queue[Any]"`
+    to `"EventBus"` (import `EventBus`). Keep the `FeeModelCommissionEstimator` / clock / store / feed wiring order
+    byte-identical (Trap 4/6). Update the docstring to describe `(ctx, spec)`; do NOT leave the deleted-kwarg
+    docstring stanza describing params that no longer exist.
+  </action>
+  <verify>
+    <automated>poetry run python -c "import inspect; from itrader.trading_system.compose import compose_engine; p=list(inspect.signature(compose_engine).parameters); assert p==['ctx','spec'], p" && poetry run mypy itrader/trading_system/compose.py itrader/events_handler/full_event_handler.py itrader/order_handler/order_handler.py itrader/strategy_handler/strategies_handler.py itrader/portfolio_handler/portfolio_handler.py itrader/execution_handler/execution_handler.py itrader/trading_system/engine_context.py</automated>
+  </verify>
+  <acceptance_criteria>
+    - `inspect.signature(compose_engine)` parameters == `['ctx', 'spec']`.
+    - `grep -c 'queue.Queue()' itrader/trading_system/compose.py` == 0 (internal queue deleted, D-01).
+    - `grep -c 'spec.ticker\|spec.starting_cash\|spec.strategies\|spec.portfolios' itrader/trading_system/compose.py` == 0 (A1 — body never reads those).
+    - `poetry run mypy` (the six edited strict modules + `engine_context.py`) is clean (the retype + fold are self-consistent; the only construction sites are here).
+    - `grep -c 'ctx.bus' itrader/trading_system/compose.py` ≥ 6 (bus injected into all handler ctors + Engine holder).
+  </acceptance_criteria>
+  <done>`compose_engine(ctx, spec)` folded; internal queue deleted; `ctx.bus` injected; storage read back off handlers; mypy strict clean.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Rewire both backtest call sites to (ctx, spec) + extend the inertness gate</name>
+  <files>itrader/trading_system/backtest_trading_system.py, tests/integration/test_okx_inertness.py</files>
+  <read_first>
+    - itrader/trading_system/backtest_trading_system.py (WHOLE file — TABS; legacy arm :118-141, factory arm :401-448, `_seed_supported_symbols` :58, `from itrader import config, idgen` :29, factory-mode holder `signal_store or engine.signal_store` :117)
+    - itrader/trading_system/system_spec.py (required fields: `start:str`, `end:str`, `timeframe:str`, `ticker:str`, `starting_cash:int`, `data:dict`, `strategies:list`, `portfolios:list`, `exchange:Any=None`, `results_store:Any=None`)
+    - itrader/trading_system/engine_context.py + itrader/trading_system/compose.py (the Task-1/Task-2 outputs this task feeds)
+    - itrader/events_handler/bus.py (`FifoEventBus` to construct)
+    - tests/integration/test_okx_inertness.py (WHOLE file — the `_PROBE` string + the existing `_cfg.__dict__` CFG-02 assertion to extend)
+    - .planning/phases/02-event-bus/02-PATTERNS.md § "backtest_trading_system.py (TWO call sites)" + RESEARCH § Pitfall 1
+    - INDENTATION: backtest_trading_system.py = TABS; test_okx_inertness.py = 4-SPACE.
+  </read_first>
+  <action>
+    (a) Legacy `__init__` arm (:118-141): stop creating `order_storage`/`self._signal_store` inline (handlers own
+    them now). Keep the `_seed_supported_symbols(get_exchange_preset('default'), tickers)` derivation. Synthesize a
+    minimal frozen `SystemSpec(start=start_date or '', end=end_date or '', timeframe=timeframe, ticker='BTCUSD',
+    starting_cash=0, data=csv_paths or {}, strategies=[], portfolios=[], exchange=<the seeded ExchangeConfig>)`
+    (placeholder `ticker`/`starting_cash` are never read by compose — A1). Build
+    `ctx = EngineContext(bus=FifoEventBus(), config=config, environment='backtest', sql_engine=None)` (use the
+    module-level `config` singleton already imported at :29). Call `self.engine = compose_engine(ctx, spec)`; then
+    `self._signal_store = self.engine.signal_store` (read the handler-owned store back off the engine). Construct
+    the runner as today: `self.runner = BacktestRunner(self.engine)`. Import `EngineContext`, `FifoEventBus`,
+    `SystemSpec` (SystemSpec is already imported).
+
+    (b) Factory `build_backtest_system(spec)` arm (:401-448): drop the `OrderStorageFactory.create('backtest')` +
+    `SignalStorageFactory.create('backtest')` creation (handlers own them now). Seed the exchange as today
+    (`exchange_config = spec.exchange or get_exchange_preset('default')`; `tickers = {str(t) for t in spec.data.keys()}`;
+    `exchange_config = _seed_supported_symbols(exchange_config, tickers)`), then produce a spec carrying the seeded
+    exchange via `spec = dataclasses.replace(spec, exchange=exchange_config)` (SystemSpec is frozen — use
+    `dataclasses.replace`; `import dataclasses`). Build `ctx = EngineContext(bus=FifoEventBus(), config=config,
+    environment='backtest', sql_engine=None)`. Call `engine = compose_engine(ctx, spec)`. The strategies/portfolios
+    loop is unchanged (still reads `spec.strategies` / `spec.portfolios` in the FACTORY, NOT in compose — Trap 6
+    order preserved). Return `BacktestTradingSystem(engine=engine, runner=runner, signal_store=engine.signal_store)`
+    (or omit `signal_store` and rely on the `signal_store or engine.signal_store` fallback at :117 — both resolve
+    to `engine.signal_store`). Remove any now-unused imports (`OrderStorageFactory`/`SignalStorageFactory`) only if
+    truly unreferenced elsewhere in the module — verify with grep first.
+
+    (c) Extend `tests/integration/test_okx_inertness.py` `_PROBE` (register-vs-build): after the existing
+    `_cfg.__dict__` CFG-02 assertion, add — `from itrader.events_handler.bus import FifoEventBus` and
+    `from itrader.trading_system.engine_context import EngineContext`; construct `_bus = FifoEventBus()` and
+    `_ctx = EngineContext(bus=_bus, config=_cfg, environment='backtest', sql_engine=None)`; then assert
+    `"sqlalchemy" not in sys.modules and "ccxt" not in sys.modules` with a clear "P2 register-vs-build inertness
+    violation: constructing FifoEventBus/EngineContext(sql_engine=None) pulled a heavy backend" message, and
+    re-assert `"sql" not in _cfg.__dict__` (building the ctx must not resolve the lazy `sql` accessor). Keep the
+    `print("INERTNESS_OK")` sentinel last. Do NOT weaken the existing forbidden-module list or the Phase-7
+    empty-route test.
+  </action>
+  <verify>
+    <automated>poetry run pytest tests/integration/test_backtest_oracle.py tests/integration/test_okx_inertness.py -x</automated>
+  </verify>
+  <acceptance_criteria>
+    - `poetry run pytest tests/integration/test_backtest_oracle.py -x` passes byte-exact `134 / 46189.87730727451` (`check_exact=True`).
+    - Determinism double-run: running the oracle twice yields identical trade count + final equity.
+    - `poetry run pytest tests/integration/test_okx_inertness.py -x` green, including the new register-vs-build assertion (FifoEventBus/EngineContext pull no `sqlalchemy`/`ccxt`; `sql` stays out of `config.__dict__`).
+    - `git diff --exit-code itrader/trading_system/live_trading_system.py` shows no changes (D-11 non-change).
+    - `grep -c 'compose_engine(ctx' itrader/trading_system/backtest_trading_system.py` == 2 (both arms folded).
+  </acceptance_criteria>
+  <done>Both backtest arms build + inject `EngineContext(FifoEventBus, backtest, sql_engine=None)`; oracle byte-exact; inertness gate extended and green; live system untouched.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| (none new) | The compose seam is backtest-only composition-root wiring. `EngineContext(sql_engine=None)` + `FifoEventBus` introduce no new I/O, no external input, no auth/secrets. The priority bus is not wired here (D-11); `live_trading_system.py` is untouched. CONTROL/BUSINESS tiering is operational ordering, not a trust boundary. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-02-07 | Tampering (behavioral) | `compose_engine` spec fold | high | mitigate | A1 — the body reads only `{data,start,end,timeframe,exchange,results_store}` with empty→None mapping, never `spec.ticker`/`spec.starting_cash`; the legacy arm passes placeholders. The byte-exact oracle (`check_exact=True`) + determinism double-run gate the fold; any drift fails the plan. |
+| T-02-08 | Tampering (behavioral) | legacy `__init__` arm (Pitfall 1) | high | mitigate | The oracle runs through the spec-LESS legacy arm — BOTH arms are folded to `(ctx, spec)` and the arm synthesizes a placeholder `SystemSpec`; `grep -c 'compose_engine(ctx'` == 2 + the oracle gate prove neither arm was missed. |
+| T-02-09 | (availability/perf) | register-vs-build inertness | high | mitigate | Extended `test_okx_inertness.py`: constructing `FifoEventBus()` + `EngineContext(sql_engine=None)` asserts no `sqlalchemy`/`ccxt` and `sql` stays unresolved in `config.__dict__` — closes the recurring eager-SQL-import failure mode (GATE-01 lineage). |
+| T-02-10 | Tampering (behavioral) | live-ordering via priority bus | low | accept | D-11 — no live wiring; `live_trading_system.py` diff is asserted empty. Validated v1.7 live ordering is untouched until P6/P7 + the P12 live-smoke gate. |
+| T-02-SC | Tampering (supply chain) | package installs | low | accept | Zero installs this phase; `poetry.lock` byte-unchanged is a phase-gate check. |
+</threat_model>
+
+<verification>
+- `poetry run pytest tests/integration/test_backtest_oracle.py -x` byte-exact `134 / 46189.87730727451`; run twice → identical (determinism).
+- `poetry run pytest tests/integration/test_okx_inertness.py -x` green incl. the new register-vs-build assertion.
+- `poetry run mypy itrader` clean (the retype + fold self-consistent; live/screeners `ignore_errors` unchanged).
+- `poetry run pytest tests/unit/events tests/unit/order tests/unit/strategy -x` green (no substrate/handler regression).
+- `git diff --exit-code itrader/trading_system/live_trading_system.py` → no changes (D-11).
+- `grep -c 'queue.Queue()' itrader/trading_system/compose.py` == 0; `grep -c 'compose_engine(ctx' itrader/trading_system/backtest_trading_system.py` == 2.
+- `git diff --stat poetry.lock` empty (no dependency change).
+</verification>
+
+<success_criteria>
+- `EngineContext` (4 loose fields) exists; `compose_engine(ctx, spec)` is the two-arg end-state signature with the internal queue deleted and `ctx.bus` threaded into every handler.
+- Both backtest arms build + inject `EngineContext(bus=FifoEventBus(), environment='backtest', sql_engine=None)` and read handler-owned storage back.
+- SMA_MACD oracle byte-exact + deterministic; inertness gate green + extended; `mypy --strict` clean.
+- `live_trading_system.py` unchanged (D-11); `poetry.lock` unchanged.
+</success_criteria>
+
+<output>
+Create `.planning/phases/02-event-bus/02-03-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/02-event-bus/02-03-SUMMARY.md
+++ b/.planning/phases/02-event-bus/02-03-SUMMARY.md
@@ -1,0 +1,201 @@
+---
+phase: 02-event-bus
+plan: 03
+subsystem: infra
+tags: [event-bus, engine-context, compose-seam, dependency-injection, mypy-strict, oracle-gate]
+
+# Dependency graph
+requires:
+  - phase: 02-01
+    provides: EventBus Protocol + FifoEventBus/PriorityEventBus substrate + 3 CONTROL EventType members
+  - phase: 02-02
+    provides: handler-owned storage seams (OrderHandler.storage, StrategiesHandler.signal_store)
+provides:
+  - Frozen EngineContext dataclass (bus/config/environment/sql_engine, loose types)
+  - Two-arg compose_engine(ctx, spec) end-state signature (internal queue.Queue() deleted)
+  - Both backtest arms (legacy __init__ + build_backtest_system factory) folded to (ctx, spec) with EngineContext(FifoEventBus, backtest, sql_engine=None)
+  - global_queue retyped to EventBus across 5 handlers + SimulatedExchange + BacktestBarFeed.bind (retype-not-rename)
+  - Extended register-vs-build inertness gate
+affects: [P3, P4, P6, P7, P9, live-system-refactor]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "EngineContext infra bundle: ctx (infra) + spec (declarative WHAT) two-object split at the compose seam"
+    - "Retype-not-rename DI: global_queue param retyped to EventBus Protocol, name preserved, no call-site churn"
+    - "Handler-owned storage read-back: compose reads order_handler.storage / strategies_handler.signal_store off the constructed handlers"
+
+key-files:
+  created:
+    - itrader/trading_system/engine_context.py
+  modified:
+    - itrader/trading_system/compose.py
+    - itrader/trading_system/backtest_trading_system.py
+    - itrader/events_handler/full_event_handler.py
+    - itrader/order_handler/order_handler.py
+    - itrader/strategy_handler/strategies_handler.py
+    - itrader/portfolio_handler/portfolio_handler.py
+    - itrader/execution_handler/execution_handler.py
+    - itrader/execution_handler/exchanges/simulated.py
+    - itrader/price_handler/feed/bar_feed.py
+    - tests/integration/test_okx_inertness.py
+
+key-decisions:
+  - "D-01/CTX-01: compose_engine(ctx, spec) two-arg end-state signature; internal queue.Queue() deleted, ctx.bus owns transport"
+  - "D-05/BUS-04: EngineContext = exactly 4 fields (bus/config/environment/sql_engine), loose types only tightened downstream, never widened/added"
+  - "D-04/A1: compose reads only {data,start,end,timeframe,exchange,results_store}; order_config stays handler-owned via OrderConfig.default()"
+  - "D-06: both backtest arms build EngineContext(FifoEventBus, backtest, sql_engine=None); legacy arm synthesizes placeholder SystemSpec (Pitfall 1)"
+  - "D-07/D-08: retype-not-rename — global_queue param retyped to EventBus, name unchanged, no .put()/.get_nowait() call-site changes"
+  - "D-11: live_trading_system.py unchanged (checkable non-diff)"
+
+patterns-established:
+  - "Infra/declarative split: EngineContext carries infra, SystemSpec carries the run description; the seam reads only A1-permitted spec fields"
+  - "EventBus Protocol propagation: any strict-typed component receiving global_queue retypes to EventBus (only uses .put()); Protocol satisfied structurally"
+
+requirements-completed: [BUS-01, BUS-04, CTX-01, CTX-03]
+
+coverage:
+  - id: D1
+    description: "Frozen EngineContext dataclass with exactly 4 loose-typed fields (bus/config/environment/sql_engine)"
+    requirement: "BUS-04"
+    verification:
+      - kind: unit
+        ref: "poetry run python -c 'fields(EngineContext) == [bus,config,environment,sql_engine]' (Task 1 automated verify)"
+        status: pass
+    human_judgment: false
+  - id: D2
+    description: "compose_engine folded to two-arg (ctx, spec); internal queue.Queue() deleted; A1 spec-read constraint honored"
+    requirement: "CTX-01"
+    verification:
+      - kind: unit
+        ref: "inspect.signature(compose_engine) == ['ctx','spec']; grep queue.Queue()==0; grep spec.ticker/starting_cash/strategies/portfolios==0"
+        status: pass
+      - kind: integration
+        ref: "tests/integration/test_backtest_oracle.py (byte-exact 134 / 46189.87730727451, check_exact=True)"
+        status: pass
+    human_judgment: false
+  - id: D3
+    description: "Both backtest arms rewired to EngineContext(FifoEventBus, backtest, sql_engine=None); handler-owned storage read back"
+    requirement: "CTX-03"
+    verification:
+      - kind: integration
+        ref: "tests/integration/test_backtest_oracle.py (oracle byte-exact, determinism double-run identical); grep compose_engine(ctx==2"
+        status: pass
+    human_judgment: false
+  - id: D4
+    description: "Register-vs-build inertness gate extended: FifoEventBus + EngineContext(sql_engine=None) pull no sqlalchemy/ccxt; sql stays unresolved"
+    requirement: "CTX-03"
+    verification:
+      - kind: integration
+        ref: "tests/integration/test_okx_inertness.py (register-vs-build assertion)"
+        status: pass
+    human_judgment: false
+  - id: D5
+    description: "global_queue retyped to EventBus across handlers + exchange + feed (retype-not-rename); mypy --strict clean"
+    requirement: "BUS-01"
+    verification:
+      - kind: unit
+        ref: "poetry run mypy itrader (237 source files, Success: no issues found)"
+        status: pass
+    human_judgment: false
+
+# Metrics
+duration: 18min
+completed: 2026-07-09
+status: complete
+---
+
+# Phase 2 Plan 03: EngineContext + Compose-Seam Fold Summary
+
+**Frozen EngineContext + two-arg compose_engine(ctx, spec) fold — internal queue.Queue() deleted, global_queue retyped to the EventBus Protocol across 7 strict-typed components, both backtest arms rewired to FifoEventBus, oracle byte-exact at 134 / 46189.87730727451.**
+
+## Performance
+
+- **Duration:** ~18 min
+- **Started:** 2026-07-09 (Task 1)
+- **Completed:** 2026-07-09
+- **Tasks:** 3
+- **Files created:** 1
+- **Files modified:** 9
+
+## Accomplishments
+- Introduced the frozen `EngineContext` (exactly 4 loose-typed fields `bus`/`config`/`environment`/`sql_engine`) as the infra half of the ctx+spec compose seam.
+- Folded `compose_engine` to its end-state two-arg `(ctx, spec)` signature, DELETING the internal `queue.Queue()` — `ctx.bus` now owns the transport, injected into all 6 handler ctors + the `Engine` holder.
+- Retyped `global_queue` to `EventBus` (name unchanged, D-07/D-08) across 5 handlers, `SimulatedExchange`, and `BacktestBarFeed.bind` — no `.put()`/`.get_nowait()` call-site changed.
+- Rewired BOTH backtest arms (the spec-LESS legacy `__init__` the oracle runs through, and the `build_backtest_system` factory) to build+inject `EngineContext(bus=FifoEventBus(), environment='backtest', sql_engine=None)` and read handler-owned storage back.
+- Extended the inertness gate with a register-vs-build assertion; SMA_MACD oracle byte-exact + deterministic double-run identical; `mypy --strict` clean on all 237 source files.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: EngineContext dataclass + retype-not-rename bus swap** - `7c2e18bf` (feat)
+2. **Task 2: Fold compose_engine to (ctx, spec) — delete internal queue** - `9e7cdf49` (feat)
+3. **Task 3: Rewire both backtest call sites + extend inertness gate** - `1369a21a` (feat)
+
+## Files Created/Modified
+- `itrader/trading_system/engine_context.py` (created) - Frozen `EngineContext` infra bundle (4 loose fields), imports only stdlib + the `EventBus` Protocol.
+- `itrader/trading_system/compose.py` - `compose_engine(ctx, spec)`; internal queue deleted; `ctx.bus` threaded into every handler + Engine; A1 spec fold; storage read back off handlers; `Engine.global_queue` field retyped to `EventBus`; dropped now-unused `queue`/`Path`/`OrderStorage`/`ExchangeConfig` imports.
+- `itrader/trading_system/backtest_trading_system.py` - Legacy arm synthesizes a placeholder `SystemSpec` + `EngineContext`, reads signal store back off the engine; factory uses `dataclasses.replace` to seed `spec.exchange`, builds ctx, calls `compose_engine(ctx, spec)`; dropped factory storage selection + unused `OrderStorageFactory`/`SignalStorageFactory` imports.
+- `itrader/events_handler/full_event_handler.py` - `global_queue` param retyped to `EventBus` (kept `import queue` for the `queue.Empty` drain catch).
+- `itrader/order_handler/order_handler.py` - `global_queue` param retyped to `EventBus`.
+- `itrader/strategy_handler/strategies_handler.py` - `global_queue` param + self-attr retyped to `EventBus`.
+- `itrader/portfolio_handler/portfolio_handler.py` - `global_queue` param + self-attr retyped to `EventBus` (4-space file).
+- `itrader/execution_handler/execution_handler.py` - `global_queue` param retyped to `EventBus`.
+- `itrader/execution_handler/exchanges/simulated.py` - (Rule 3) `global_queue` param retyped to `EventBus` — only calls `.put()`.
+- `itrader/price_handler/feed/bar_feed.py` - (Rule 3) `bind` param + self-attr retyped to `Optional[EventBus]`; dropped now-unused `import queue`.
+- `tests/integration/test_okx_inertness.py` - Extended `_PROBE` with the register-vs-build assertion (FifoEventBus + EngineContext(sql_engine=None) pull no sqlalchemy/ccxt; `sql` stays unresolved in `config.__dict__`).
+
+## Decisions Made
+- None beyond the locked plan decisions (D-01/D-04/D-05/D-06/D-07/D-08/D-11 delivered as specified).
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Retype SimulatedExchange.global_queue to EventBus**
+- **Found during:** Task 2 (compose fold)
+- **Issue:** `ExecutionHandler.global_queue` retyped to `EventBus` propagated into `ExecutionHandler`'s construction of `SimulatedExchange(self.global_queue, ...)`, whose param was typed `Queue[Any]` — `mypy --strict` error `arg-type` at execution_handler.py:154.
+- **Fix:** Retyped `SimulatedExchange.__init__`'s `global_queue` param to `EventBus` (it only calls `.put()`, which the Protocol provides) and added the `EventBus` import.
+- **Files modified:** itrader/execution_handler/exchanges/simulated.py
+- **Verification:** `mypy --strict` clean on the 8-module set; oracle byte-exact.
+- **Committed in:** `9e7cdf49` (Task 2 commit)
+
+**2. [Rule 3 - Blocking] Retype BacktestBarFeed.bind global_queue to EventBus**
+- **Found during:** Task 3 (both-arm rewire — surfaced by the full `mypy itrader` gate)
+- **Issue:** `Engine.global_queue` is now `EventBus`; `BacktestRunner` calls `engine.feed.bind(engine.global_queue, ...)` whose param + self-attr were typed `Optional[queue.Queue[Any]]` — `mypy --strict` error `arg-type` at backtest_runner.py:113.
+- **Fix:** Retyped `BacktestBarFeed.bind`'s `global_queue` param and the `self.global_queue` attr to `Optional[EventBus]` (only calls `.put()`), added the `EventBus` import, dropped the now-unused `import queue`.
+- **Files modified:** itrader/price_handler/feed/bar_feed.py
+- **Verification:** `poetry run mypy itrader` — Success, 237 files; oracle byte-exact; 571 unit + 228 e2e/integration tests green.
+- **Committed in:** `1369a21a` (Task 3 commit)
+
+---
+
+**Total deviations:** 2 auto-fixed (2 blocking mypy propagations)
+**Impact on plan:** Both are the natural, required continuation of the retype-not-rename bus swap — any strict-typed component receiving `global_queue` had to retype to the `EventBus` Protocol for `mypy --strict` to pass. No behavior change (both only enqueue via `.put()`), no scope creep. The oracle stayed byte-exact throughout.
+
+## Issues Encountered
+- Two docstring greps initially over-counted: the acceptance-criteria greps (`queue.Queue()`, `spec.ticker|...`, `compose_engine(ctx`) matched literal strings in docstrings/comments. Reworded the docstrings to avoid the literal forms so the greps report the code-only counts (0 / 0 / 2). No functional impact.
+
+## Gate Results
+- Oracle: `tests/integration/test_backtest_oracle.py` byte-exact `134 / 46189.87730727451` (`check_exact=True`), run twice — identical (determinism).
+- Inertness: `tests/integration/test_okx_inertness.py` green incl. new register-vs-build assertion.
+- `poetry run mypy itrader` — Success: no issues found in 237 source files.
+- Unit + e2e/integration: 571 + 228 passed (6 OKX-credential-gated skips).
+- `grep -c 'queue.Queue()' compose.py` == 0; `grep -c 'compose_engine(ctx' backtest_trading_system.py` == 2.
+- `git diff --exit-code live_trading_system.py` — no changes (D-11); `poetry.lock` byte-unchanged.
+
+## Next Phase Readiness
+- The compose seam is at its end-state form — P3/P4/P9 only TIGHTEN `EngineContext`'s loose types (never add fields); no re-edit of the two-arg signature required downstream.
+- `PriorityEventBus` remains wired into no path (D-11) — live ordering untouched until P6/P7 + the P12 live-smoke gate.
+
+## Self-Check: PASSED
+
+- FOUND: itrader/trading_system/engine_context.py
+- FOUND: .planning/phases/02-event-bus/02-03-SUMMARY.md
+- FOUND commits: 7c2e18bf, 9e7cdf49, 1369a21a
+
+---
+*Phase: 02-event-bus*
+*Completed: 2026-07-09*

--- a/.planning/phases/02-event-bus/02-CONTEXT.md
+++ b/.planning/phases/02-event-bus/02-CONTEXT.md
@@ -47,11 +47,14 @@ stays in P3/P4.
     the declarative spec) and B3 (hybrid `(ctx, spec, *, order_storage, signal_store)` — reintroduces the
     P3 double-edit). The clean two-arg form only pays off *with* handler-owned storage.
 - **D-03 (PHASING / TRACEABILITY SHIFT):** Choosing D-01+D-02 means **P2 absorbs CTX-01
-  (`compose_engine(ctx, spec)`) and CTX-02 (storage-in-handler)** — both scheduled as **P3** in the design
-  (§16) and REQUIREMENTS.md. **P3 shrinks** to CTX-03 (`SqlBackend→SqlEngine` rename) + CTX-04 (lazy-import
-  guard). This is a deliberate owner-directed roadmap reshape (like P1's cardinality override), same total
-  work, P2/P3 merged on the compose seam. **Downstream must NOT "fix" this back.** REQUIREMENTS.md/ROADMAP.md
-  traceability should be updated so CTX-01/CTX-02 point at P2 (see Deferred → action item).
+  (`compose_engine(ctx, spec)`), CTX-02 (storage-in-handler), and CTX-03 (the backtest byte-exact +
+  lazy-SQL-inertness gate for that change — inseparable from the change itself)** — all scheduled as **P3**
+  in the design (§16) and REQUIREMENTS.md. **P3 shrinks to just CTX-04** (`SqlBackend→SqlEngine` rename — a
+  mechanical rename, genuinely separable and left in P3). This is a deliberate owner-directed roadmap reshape
+  (like P1's cardinality override), same total work, P2/P3 merged on the compose seam. **Downstream must NOT
+  "fix" this back.** REQUIREMENTS.md/ROADMAP.md traceability updated so CTX-01/CTX-02/CTX-03 point at P2
+  (done 2026-07-09). Note: P3 now carries a single requirement (CTX-04) — worth a look at close whether it
+  folds into P2 or P4.
 - **D-04:** The kwargs→spec fold is **mostly 1:1 with existing `SystemSpec` fields** — `csv_paths→data`,
   `start_date→start`, `end_date→end`, `timeframe→timeframe`, `exchange_config←exchange` (factory already
   derives `ExchangeConfig` from `spec.exchange`), `results_store→results_store` (already on the spec). The
@@ -130,8 +133,8 @@ stays in P3/P4.
   deviations D-01/D-02/D-03 above** — P2 pulls CTX-01/CTX-02 forward from P3.
 
 ### Requirements
-- `.planning/REQUIREMENTS.md` — **BUS-01..BUS-04** (P2 as-scheduled) **plus CTX-01, CTX-02** (pulled into
-  P2 per D-03; traceability update pending). CTX-03/CTX-04 remain P3.
+- `.planning/REQUIREMENTS.md` — **BUS-01..BUS-04** (P2 as-scheduled) **plus CTX-01, CTX-02, CTX-03** (pulled
+  into P2 per D-03; traceability table + section header updated 2026-07-09). CTX-04 remains P3.
 
 ### Roadmap
 - `.planning/ROADMAP.md` — Phase 2 (Event Bus) success criteria + Phase 3 (which shrinks per D-03).
@@ -206,9 +209,9 @@ stays in P3/P4.
 <deferred>
 ## Deferred Ideas
 
-- **REQUIREMENTS.md / ROADMAP.md traceability update** (action item, D-03) — move CTX-01 + CTX-02 into P2's
-  requirement set; note P3 shrinks to CTX-03 (`SqlBackend→SqlEngine` rename) + CTX-04 (lazy-import guard).
-  Do this before/at planning so the plan-checker's decision-coverage gate sees CTX-01/02 cited under P2.
+- **REQUIREMENTS.md / ROADMAP.md traceability update** (D-03) — ✅ done 2026-07-09: CTX-01/CTX-02/CTX-03
+  moved into P2's requirement set (traceability table + section header + ROADMAP Phase 2/3); P3 now = CTX-04
+  (`SqlBackend→SqlEngine` rename) only. So the plan-checker's decision-coverage gate sees CTX-01/02/03 under P2.
 - **Wiring `PriorityEventBus` into the live system** — P6/P7, when `LiveRunner` replaces
   `_event_processing_loop` and the connector→CONTROL-route handoff + flag-machinery deletion land.
 - **`RuntimeConfig` overlay** — P9; P2's `EngineContext.config` is a loose-typed placeholder (today's

--- a/.planning/phases/02-event-bus/02-CONTEXT.md
+++ b/.planning/phases/02-event-bus/02-CONTEXT.md
@@ -1,0 +1,225 @@
+# Phase 2: Event Bus - Context
+
+**Gathered:** 2026-07-09
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Introduce a stdlib two-tier `EventBus` (`itrader/events_handler/bus.py`) — `FifoEventBus`
+(backtest, thin `queue.Queue` wrapper) + `PriorityEventBus` (live, `PriorityQueue` keyed
+`(tier, seq, event)`) — behind one `.put(event)` surface; add the three new CONTROL `EventType`
+members; and **settle `compose_engine`'s signature to its end-state `(ctx, spec)` form** via a
+frozen `EngineContext` — **without disturbing the byte-exact backtest oracle
+(`134 / 46189.87730727451`) or the OKX import-inertness gate** (`tests/integration/test_okx_inertness.py`).
+
+Delivers (BUS-01..04 + the pulled-forward CTX-01/CTX-02 — see D-03):
+- `EventBus` Protocol (`put`/`get`/`get_nowait`/`qsize`/`empty`/`depth_by_tier`) with two
+  byte-compatible implementations sharing one `.put()`.
+- New CONTROL `EventType`s (`STREAM_STATE`, `CONNECTOR_FATAL`, `CONFIG_UPDATE`) + a declarative
+  `_CONTROL_EVENT_TYPES` frozenset.
+- A frozen `EngineContext` (`bus`/`config`/`environment`/`sql_engine`) threaded once into
+  `compose_engine(ctx, spec)`, with Order + Strategies handlers owning their storage init.
+- Backtest wires `FifoEventBus` at **zero oracle risk**; the priority bus is backtest-dark.
+
+This is an **oracle-gated foundation phase** — blast radius is the enemy. The owner chose the
+end-state `(ctx, spec)` signature (Option B) over the minimal prepend-ctx form, accepting a wider
+P2 in exchange for never re-editing the signature downstream. The heavy SQL/migrations/rename work
+stays in P3/P4.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### `compose_engine` signature (BUS-04) — OWNER OVERRIDE OF SPEC PHASING
+- **D-01:** The signature settles to the design's **end-state two-arg form `compose_engine(ctx, spec)`**
+  (spec §5) — reached in P2 so it is **never re-edited** downstream. This is Option B, chosen over the
+  minimal "prepend `ctx`, keep the 8 kwargs" form. The backtest factory builds the `FifoEventBus` + the
+  `EngineContext` and injects it; the internal `queue.Queue()` at `compose.py:164` is **deleted**.
+- **D-02:** Storage placement = **handlers own their storage init** (spec §7b / LR-13). Order + Strategies
+  handlers adopt `PortfolioHandler`'s **existing** shape (`OrderHandler(..., *, environment, sql_engine,
+  storage=None) → self.storage = storage or OrderStorageFactory.create(environment, backend=sql_engine)`);
+  `compose_engine` reads the concrete back off `.storage` for the `portfolio_handler.set_order_storage(...)`
+  wiring. **Backtest slice only** — `environment='backtest', sql_engine=None` → the same in-memory storage
+  instances as today → byte-exact.
+  - **Rejected:** B2 (putting `order_storage`/`signal_store` backend instances onto `SystemSpec` — pollutes
+    the declarative spec) and B3 (hybrid `(ctx, spec, *, order_storage, signal_store)` — reintroduces the
+    P3 double-edit). The clean two-arg form only pays off *with* handler-owned storage.
+- **D-03 (PHASING / TRACEABILITY SHIFT):** Choosing D-01+D-02 means **P2 absorbs CTX-01
+  (`compose_engine(ctx, spec)`) and CTX-02 (storage-in-handler)** — both scheduled as **P3** in the design
+  (§16) and REQUIREMENTS.md. **P3 shrinks** to CTX-03 (`SqlBackend→SqlEngine` rename) + CTX-04 (lazy-import
+  guard). This is a deliberate owner-directed roadmap reshape (like P1's cardinality override), same total
+  work, P2/P3 merged on the compose seam. **Downstream must NOT "fix" this back.** REQUIREMENTS.md/ROADMAP.md
+  traceability should be updated so CTX-01/CTX-02 point at P2 (see Deferred → action item).
+- **D-04:** The kwargs→spec fold is **mostly 1:1 with existing `SystemSpec` fields** — `csv_paths→data`,
+  `start_date→start`, `end_date→end`, `timeframe→timeframe`, `exchange_config←exchange` (factory already
+  derives `ExchangeConfig` from `spec.exchange`), `results_store→results_store` (already on the spec). The
+  **one** kwarg without a spec field is `order_config`; planner decides: keep it **handler-owned** via
+  `OrderConfig.default()` (consistent with P1 D-03 "order lives with its owner", **leaned**) or add a spec
+  field. This clean mapping is what makes B low-risk despite the wider surface.
+
+### `EngineContext` skeleton
+- **D-05:** Frozen dataclass with **all 4 fields now** (spec §7a): `bus: EventBus`, `config`,
+  `environment: str`, `sql_engine`. `bus`/`environment`/`sql_engine` are **actively consumed in P2** (handlers
+  derive storage from `environment`+`sql_engine`); `config` is carried but **unread until P9**. **Loose types**
+  for the not-yet-built pieces: `config` typed as today's `SystemConfig` (P9 widens/swaps to `RuntimeConfig`);
+  `sql_engine: Optional[...] = None` (the concrete `SqlEngine` type lands with the P3/P4 rename). **P3/P4/P9
+  only tighten types — never add fields.** Settling the full shape once matches the reason B was chosen.
+- **D-06:** Backtest factory constructs `EngineContext(bus=FifoEventBus(), config=<the SystemConfig>,
+  environment='backtest', sql_engine=None)`. `sql_engine=None` + `FifoEventBus` **pull nothing heavy** →
+  inertness gate stays green (extended register-vs-build assertion).
+
+### `EventBus` Protocol + `FifoEventBus` (bus reach / blast radius)
+- **D-07:** **Full bus swap** — every handler constructor that takes `global_queue` now receives the
+  `FifoEventBus` in its place (duck-typed `.put()`, **no `.put` call-site changes**, BUS-01); `EventHandler`
+  drains via `bus.get_nowait()`/`bus.empty()`. `FifoEventBus` is a thin wrapper over `queue.Queue` → **byte-identical
+  FIFO** → oracle safe. Boundary-only wrapping was rejected as a throwaway seam given the compose rewrite.
+- **D-08:** The constructor **parameter name stays `global_queue`/`events_queue`** (CLAUDE.md naming
+  convention: "the shared event queue is always named `global_queue` or `events_queue`") — **retyped** to
+  `EventBus`. Do NOT rename the param to `bus` (breaks the documented convention + widens the diff).
+- **D-09:** Protocol surface = `put`, `get(timeout)`, `get_nowait`, `qsize`, `empty`, `depth_by_tier`
+  (§4a). `bus.py` lives at `itrader/events_handler/bus.py`, **4-space indent** (the `events_handler/events/`
+  package convention — NOT the tab handler-module convention).
+
+### `PriorityEventBus` + CONTROL events (live-wiring boundary)
+- **D-10:** P2 = **define `PriorityEventBus` + unit-test only** (Option 1). Ship the full substrate:
+  `PriorityEventBus` (`PriorityQueue` keyed `(tier, seq, event)`; `tier ∈ {CONTROL=0, BUSINESS=1}` assigned
+  from `_CONTROL_EVENT_TYPES`; `seq = itertools.count()` — thread-safe, globally-unique); the **BUS-02
+  ordering test** (proves the tuple comparison never dereferences the non-orderable frozen event, and strict
+  within-tier FIFO holds); the 3 new CONTROL `EventType`s in `core/enums/event.py`; and `_CONTROL_EVENT_TYPES`.
+- **D-11:** **ZERO live wiring in P2** — `live_trading_system.py` stays untouched on its raw `queue.Queue`
+  until P6/P7. Rationale: (a) the 3 new CONTROL events have **no producers/consumers** until P6/P7/P8
+  (`SafetyController`/`StreamRecoveryHandler`/connector→CONTROL-route handoff); (b) the **one existing**
+  CONTROL event `STRATEGY_COMMAND` already flows through the live queue — swapping to priority now would
+  **silently change validated v1.7 live ordering** (preemption) with **no live-smoke gate until P12**; (c) the
+  live drain loop + flag side-channel (`_pending_stream_resume`/`_pending_connector_halt`) is **deleted and
+  rewritten by `LiveRunner`** in P6/P7 anyway, so Option 2 saves no work and creates a half-migrated
+  intermediate. **Option 2 (wire live now) explicitly rejected.**
+
+### Tier assignment (spec §4a — finalize in P2)
+- **CONTROL** (preempts market data): `STREAM_STATE`, `CONNECTOR_FATAL`, `CONFIG_UPDATE`, `STRATEGY_COMMAND`.
+- **BUSINESS** (strict FIFO): `BAR`, `SIGNAL`, `ORDER`, `FILL`, `UNIVERSE_*`, `BARS_*`, `ERROR`,
+  `PORTFOLIO_UPDATE` (plus existing `TIME`/`UPDATE`/`ORDER_ACK`/`SCREENER`). **Externally-injected `SIGNAL`s
+  stay BUSINESS** (must interleave in order with bars/fills — control priority is for operational commands,
+  not trading intents).
+
+### Claude's Discretion
+- The `EngineContext` class **home/module** (near `compose_engine` in `trading_system/`, or `events_handler/`
+  — pick to avoid an import cycle with `EventBus`).
+- `FifoEventBus.depth_by_tier` exact shape (FIFO is tierless — a single-bucket mapping such as
+  `{BUSINESS: qsize}` is fine; must satisfy the Protocol).
+- Whether to add an **optional standalone integration test** driving a representative CONTROL+BUSINESS
+  interleaving through `PriorityEventBus` (no `live_trading_system.py` touch) for integration confidence
+  beyond unit tests — the better buy than wiring live.
+- `order_config` home under the fold (D-04) — leaned handler-owned per P1 D-03.
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Design source (the P2 contract)
+- `docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md` — **§4 (event bus &
+  threading model)** = `FifoEventBus`/`PriorityEventBus`, `(tier, seq, event)` keying,
+  `_CONTROL_EVENT_TYPES`, tier assignment, single-writer engine-thread contract; **§5 (topology)** =
+  the `compose_engine(ctx, spec)` end-state signature; **§7a–7b (`EngineContext` + storage-in-handler,
+  LR-13/LR-14)** = the frozen `EngineContext` shape and handler-owns-init pattern. **Note the P2
+  deviations D-01/D-02/D-03 above** — P2 pulls CTX-01/CTX-02 forward from P3.
+
+### Requirements
+- `.planning/REQUIREMENTS.md` — **BUS-01..BUS-04** (P2 as-scheduled) **plus CTX-01, CTX-02** (pulled into
+  P2 per D-03; traceability update pending). CTX-03/CTX-04 remain P3.
+
+### Roadmap
+- `.planning/ROADMAP.md` — Phase 2 (Event Bus) success criteria + Phase 3 (which shrinks per D-03).
+
+### Prior-phase decisions that bind here
+- `.planning/phases/01-config-centralization/01-CONTEXT.md` — P1 **D-01** (config mutable-by-convention),
+  **D-03** (order config lives with its owner — informs D-04's `order_config` lean), **D-05** (lazy `sql`
+  accessor — the inertness seam `EngineContext.sql_engine=None` must not disturb).
+
+### Gates (must stay green — verify after every plan)
+- `tests/integration/test_backtest_oracle.py` — SMA_MACD byte-exact oracle (`134 / 46189.87730727451`).
+- `tests/integration/test_okx_inertness.py` — extended register-vs-build assertion: `FifoEventBus` /
+  `EngineContext(sql_engine=None)` pull nothing heavy; import constructs no `SqlSettings`.
+
+### Code touchpoints
+- `itrader/trading_system/compose.py` (`compose_engine` :116, internal `queue.Queue()` :164 deleted),
+  `itrader/trading_system/backtest_trading_system.py` (`build_backtest_system` :401/:437,
+  `BacktestTradingSystem.__init__` compose call :131), `itrader/trading_system/system_spec.py` (`SystemSpec`
+  fields for the kwargs→spec fold), `itrader/events_handler/full_event_handler.py` (`EventHandler` drain
+  :66/:127 → `bus.get_nowait()`), `itrader/core/enums/event.py` (`EventType` — add 3 CONTROL members),
+  `itrader/portfolio_handler/portfolio_handler.py` (the handler-owns-storage template),
+  `itrader/trading_system/live_trading_system.py` (**untouched** in P2 per D-11).
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- **`PortfolioHandler` already owns its storage** — it is the exact template Order + Strategies handlers
+  adopt for D-02. No new pattern is invented; two handlers adopt an established one.
+- **`SystemSpec` already carries `data`/`start`/`end`/`timeframe`/`exchange`/`results_store`/`actions`**
+  (`system_spec.py`) — so the D-01 kwargs→spec fold is mostly 1:1 with existing fields (this is what makes
+  Option B low-risk). `results_store` is already typed `Any` on the spec to stay SQL-import-inert.
+- **`OrderStorageFactory.create(environment, backend=...)`** — the factory the handler-owned init calls;
+  backtest → in-memory regardless of `backend`, so D-02's backtest slice needs no `SqlEngine`.
+- **`itertools.count()`** (stdlib) — the thread-safe monotonic `seq` source for `PriorityEventBus`; zero
+  new dependency (milestone gate: no poetry change in P1–P12).
+
+### Established Patterns
+- `EventType` enum (`core/enums/event.py`) already holds `STRATEGY_COMMAND`, `UNIVERSE_POLL`, `BARS_LOADED`,
+  `BARS_LOAD_FAILED` from v1.7 — the 3 new CONTROL members slot alongside.
+- Import-side-effect singletons (`itrader/__init__.py` builds `config`, `idgen`) — `EngineContext.config`
+  carries the existing `SystemConfig` instance in P2 (loose type, D-05).
+- Indentation split: `events_handler/events/` = 4-space; handler modules = tabs. New `bus.py` follows the
+  4-space events-package convention (D-09); the handler-ctor edits for the bus swap (D-07) touch tab files —
+  match each file, never normalize.
+
+### Integration Points
+- `compose_engine` grows a leading `ctx: EngineContext` and reads run config off `spec`; its internal
+  `queue.Queue()` is deleted (D-01). The backtest factory builds `ctx` + `FifoEventBus` and injects.
+- Every handler constructor's `global_queue` param is **retyped** to `EventBus` (name unchanged, D-08); the
+  `EventHandler` drain switches to `bus.get_nowait()`/`bus.empty()` (D-07).
+- `live_trading_system.py` is **not** an integration point in P2 (D-11) — it stays on its raw queue.
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- The owner deliberately chose the **end-state `compose_engine(ctx, spec)` signature now** (Option B) over
+  the smaller prepend-ctx form, on the "settle it once, never re-edit" principle — and, seeing that the
+  clean two-arg form requires handler-owned storage, accepted pulling CTX-01/CTX-02 forward into P2 because
+  that is exactly what the spec (§7b) already designed. This mirrors the P1 stance of reshaping the roadmap
+  around a load-bearing design principle rather than following phase numbering mechanically.
+- The **priority bus earns its keep only once CONTROL traffic exists** — so P2 builds and proves it in
+  isolation and refuses to wire it into the human-validated live path before its producers/consumers (and
+  live gates) land in P6/P7/P12.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- **REQUIREMENTS.md / ROADMAP.md traceability update** (action item, D-03) — move CTX-01 + CTX-02 into P2's
+  requirement set; note P3 shrinks to CTX-03 (`SqlBackend→SqlEngine` rename) + CTX-04 (lazy-import guard).
+  Do this before/at planning so the plan-checker's decision-coverage gate sees CTX-01/02 cited under P2.
+- **Wiring `PriorityEventBus` into the live system** — P6/P7, when `LiveRunner` replaces
+  `_event_processing_loop` and the connector→CONTROL-route handoff + flag-machinery deletion land.
+- **`RuntimeConfig` overlay** — P9; P2's `EngineContext.config` is a loose-typed placeholder (today's
+  `SystemConfig`) until then.
+- **`SqlBackend→SqlEngine` rename + migrations relocation** — P3/P4; P2's `EngineContext.sql_engine` is
+  typed loosely (`Optional[...] = None`) and only exercised on the `None` (backtest/in-memory) path.
+- **`order_config` onto `SystemSpec`** — only if the planner rejects the handler-owned lean in D-04.
+
+</deferred>
+
+---
+
+*Phase: 2-Event Bus*
+*Context gathered: 2026-07-09*

--- a/.planning/phases/02-event-bus/02-DISCUSSION-LOG.md
+++ b/.planning/phases/02-event-bus/02-DISCUSSION-LOG.md
@@ -1,0 +1,86 @@
+# Phase 2: Event Bus - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-07-09
+**Phase:** 2-Event Bus
+**Areas discussed:** compose_engine signature, EngineContext skeleton fields, Bus reach / blast radius, PriorityEventBus wiring boundary
+
+---
+
+## compose_engine signature (BUS-04)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Prepend ctx, keep kwargs | `compose_engine(ctx, *, <8 existing kwargs>)`; factory injects FifoEventBus + minimal ctx; smallest oracle-path diff; kwargs→spec fold deferred | |
+| Go straight to `(ctx, spec)` | Fold the 8 kwargs into SystemSpec now → end-state two-arg signature; bigger backtest-wiring rewrite | ✓ |
+| Defer ctx to P3 | compose_engine builds FifoEventBus() itself; no ctx param; signature edited twice (the trap BUS-04 names) | |
+
+**User's choice:** Go straight to `(ctx, spec)` (Option B).
+**Notes:** After seeing examples for all three and the recommendation (A), the owner deliberately chose the end-state signature to settle it once. Follow-up fork surfaced (storage placement) — see below.
+
+### Sub-decision: storage placement under `(ctx, spec)`
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| B1 — storage-in-handler now | Handlers own storage init from (environment, sql_engine); compose reads `.storage` back. Cleanest (ctx, spec); pulls CTX-02 into P2. | ✓ |
+| B2 — storages onto SystemSpec | Backend instances become SystemSpec fields; pollutes the declarative spec | |
+| B3 — hybrid (ctx, spec, *kwargs) | Storages stay injected kwargs; not the clean two-arg form; P3 double-edit returns | |
+| Reconsider — back to Option A | Revert to prepend-ctx if the consequence changes the call | |
+
+**User's choice:** B1 — handlers own their storage (the owner recognized this is exactly spec §7b / LR-13, and that `PortfolioHandler` already works this way).
+**Notes:** Owner asked "can't they live in the class itself — isn't that what the spec defined?" Confirmed yes. Consequence accepted: **P2 absorbs CTX-01 + CTX-02** (scheduled P3), P3 shrinks to the SqlEngine rename + lazy-guard. Low-risk because the backtest slice is in-memory + PortfolioHandler is the template; heavy SQL/migrations stay in P3/P4. Traceability update flagged.
+
+---
+
+## EngineContext skeleton fields
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Include all 4 now (loose type) | bus + config + environment + sql_engine, placeholder types for RuntimeConfig/SqlEngine; P3/P4/P9 only tighten types | ✓ |
+| Defer config (bus/env/sql_engine only) | Ship 3 fields; add config in P9; frozen dataclass gains a field later | |
+
+**User's choice:** Include all 4 now, loose types.
+**Notes:** Consistent with choosing B to settle the shape once. bus/environment/sql_engine are actively consumed in P2 (storage-in-handler); config is carried but unread until P9.
+
+---
+
+## Bus reach / blast radius
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Full swap now | Every handler ctor receives the FifoEventBus (retyped `global_queue`, no .put call-site changes); EventHandler drains via bus.get_nowait(); byte-identical FIFO → oracle safe | ✓ |
+| Boundary-only | Handlers keep raw queue.Queue; bus wraps only at compose/drain edge; throwaway seam given the compose rewrite | |
+
+**User's choice:** Full swap now.
+**Notes:** Coherent with the committed `(ctx, spec)` + handler-owned-storage rewrite. Ctor param name stays `global_queue`/`events_queue` (CLAUDE.md convention), retyped to EventBus.
+
+---
+
+## PriorityEventBus wiring boundary
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Define + unit-test only | Ship PriorityEventBus + (tier,seq,event) ordering test + 3 CONTROL EventTypes + _CONTROL_EVENT_TYPES; ZERO live wiring; live_trading_system.py untouched until P6/P7 | ✓ |
+| Also wire live in P2 | Replace the live system's raw queue with PriorityEventBus now; pulls P6/P7 work into a foundation phase | |
+
+**User's choice:** Define + unit-test only (Option 1).
+**Notes:** Owner initially leaned Option 2, asked for a recommendation. Recommended Option 1: the 3 new CONTROL events have no producers/consumers until P6/P7/P8; the one existing CONTROL event (STRATEGY_COMMAND) would silently change validated v1.7 live ordering with no live-smoke gate until P12; the live drain loop is deleted/rewritten by LiveRunner in P6/P7 anyway, so Option 2 saves no work and creates a half-migrated intermediate. Owner accepted Option 1. Optional standalone integration test (no live touch) offered as the better integration-confidence buy.
+
+---
+
+## Claude's Discretion
+
+- `EngineContext` class home/module (avoid an import cycle with `EventBus`).
+- `FifoEventBus.depth_by_tier` exact shape (single-bucket, tierless).
+- Whether to add the optional standalone PriorityEventBus CONTROL+BUSINESS interleaving integration test.
+- `order_config` home under the kwargs→spec fold (leaned handler-owned per P1 D-03).
+
+## Deferred Ideas
+
+- REQUIREMENTS.md / ROADMAP.md traceability update — CTX-01/CTX-02 → P2; P3 shrinks to CTX-03/CTX-04.
+- Wiring PriorityEventBus into live — P6/P7.
+- RuntimeConfig overlay — P9 (EngineContext.config placeholder until then).
+- SqlBackend→SqlEngine rename + migrations relocation — P3/P4 (EngineContext.sql_engine loose-typed until then).
+- order_config onto SystemSpec — only if the planner rejects the handler-owned lean.

--- a/.planning/phases/02-event-bus/02-PATTERNS.md
+++ b/.planning/phases/02-event-bus/02-PATTERNS.md
@@ -1,0 +1,255 @@
+# Phase 2: Event Bus - Pattern Map
+
+**Mapped:** 2026-07-09
+**Files analyzed:** 8 (1 new, 7 modified)
+**Analogs found:** 8 / 8
+
+> Indentation hazard is per-file and load-bearing. Each entry pins the convention the
+> planner must carry into `<read_first>`. **New `bus.py` = 4-space** (events-package convention);
+> **all handler-ctor / compose edits = TABS**; **`core/enums/event.py` = 4-space**. Never normalize.
+
+## File Classification
+
+| New/Modified File | Role | Data Flow | Closest Analog | Match Quality | Indent |
+|-------------------|------|-----------|----------------|---------------|--------|
+| `itrader/events_handler/bus.py` **(NEW)** | utility / transport substrate | pub-sub (queue) | `events_handler/events/` package + `full_event_handler.py` drain | role-match (new symbol) | 4-space |
+| `itrader/core/enums/event.py` (MOD) | config / enum | — | itself (existing `EventType` members) | exact | 4-space |
+| `itrader/events_handler/full_event_handler.py` (MOD) | dispatcher | event-driven | itself (drain loop `:125-130`) | exact (retype only) | TABS |
+| `itrader/trading_system/compose.py` (MOD) | config / composition seam | request-response (wiring) | itself (`compose_engine` `:116`) | exact | TABS |
+| `itrader/trading_system/backtest_trading_system.py` (MOD) | config / factory + legacy ctor | request-response | itself (two call sites) | exact | TABS |
+| `itrader/trading_system/system_spec.py` (READ-ref) | model / value object | — | itself (`SystemSpec` fields) | exact | TABS |
+| `itrader/order_handler/order_handler.py` (MOD) | controller (thin handler) | CRUD (storage) | `portfolio_handler.py __init__ :68-81` | role-match | TABS |
+| `itrader/strategy_handler/strategies_handler.py` (MOD) | controller (thin handler) | CRUD (storage) | `portfolio_handler.py __init__ :68-81` | role-match | TABS |
+| `EngineContext` home (NEW dataclass; discretion: `trading_system/`) | model / value object | — | `system_spec.py::SystemSpec` (frozen-dataclass shape) | role-match | TABS if in `trading_system/` |
+
+---
+
+## Pattern Assignments
+
+### `itrader/events_handler/bus.py` (NEW — utility / transport, 4-space)
+
+No exact analog exists — this is net-new. Copy **structure** from three sources:
+
+**1. Enum-member add pattern & string-value convention** — from `core/enums/event.py:8-49`
+(shown below in that file's section). `EventTier` mirrors this: a small `enum.Enum` (`CONTROL=0`, `BUSINESS=1`).
+
+**2. Protocol house-pattern** — the project already uses `typing.Protocol` for read-model seams
+(`core/portfolio_read_model.py::PortfolioReadModel`, `_AlertSinkLike` in `full_event_handler.py`).
+`EventBus` is the same shape: a structural interface, no ABC inheritance. Surface (D-09):
+`put`, `get(timeout)`, `get_nowait`, `qsize`, `empty`, `depth_by_tier`.
+
+**3. Drain-contract the buses must satisfy** — from `full_event_handler.py:125-130` (verbatim, the
+consumer that pins the invariant):
+```python
+while True:
+    try:
+        event = self.global_queue.get_nowait()   # bus.get_nowait() — MUST return a BARE Event
+    except queue.Empty:                            # BOTH buses MUST raise queue.Empty
+        break
+    self._dispatch(event)
+```
+Load-bearing (RESEARCH Pitfall 2): `FifoEventBus.get_nowait()` delegates to `queue.Queue` (raises
+`queue.Empty`); `PriorityEventBus.get()/get_nowait()` return `self._pq.get(...)[2]` (unwrap tuple,
+never return `(tier, seq, event)`).
+
+**Priority invariant (BUS-02, verified by running it — RESEARCH Code Examples):**
+```python
+import itertools, queue
+_CONTROL_EVENT_TYPES: frozenset[EventType] = frozenset({
+    EventType.STREAM_STATE, EventType.CONNECTOR_FATAL,
+    EventType.CONFIG_UPDATE, EventType.STRATEGY_COMMAND,
+})
+def _tier(event_type: EventType) -> int:
+    return 0 if event_type in _CONTROL_EVENT_TYPES else 1  # CONTROL=0 < BUSINESS=1
+# ONE shared itertools.count() as seq; each next() is C-atomic → thread-safe, globally unique
+# → the (tier, seq, event) tuple NEVER dereferences the non-orderable Event.
+```
+Note (RESEARCH State-of-the-Art): `Event` is a `msgspec.Struct(frozen=True)` (NOT a dataclass) —
+`Event < Event` raises `TypeError`; the BUS-02 negative test asserts this to prove the `seq`
+guarantee is load-bearing. `depth_by_tier` on `FifoEventBus` may be a single-bucket mapping
+(`{BUSINESS: qsize}` — discretion, FIFO is tierless).
+
+---
+
+### `itrader/core/enums/event.py` (MOD — enum add, 4-space)
+
+**Analog:** itself. The 3 new CONTROL members slot alongside the existing v1.7 additions
+(`UNIVERSE_POLL`/`STRATEGY_COMMAND`/`BARS_LOADED`), same explicit-uppercase-string style
+(current members `:23-36`, `_missing_` parser `:38-49`):
+```python
+    STREAM_STATE = "STREAM_STATE"        # BUS-03: connector stream up/down (CONTROL)
+    CONNECTOR_FATAL = "CONNECTOR_FATAL"  # BUS-03: connector fatal → halt (CONTROL)
+    CONFIG_UPDATE = "CONFIG_UPDATE"      # BUS-03: scoped runtime config change (CONTROL)
+```
+`_missing_` (case-insensitive parse) needs no change — it iterates all members. `EventHandler.routes`
+does NOT need a new branch in P2 (D-11: no consumers) unless the planner mirrors the existing
+`STRATEGY_COMMAND: []` explicit-empty style (`full_event_handler.py:108-111`) for the 3 new types to
+avoid `_dispatch`'s `NotImplementedError` if ever routed — recommended for parity with the v1.7 members.
+
+---
+
+### `itrader/events_handler/full_event_handler.py` (MOD — retype only, TABS)
+
+**Analog:** itself. Ctor param `global_queue: "queue.Queue[Any]"` at `:66` → retype annotation to
+`EventBus` (D-08: **name stays `global_queue`**). Body is unchanged — the drain (`:125-130`, above)
+already uses only Protocol methods (`get_nowait`). RESEARCH Pitfall 3: this class is shared with the
+untouched live path, but `live_trading_system` is in the mypy `ignore_errors` override
+(`pyproject.toml:104`), so the retype is strict-safe. Run `poetry run mypy itrader` after.
+
+---
+
+### `itrader/trading_system/compose.py` (MOD — signature settle + delete internal queue, TABS)
+
+**Analog:** itself. Current signature (`:116-127`) is 8 kwargs; the internal
+`global_queue: "queue.Queue[Any]" = queue.Queue()` at `:164` is **deleted** (D-01). Target end-state:
+`compose_engine(ctx: EngineContext, spec: SystemSpec) -> Engine`.
+
+**Current kwargs → spec fold (D-04, mostly 1:1):**
+```python
+# CURRENT (compose.py:116-127) — the 8-kwarg form to collapse
+def compose_engine(*, order_storage, signal_store, csv_paths=None,
+    start_date=None, end_date=None, timeframe="1d",
+    exchange_config=None, order_config=None, results_store=None) -> Engine:
+```
+Fold map: `csv_paths→spec.data`, `start_date→spec.start`, `end_date→spec.end`, `timeframe→spec.timeframe`,
+`exchange_config←spec.exchange` (factory still derives via `_seed_supported_symbols`), `results_store→spec.results_store`.
+`order_storage`/`signal_store` come off the **handlers** now (D-02, below), not params. `order_config`
+stays handler-owned via `OrderConfig.default()` (D-04 lean; current `:220`
+`resolved_order_config = order_config or OrderConfig.default()`).
+
+**A1 (RESEARCH Assumptions):** keep the body's spec reads to `{data, start, end, timeframe, exchange, results_store}`
+ONLY — `compose_engine` must NOT read `spec.ticker`/`spec.starting_cash` (the legacy arm passes placeholders).
+
+**Bus injection & storage back-read (D-01/D-02):** replace the deleted `queue.Queue()` with `ctx.bus`;
+pass `ctx.bus` into every handler ctor (`ScreenersHandler(global_queue, feed)` `:180`,
+`PortfolioHandler(global_queue)` `:181`, `ExecutionHandler(global_queue, ...)` `:187`,
+`StrategiesHandler(global_queue, ...)` `:215`, `OrderHandler(global_queue, ...)` `:221`,
+`EventHandler(..., global_queue)` `:245`). Then read storage back off the handlers for wiring:
+```python
+# CURRENT (compose.py:234): order_storage is a param today
+portfolio_handler.set_order_storage(order_storage)
+# TARGET: order_storage = order_handler.storage; portfolio_handler.set_order_storage(order_storage)
+```
+
+---
+
+### `itrader/trading_system/backtest_trading_system.py` (MOD — TWO call sites, TABS)
+
+**Analog:** itself. **RESEARCH Pitfall 1 (highest-value finding):** there are TWO call sites and
+the oracle runs through the spec-LESS legacy arm.
+
+**Site 1 — legacy `__init__` arm (`:131-140`, what `scripts/run_backtest.py` + `test_backtest_oracle.py:261` call):**
+```python
+# CURRENT — builds kwargs inline, NO SystemSpec
+order_storage = OrderStorageFactory.create('backtest')
+self._signal_store = SignalStorageFactory.create('backtest')
+tickers = {str(t).upper() for t in (csv_paths or {}).keys()}
+exchange_config = _seed_supported_symbols(get_exchange_preset('default'), tickers)
+self.engine = compose_engine(order_storage=..., signal_store=..., csv_paths=..., ...)
+```
+Must synthesize a minimal `SystemSpec` (data=`csv_paths or {}`, start/end/timeframe from ctor args,
+exchange=the seeded `ExchangeConfig`, empty `strategies`/`portfolios`, placeholder `ticker`/`starting_cash`
+— `compose_engine` reads none of these per A1) and build `EngineContext(bus=FifoEventBus(), config=<SystemConfig>, environment='backtest', sql_engine=None)` here.
+
+**Site 2 — `build_backtest_system(spec)` factory (`:437-447`):** already has a `spec`. Build the
+same `EngineContext` and call `compose_engine(ctx, spec)`. Storage is now handler-owned; the factory's
+`OrderStorageFactory.create('backtest')` (`:414-415`) moves INTO the handlers (D-02) — the factory keeps
+only symbol-set seeding + `EngineContext` construction.
+
+---
+
+### `itrader/order_handler/order_handler.py` (MOD — adopt handler-owned storage, TABS)
+
+**Analog:** `portfolio_handler.py::__init__` (`:68-81`) — the exact template (see Shared Patterns).
+Current ctor (`:43-49`) already takes `order_storage: Optional[OrderStorage] = None` and forwards it to
+`OrderManager` (`:83-84`, `order_storage or OrderStorageFactory.create_in_memory()`). Add keyword-only
+`environment: str = "backtest"`, `sql_engine: Optional[Any] = None`; resolve:
+```python
+# TARGET shape (D-02), mirroring PortfolioHandler:
+self.storage = order_storage or OrderStorageFactory.create(environment, backend=sql_engine)
+# then pass self.storage into OrderManager instead of the create_in_memory() fallback
+```
+`OrderStorageFactory.create('backtest', backend=None)` → `InMemoryOrderStorage()` (RESEARCH-verified
+`storage_factory.py:51-52`) → byte-exact. Expose `.storage` so `compose_engine` reads it back.
+Retype `global_queue` param → `EventBus` (D-08, name unchanged).
+
+---
+
+### `itrader/strategy_handler/strategies_handler.py` (MOD — adopt handler-owned storage, TABS)
+
+**Analog:** `portfolio_handler.py::__init__` (`:68-81`). Current ctor (`:39-46`) takes
+`signal_store: SignalStore` as a required positional. Add keyword-only `environment`/`sql_engine` and
+resolve like Order:
+```python
+# TARGET (D-02): signal_store optional → handler owns it
+self.signal_store = signal_store or SignalStorageFactory.create(environment, backend=sql_engine)
+```
+`SignalStorageFactory.create('backtest', backend=None)` → `InMemorySignalStore()` (RESEARCH-verified
+`storage/storage_factory.py:67-68`). Expose the concrete for `compose_engine` back-read. Retype
+`global_queue` → `EventBus`.
+
+---
+
+### `EngineContext` (NEW frozen dataclass — home: `trading_system/`, TABS — RESEARCH OQ1)
+
+**Analog:** `system_spec.py::SystemSpec` (`:79-111`) — the frozen-dataclass value-object house style
+(`@dataclass(frozen=True)`, loose `Any` types to stay import-inert, e.g. `results_store: Any = None`).
+Shape (D-05, all 4 fields now, types only tightened in P3/P4/P9):
+```python
+@dataclass(frozen=True)
+class EngineContext:
+    bus: "EventBus"                 # from events_handler.bus — no cycle (bus imports only stdlib + core.enums)
+    config: Any                     # today's SystemConfig (loose; P9 → RuntimeConfig)
+    environment: str                # 'backtest'
+    sql_engine: Optional[Any] = None  # concrete SqlEngine lands P3/P4
+```
+Place in `trading_system/` (composition-root infra; `compose_engine` is its only P2 consumer). If an
+import cycle with `EventBus` appears, fall back to a `TYPE_CHECKING`-only import (RESEARCH OQ1).
+
+---
+
+## Shared Patterns
+
+### Handler-owns-storage (the D-02 template — copy verbatim in shape)
+**Source:** `itrader/portfolio_handler/portfolio_handler.py::__init__` (`:68-81`)
+**Apply to:** `OrderHandler`, `StrategiesHandler`
+```python
+def __init__(self, global_queue: "Queue[Any]", config_dir: str = "settings",
+             environment: str = "backtest", backend: "Optional[Any]" = None) -> None:
+    self.global_queue: "Queue[Any]" = global_queue
+    ...
+    self._environment = environment   # 'backtest' = in-memory oracle-dark path
+    self._backend = backend           # typed Any to keep SQL import off the hot path (GATE-01)
+```
+Order/Strategies adopt the `storage or Factory.create(environment, backend=sql_engine)` resolution and
+expose the concrete on `.storage` for `compose_engine`'s `set_order_storage(...)` back-read.
+Backtest slice: `environment='backtest', sql_engine=None` → identical in-memory instances → byte-exact.
+
+### Retype-not-rename bus swap
+**Source:** CLAUDE.md convention + D-08. Every handler ctor's `global_queue: "queue.Queue[Any]"` (or
+`"Queue[Any]"`) annotation → `EventBus`; **name unchanged**. Sites: `full_event_handler.py:66`,
+`order_handler.py:43`, `strategies_handler.py:41`, `portfolio_handler.py:68`,
+`compose.py` handler-construction calls. No `.put()` call-site changes (duck-typed). `.empty()` is NOT
+used by the drain (D-15 race-free); it stays on the Protocol for monitoring only.
+
+### Frozen value-object convention
+**Source:** `system_spec.py` (`@dataclass(frozen=True)`, `Any`-typed inertness-sensitive fields).
+**Apply to:** `EngineContext`.
+
+### Import-inertness discipline (gate: `test_okx_inertness.py`)
+**Source:** `system_spec.py:93-98` (`results_store: Any` — spec never imports SQL) + factory lazy-SQL
+arms. `EngineContext(sql_engine=None)` + `FifoEventBus` must pull nothing heavy; `bus.py` imports only
+stdlib (`queue`, `itertools`, `typing`, `dataclasses`, `enum`) + `core.enums.event`.
+
+## No Analog Found
+
+None. Every file has an in-repo analog (mostly itself for retype/settle edits; `PortfolioHandler` for
+the two storage retrofits; `SystemSpec` for `EngineContext`). `bus.py` is net-new but composes
+established house patterns (`Protocol` read-model seam, string-enum, frozen dataclass, stdlib `queue`).
+
+## Metadata
+
+**Analog search scope:** `itrader/events_handler/`, `itrader/trading_system/`, `itrader/core/enums/`,
+`itrader/order_handler/`, `itrader/strategy_handler/`, `itrader/portfolio_handler/`
+**Files scanned:** 8 (all touchpoints from RESEARCH.md `## Sources`, line numbers re-verified)
+**Pattern extraction date:** 2026-07-09

--- a/.planning/phases/02-event-bus/02-RESEARCH.md
+++ b/.planning/phases/02-event-bus/02-RESEARCH.md
@@ -1,0 +1,427 @@
+# Phase 2: Event Bus - Research
+
+**Researched:** 2026-07-09
+**Domain:** stdlib event-bus substrate + `compose_engine` end-state signature settlement (oracle-gated foundation refactor)
+**Confidence:** HIGH — every claim below verified against the current code in this session (line numbers re-confirmed, not trusted from CONTEXT.md)
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+
+- **D-01:** `compose_engine` settles to the design's **end-state two-arg form `compose_engine(ctx, spec)`** (spec §5) — reached in P2 so it is **never re-edited** downstream. Option B, chosen over the minimal "prepend `ctx`, keep the 8 kwargs" form. The backtest factory builds `FifoEventBus` + `EngineContext` and injects it; the internal `queue.Queue()` at `compose.py:164` is **deleted**.
+- **D-02:** Storage placement = **handlers own their storage init** (spec §7b / LR-13). Order + Strategies handlers adopt `PortfolioHandler`'s **existing** shape (`OrderHandler(..., *, environment, sql_engine, storage=None) → self.storage = storage or OrderStorageFactory.create(environment, backend=sql_engine)`); `compose_engine` reads the concrete back off `.storage` for the `portfolio_handler.set_order_storage(...)` wiring. **Backtest slice only** — `environment='backtest', sql_engine=None` → same in-memory instances as today → byte-exact. **Rejected:** B2 (backend instances on `SystemSpec`) and B3 (hybrid `(ctx, spec, *, order_storage, signal_store)`).
+- **D-03 (PHASING SHIFT):** P2 absorbs CTX-01 (`compose_engine(ctx, spec)`), CTX-02 (storage-in-handler), CTX-03 (backtest byte-exact + lazy-SQL-inertness gate). **P3 shrinks to just CTX-04** (`SqlBackend→SqlEngine` rename). **Downstream must NOT "fix" this back.** Traceability already updated (done 2026-07-09).
+- **D-04:** kwargs→spec fold is **mostly 1:1 with existing `SystemSpec` fields** — `csv_paths→data`, `start_date→start`, `end_date→end`, `timeframe→timeframe`, `exchange_config←exchange`, `results_store→results_store`. The **one** kwarg without a spec field is `order_config`; planner decides keep it **handler-owned** via `OrderConfig.default()` (leaned) or add a spec field.
+- **D-05:** Frozen `EngineContext` dataclass with **all 4 fields now**: `bus: EventBus`, `config`, `environment: str`, `sql_engine`. `bus`/`environment`/`sql_engine` actively consumed in P2; `config` carried but **unread until P9**. **Loose types**: `config` = today's `SystemConfig`; `sql_engine: Optional[...] = None`. **P3/P4/P9 only tighten types — never add fields.**
+- **D-06:** Backtest factory constructs `EngineContext(bus=FifoEventBus(), config=<the SystemConfig>, environment='backtest', sql_engine=None)`. `sql_engine=None` + `FifoEventBus` pull nothing heavy → inertness gate stays green.
+- **D-07:** **Full bus swap** — every handler constructor that takes `global_queue` now receives the `FifoEventBus` in its place (duck-typed `.put()`, **no `.put` call-site changes**, BUS-01); `EventHandler` drains via `bus.get_nowait()`/`bus.empty()`. `FifoEventBus` is a thin wrapper over `queue.Queue` → **byte-identical FIFO** → oracle safe. Boundary-only wrapping rejected.
+- **D-08:** Constructor **parameter name stays `global_queue`/`events_queue`** (CLAUDE.md naming convention) — **retyped** to `EventBus`. Do NOT rename the param to `bus`.
+- **D-09:** Protocol surface = `put`, `get(timeout)`, `get_nowait`, `qsize`, `empty`, `depth_by_tier` (§4a). `bus.py` lives at `itrader/events_handler/bus.py`, **4-space indent** (events-package convention, NOT tabs).
+- **D-10:** P2 = **define `PriorityEventBus` + unit-test only** (Option 1). Ship: `PriorityEventBus` (`PriorityQueue` keyed `(tier, seq, event)`; `tier ∈ {CONTROL=0, BUSINESS=1}` from `_CONTROL_EVENT_TYPES`; `seq = itertools.count()`); the BUS-02 ordering test; 3 new CONTROL `EventType`s; `_CONTROL_EVENT_TYPES`.
+- **D-11:** **ZERO live wiring in P2** — `live_trading_system.py` stays untouched on its raw `queue.Queue` until P6/P7. **Option 2 (wire live now) explicitly rejected.**
+
+### Tier assignment (finalize in P2)
+- **CONTROL** (preempts market data): `STREAM_STATE`, `CONNECTOR_FATAL`, `CONFIG_UPDATE`, `STRATEGY_COMMAND`.
+- **BUSINESS** (strict FIFO): `BAR`, `SIGNAL`, `ORDER`, `FILL`, `UNIVERSE_*`, `BARS_*`, `ERROR`, `PORTFOLIO_UPDATE` (+ existing `TIME`/`UPDATE`/`ORDER_ACK`/`SCREENER`). **Externally-injected `SIGNAL`s stay BUSINESS.**
+
+### Claude's Discretion
+- The `EngineContext` class **home/module** (near `compose_engine` in `trading_system/`, or `events_handler/` — pick to avoid an import cycle with `EventBus`).
+- `FifoEventBus.depth_by_tier` exact shape (FIFO is tierless — a single-bucket mapping such as `{BUSINESS: qsize}` is fine; must satisfy the Protocol).
+- Whether to add an **optional standalone integration test** driving a representative CONTROL+BUSINESS interleaving through `PriorityEventBus` (no `live_trading_system.py` touch).
+- `order_config` home under the fold (D-04) — leaned handler-owned per P1 D-03.
+
+### Deferred Ideas (OUT OF SCOPE)
+- REQUIREMENTS.md / ROADMAP.md traceability update (D-03) — ✅ already done 2026-07-09.
+- Wiring `PriorityEventBus` into the live system — P6/P7.
+- `RuntimeConfig` overlay — P9 (`EngineContext.config` is a loose placeholder until then).
+- `SqlBackend→SqlEngine` rename + migrations relocation — P3/P4.
+- `order_config` onto `SystemSpec` — only if the planner rejects the handler-owned lean.
+</user_constraints>
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| BUS-01 | `EventBus` Protocol (`put`/`get`/`get_nowait`/`qsize`/`empty`/`depth_by_tier`) + `FifoEventBus`/`PriorityEventBus` sharing one `.put()`; no handler `.put` call-site changes | Protocol surface + drain interaction verified (`full_event_handler.py:125-130`); `queue.Queue` supplies `put/get/get_nowait/qsize/empty` natively, `FifoEventBus` adds `depth_by_tier` |
+| BUS-02 | `PriorityEventBus` orders `(tier, seq, event)`; test proves tuple comparison never dereferences the non-orderable event + strict within-tier FIFO | **Verified live:** `Event` (msgspec.Struct) raises `TypeError` on `<`; unique `itertools.count()` `seq` guarantees the heap never compares events (ran the harness — see Code Examples) |
+| BUS-03 | 3 new CONTROL `EventType` members (`STREAM_STATE`, `CONNECTOR_FATAL`, `CONFIG_UPDATE`); backtest uses `FifoEventBus` | `EventType` current members enumerated (`core/enums/event.py:23-36`); string-valued enum, `_missing_` case-insensitive parse — the 3 slot alongside the v1.7 members |
+| BUS-04 | Minimal `EngineContext` skeleton so `compose_engine` settles once | `EngineContext` 4-field shape from spec §7a; frozen-dataclass convention confirmed |
+| CTX-01 | `EngineContext` threaded once into `compose_engine(ctx, spec)`; infra-only | Two call sites found (`__init__:131`, `build_backtest_system:437`) — **both** must fold to `(ctx, spec)`; see Common Pitfall 1 |
+| CTX-02 | Order + Strategies handlers own storage init from `(environment, sql_engine)` w/ `storage=` override; `compose_engine` reads `.storage` back for wiring | `PortfolioHandler.__init__:68-81` is the exact template; `OrderStorageFactory.create(env, backend=)` + `SignalStorageFactory.create(env, backend=)` signatures verified |
+| CTX-03 | Backtest (`environment='backtest', sql_engine=None`) → same in-memory instances → oracle byte-exact; factory SQL imports stay lazy → inertness green | Both factories return `InMemory*` for `'backtest'`/`'test'` with SQL imports lazily inside the `'live'` arm (verified) |
+</phase_requirements>
+
+## Summary
+
+This is a **specified/mechanical, oracle-gated foundation refactor** — STATE.md explicitly flags P2 as "skip research-phase (specified)." The design contract (spec §4/§5/§7) and the eleven locked decisions (D-01..D-11) fully determine WHAT to build. This research exists purely to **de-risk EXECUTION**: it re-verifies every pinned touchpoint against the live code (the CONTEXT.md line numbers were checked and are accurate as of this session), enumerates the exact blast radius of the full-bus-swap, and proves the load-bearing stdlib invariant (the priority-queue tuple never compares two events) by running it.
+
+The single highest-value finding: **there are TWO `compose_engine` call sites on the backtest path, and the oracle runs through the one that does NOT have a `SystemSpec`.** `scripts/run_backtest.py::main` → `BacktestTradingSystem(exchange="csv", ...)` → the *legacy direct-construction* arm (`__init__:118-141`), which builds kwargs inline, not a spec. `build_backtest_system(spec)` (`:401`) is the second site and already has a spec. Settling `compose_engine(ctx, spec)` means the legacy arm must synthesize a `SystemSpec` (with placeholder `ticker`/`starting_cash` that `compose_engine` never reads) or the planner must otherwise thread a spec into it. This is the one place where the "mostly 1:1 fold" (D-04) has a wrinkle.
+
+The second load-bearing finding: `FifoEventBus.get_nowait()` **must raise the same `queue.Empty`** the `EventHandler` drain already catches (`full_event_handler.py:128`), and `PriorityEventBus.get*()` must **unwrap the `(tier, seq, event)` tuple and return only the event** — the drain expects a bare event, not a tuple. Both are byte-exactness-critical.
+
+**Primary recommendation:** Implement `bus.py` first (pure, testable in isolation — `FifoEventBus`, `PriorityEventBus`, `EventBus` Protocol, `_CONTROL_EVENT_TYPES`, the 3 CONTROL `EventType`s, BUS-02 ordering test) with zero touch to any wiring; then in a second slice do the retype-not-rename bus swap + the `compose_engine(ctx, spec)` fold + `EngineContext` + handler-owned storage, gated by the oracle + inertness tests after each edit. Run the two gate tests (`test_backtest_oracle.py`, `test_okx_inertness.py`) as a per-PLAN gate.
+
+## Architectural Responsibility Map
+
+| Capability | Primary Tier | Secondary Tier | Rationale |
+|------------|-------------|----------------|-----------|
+| Event transport / tiered `.put()` routing | Event-transport substrate (`events_handler/bus.py`) | — | The bus is the queue-replacement bulkhead; handlers stay tier-unaware (bus assigns tier from `_CONTROL_EVENT_TYPES`) |
+| Event-type vocabulary (CONTROL members) | Shared core (`core/enums/event.py`) | — | `EventType` is a cross-cutting primitive; `core` depends on nothing inside `itrader` |
+| Component-graph wiring / storage back-read | Composition seam (`trading_system/compose.py`) | Backtest factory + legacy `__init__` | `compose_engine` is mode-agnostic; the factory/legacy arm selects concretes and injects the `EngineContext` |
+| Handler-owned storage init | Domain handlers (order/strategies) | Storage factories | LR-13 — the handler derives its own backend from `(environment, sql_engine)`, mirroring `PortfolioHandler` |
+| Queue drain / dispatch | Event dispatcher (`events_handler/full_event_handler.py`) | — | The drain switches from `queue.Queue` methods to the `EventBus` Protocol surface (`get_nowait`) |
+
+## Standard Stack
+
+**No new packages.** Every mechanic is Python 3.13 stdlib or already-pinned. Adding any dependency **regresses the inertness gate and violates the "no poetry change P1–P12" milestone rule** (REQUIREMENTS.md gate 2).
+
+### Core (all stdlib — already available)
+| Module | Purpose | Why Standard |
+|--------|---------|--------------|
+| `queue.Queue` | `FifoEventBus` internal buffer (thin wrapper) | Already THE backtest queue — byte-identical FIFO, zero oracle risk (D-07) |
+| `queue.PriorityQueue` | `PriorityEventBus` internal heap | stdlib min-heap; `get/get_nowait/qsize/empty` inherited from `Queue`, `queue.Empty` raised identically |
+| `itertools.count()` | Monotonic globally-unique `seq` source | Thread-safe (each `next()` is a single bytecode-atomic C call); guarantees the tuple comparison never reaches the event (D-10) |
+| `typing.Protocol` | `EventBus` structural interface | Duck-typed `.put()` needs no ABC inheritance on `queue.Queue`; matches the `PortfolioReadModel`/`_AlertSinkLike` house pattern |
+| `dataclasses.dataclass(frozen=True)` | `EngineContext` | Same frozen-value-object pattern used across `system_spec.py` / events |
+| `enum.Enum` | 3 new `EventType` members | Existing `EventType` is a string-valued `Enum` with a `_missing_` parser (`core/enums/event.py`) |
+
+### Installation
+None. `poetry install` unchanged. **Any `poetry.lock` diff in this phase is a defect.**
+
+## Package Legitimacy Audit
+
+**Not applicable — this phase installs zero external packages.** All mechanics are Python 3.13 standard library (`queue`, `itertools`, `typing`, `dataclasses`, `enum`) or already-pinned in-repo modules. The milestone gate forbids any `poetry` change across P1–P12; a lockfile diff is itself a gate failure.
+
+## Architecture Patterns
+
+### System Architecture Diagram
+
+```
+                         ┌─────────────────────────────────────┐
+                         │  EventBus (Protocol)                 │
+                         │  put · get · get_nowait · qsize ·    │
+                         │  empty · depth_by_tier               │
+                         └───────────────┬─────────────────────┘
+                    ┌────────────────────┴────────────────────┐
+                    ▼                                          ▼
+        ┌───────────────────────┐              ┌──────────────────────────────┐
+        │ FifoEventBus          │              │ PriorityEventBus               │
+        │  wraps queue.Queue    │              │  wraps queue.PriorityQueue     │
+        │  put(e)→q.put(e)      │              │  put(e)→pq.put(                │
+        │  get_nowait()→q.g_nw()│              │    (tier(e.type), next(seq),e))│
+        │  (raises queue.Empty) │              │  get_nowait()→pq.g_nw()[2]     │
+        │  BACKTEST (oracle)    │              │  LIVE (P2: DARK, unit-only)    │
+        └───────────┬───────────┘              └──────────────┬───────────────┘
+                    │                                          │
+                    │                        tier = CONTROL(0) if type in
+                    │                        _CONTROL_EVENT_TYPES else BUSINESS(1)
+                    ▼
+   BACKTEST WIRING (the only path P2 changes at runtime):
+
+   run_backtest.py::main / build_backtest_system(spec)
+        │
+        ▼  builds EngineContext(bus=FifoEventBus(), config, environment='backtest', sql_engine=None)
+   compose_engine(ctx, spec)  ──────────────────────────────────────────┐
+        │  ctx.bus injected (retyped param, NAME unchanged) into every   │
+        │  handler ctor; handlers own storage from (environment,          │
+        │  sql_engine); reads .storage back for set_order_storage         │
+        ▼                                                                 │
+   ScreenersHandler · PortfolioHandler · ExecutionHandler(→SimulatedExchange) ·
+   StrategiesHandler · OrderHandler · EventHandler(bar_source, bus)       │
+        │                                                                 │
+        ▼                                                                 │
+   EventHandler.process_events():  event = bus.get_nowait()  ← unchanged loop
+        except queue.Empty: break   (FifoEventBus MUST raise queue.Empty) │
+                                                                          │
+   live_trading_system.py ── UNTOUCHED (raw queue.Queue, D-11) ──────────┘
+```
+
+File-to-responsibility mapping is in the Architectural Responsibility Map above; the diagram shows data/wiring flow.
+
+### Recommended Project Structure
+```
+itrader/events_handler/
+├── bus.py                  # NEW (4-space): EventBus Protocol, FifoEventBus,
+│                           #   PriorityEventBus, EventTier, _CONTROL_EVENT_TYPES
+├── full_event_handler.py   # EDIT (tabs): retype global_queue param → EventBus
+└── events/
+    └── base.py             # (unchanged) Event is a msgspec.Struct, frozen
+
+itrader/core/enums/
+└── event.py                # EDIT (4-space): +STREAM_STATE +CONNECTOR_FATAL +CONFIG_UPDATE
+
+itrader/trading_system/
+├── compose.py              # EDIT (tabs): compose_engine(ctx, spec); delete queue.Queue():164
+├── backtest_trading_system.py  # EDIT (tabs): both call sites fold to (ctx, spec)
+└── (EngineContext home — discretion: here or events_handler/)
+
+itrader/order_handler/order_handler.py       # EDIT (tabs): +environment,+sql_engine,storage= ; self.storage
+itrader/strategy_handler/strategies_handler.py # EDIT (tabs): same handler-owned storage shape
+```
+
+### Pattern 1: Bus assigns tier — handlers stay tier-unaware
+**What:** `.put(event)` reads `event.type`, looks it up in the `_CONTROL_EVENT_TYPES` frozenset, assigns tier. Handlers never pass a tier.
+**When to use:** all producers (BUS-01 "no `.put` call-site changes").
+**Example:**
+```python
+# Source: spec §4a; verified pattern
+_CONTROL_EVENT_TYPES: frozenset[EventType] = frozenset({
+    EventType.STREAM_STATE, EventType.CONNECTOR_FATAL,
+    EventType.CONFIG_UPDATE, EventType.STRATEGY_COMMAND,
+})
+# Default = BUSINESS. New event types are BUSINESS unless explicitly listed CONTROL —
+# robust to future EventType additions (no enumeration of the BUSINESS set needed).
+def _tier(event_type: EventType) -> int:
+    return 0 if event_type in _CONTROL_EVENT_TYPES else 1  # CONTROL=0 < BUSINESS=1
+```
+
+### Pattern 2: Protocol surface must cover the drain's exact needs
+**What:** `EventHandler.process_events` calls `bus.get_nowait()` and catches `queue.Empty`. The Protocol must expose `get_nowait`; both implementations must raise `queue.Empty` on empty (inherited free from `Queue`/`PriorityQueue`).
+**Example:**
+```python
+# Source: verified — full_event_handler.py:125-130 (unchanged by P2)
+while True:
+    try:
+        event = self.global_queue.get_nowait()   # bus.get_nowait() — returns a bare Event
+    except queue.Empty:                            # FifoEventBus & PriorityEventBus BOTH raise this
+        break
+    self._dispatch(event)
+```
+Note: the drain does **not** use `.empty()` (D-15 race-free drain removed the precheck). `empty()` stays on the Protocol for monitoring only.
+
+### Pattern 3: Handler-owns-storage (copy PortfolioHandler verbatim in shape)
+**What:** the handler derives its backend; the seam reads it back.
+**Example:**
+```python
+# Source: PortfolioHandler.__init__ (portfolio_handler.py:68-81) — the template
+def __init__(self, global_queue: "EventBus", ..., *,
+             environment: str = "backtest", sql_engine: "Optional[Any]" = None,
+             storage: "Optional[OrderStorage]" = None) -> None:
+    self.storage = storage or OrderStorageFactory.create(environment, backend=sql_engine)
+# compose_engine then: order_storage = order_handler.storage
+#                       portfolio_handler.set_order_storage(order_storage)
+```
+`OrderStorageFactory.create('backtest', backend=None)` → `InMemoryOrderStorage()` (verified `storage_factory.py:51-52`); `SignalStorageFactory.create('backtest', backend=None)` → `InMemorySignalStore()` (verified `storage/storage_factory.py:67-68`). The `'live'` arm lazy-imports SQLAlchemy — inertness preserved.
+
+### Anti-Patterns to Avoid
+- **Renaming `global_queue` → `bus`:** breaks the CLAUDE.md naming convention AND widens the diff across ~6 files (D-08). Retype the annotation only.
+- **Returning the `(tier, seq, event)` tuple from `PriorityEventBus.get*()`:** the drain expects a bare `Event`. Unwrap `[2]`.
+- **A `FifoEventBus.get_nowait()` that raises anything but `queue.Empty`:** the drain's `except queue.Empty` would miss it → hang or crash. Delegate to the wrapped `queue.Queue`.
+- **Enumerating the BUSINESS set in a frozenset:** only enumerate CONTROL; BUSINESS is the default fall-through (robust to new event types).
+- **Wiring `PriorityEventBus` into `live_trading_system.py`:** explicitly rejected (D-11) — it silently changes validated v1.7 live ordering with no live gate until P12.
+- **Adding fields to `EngineContext` in P3/P4/P9:** D-05 — those phases only *tighten types*.
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Priority ordering | Custom heap / sorted list | `queue.PriorityQueue` | Thread-safe min-heap, `queue.Empty` semantics identical to `Queue` |
+| Monotonic sequence | A locked `int` counter | `itertools.count()` | `next()` is atomic at the C level — thread-safe without a lock |
+| Making events non-orderable | Adding `__lt__`/`@total_ordering` guards | Nothing — `msgspec.Struct` already raises `TypeError` on `<` (verified) | The unique `seq` means events are never compared; adding ordering is dead code |
+| FIFO wrapper | Reimplementing a queue | `queue.Queue` behind `FifoEventBus` | Byte-identical to today's backtest queue → zero oracle risk |
+| Structural interface | ABC + inheritance on `queue.Queue` | `typing.Protocol` | Duck-typing; `queue.Queue` needs no modification |
+
+**Key insight:** the entire substrate is a thin typing/composition layer over stdlib primitives already present in the backtest hot path. The risk is not in the primitives — it is in the *wiring reach* (below).
+
+## Runtime State Inventory
+
+This is a **code-and-signature refactor**, not a data/service rename. Each category verified explicitly:
+
+| Category | Items Found | Action Required |
+|----------|-------------|------------------|
+| Stored data | **None** — no datastore keys, collection names, or IDs change. `EventType` member *values* are wire strings (`"STREAM_STATE"` etc.) but the 3 new ones have no producers/consumers/persisted records in P2 (D-11). | None |
+| Live service config | **None** — no external service (OKX/n8n/Datadog) config references the bus or the new event types. Live wiring is untouched (D-11). | None |
+| OS-registered state | **None** — no OS-level task/process names involved. | None |
+| Secrets / env vars | **None new.** `ITRADER_DISABLE_LOGS=true` is exported by `make test` (see Pitfall 5) — pre-existing, not introduced here. | None |
+| Build artifacts / installed packages | **None** — no `poetry.lock` change (forbidden by milestone gate); no egg-info/package rename. | Verify `poetry.lock` is byte-unchanged at phase close |
+
+**Verified by:** grep for the 3 new `EventType` names (`STREAM_STATE`/`CONNECTOR_FATAL`/`CONFIG_UPDATE`) and `PriorityEventBus`/`FifoEventBus`/`EngineContext`/`_CONTROL_EVENT_TYPES` across `itrader` + `tests` returned **zero** existing references — all are net-new symbols with no runtime state to migrate.
+
+## Common Pitfalls
+
+### Pitfall 1: The oracle runs through the SPEC-LESS legacy `__init__` arm
+**What goes wrong:** the planner folds only `build_backtest_system(spec)` (`:437`) to `(ctx, spec)` and misses `BacktestTradingSystem.__init__`'s legacy arm (`:118-141`), which is what `scripts/run_backtest.py::main` and `test_backtest_oracle.py:261` actually call. The oracle breaks or the legacy arm won't compile.
+**Why it happens:** the legacy arm builds `compose_engine(**kwargs)` inline; it has no `SystemSpec` and its ctor params (`exchange`, `start_date`, `end_date`, `timeframe`, `csv_paths`) lack `ticker`/`starting_cash` that `SystemSpec` *requires* as fields.
+**How to avoid:** in the legacy arm, synthesize a minimal `SystemSpec` (data=`csv_paths or {}`, start/end/timeframe from ctor args, exchange=the seeded `ExchangeConfig`, empty `strategies`/`portfolios`, placeholder `ticker`/`starting_cash`). `compose_engine` reads none of `ticker`/`starting_cash`/`strategies`/`portfolios` — strategies/portfolios are added *post-compose* in both arms — so placeholders are byte-safe. Build the `EngineContext(bus=FifoEventBus(), ...)` here too.
+**Warning signs:** oracle test asserts a trade-count/equity drift; or `TypeError: compose_engine() got an unexpected keyword argument`.
+
+### Pitfall 2: `PriorityEventBus.get*()` returns a tuple; `FifoEventBus.get_nowait()` swallows `queue.Empty`
+**What goes wrong:** dispatch receives `(tier, seq, event)` instead of `event` (`event.type` → `AttributeError`), or the drain never terminates because the empty signal changed.
+**How to avoid:** `PriorityEventBus.get()/get_nowait()` return `self._pq.get(...)[2]`; both buses inherit/re-raise `queue.Empty` unchanged. Verified the drain (`full_event_handler.py:128`) catches exactly `queue.Empty`.
+**Warning signs:** `AttributeError: 'tuple' object has no attribute 'type'`; or an infinite drain loop.
+
+### Pitfall 3: The shared `EventHandler` retype vs. the untouched live construction sites
+**What goes wrong:** retyping `EventHandler.__init__(global_queue: EventBus)` — a class **shared** by backtest and live — could flag mypy at the live construction sites (`live_trading_system.py:499` passes a raw `queue.Queue`, which does NOT satisfy the `EventBus` Protocol: it lacks `depth_by_tier`).
+**Why it's actually SAFE here:** `itrader.trading_system.live_trading_system` is in the mypy `ignore_errors` override list (`pyproject.toml:104`, verified). So the live sites are not strict-checked in P2. The strict-checked handler *modules* (`order_handler`, `strategies_handler`, `portfolio_handler`, `execution_handler`, `full_event_handler`) only call `.put()` / `.get_nowait()` on the param — both on the Protocol — so their bodies stay mypy-clean after the retype.
+**How to avoid regressions:** run `poetry run mypy itrader` after the retype. Do NOT remove the live_trading_system mypy override to "clean it up" — that is P6/P7 work.
+**Warning signs:** mypy errors of the form `Argument 1 to "EventHandler" has incompatible type "Queue[Any]"; expected "EventBus"` on an *in-scope* module.
+
+### Pitfall 4: msgspec.Struct is `__eq__`-comparable — only `seq` uniqueness saves you
+**What goes wrong:** if two priority tuples ever share the same `(tier, seq)`, `heapq` falls through to comparing the events; `Event == Event` returns a bool (msgspec defines `__eq__`), but `Event < Event` raises `TypeError`. A duplicated `seq` (e.g. per-instance counter instead of one shared `itertools.count()`) is a latent crash.
+**How to avoid:** ONE module-level (or per-bus-instance) `itertools.count()` shared across all `.put()` calls; never reset it. The BUS-02 test must assert uniqueness produces stable ordering AND (negative test) that comparing two events directly raises `TypeError` (proving the guarantee is load-bearing).
+**Warning signs:** `TypeError: '<' not supported between instances of '...Event'` under concurrent puts.
+
+### Pitfall 5: `make test` disables logs and aborts in worktrees
+**What goes wrong:** (from project memory) `make test` exports `ITRADER_DISABLE_LOGS=true`, which fails `caplog` warn-assertion tests; and `make test` aborts in a git worktree on a missing `.env`.
+**How to avoid:** for the phase gate, run `poetry run pytest tests/integration/test_backtest_oracle.py tests/integration/test_okx_inertness.py -v` directly; re-run `make test` only in the main checkout. Also honor the worktree `.venv` shadowing note: prepend `PYTHONPATH="$PWD"` if editable-install edits aren't picked up.
+**Warning signs:** a caplog test fails only under `make test`; `make test` aborts with a `.env` error.
+
+## Code Examples
+
+### PriorityEventBus ordering invariant — VERIFIED by running it
+```python
+# Ran in-session (poetry run python) against the REAL Event base (msgspec 0.21.1):
+import msgspec, itertools, queue
+class E(msgspec.Struct, frozen=True, kw_only=True, gc=False):
+    x: int = 0
+a, b = E(x=1), E(x=1)
+a == b          # True   (msgspec defines __eq__)
+a < b           # TypeError: '<' not supported  ← the non-orderability the test must prove
+seq = itertools.count()
+pq = queue.PriorityQueue()
+pq.put((1, next(seq), b)); pq.put((0, next(seq), a)); pq.put((1, next(seq), a))
+[pq.get_nowait()[:2] for _ in range(3)]
+# → [(0, 1), (1, 0), (1, 2)]  ← CONTROL first; within BUSINESS strict FIFO by seq
+```
+This is the exact BUS-02 assertion shape: enqueue a CONTROL after two BUSINESS events, prove CONTROL dequeues first, BUSINESS stays FIFO, and a bare `event < event` raises `TypeError`.
+
+### The 3 new EventType members (slot into `core/enums/event.py`, 4-space)
+```python
+# Source: core/enums/event.py:23-36 (current members) — add alongside, string-valued
+    STREAM_STATE = "STREAM_STATE"        # BUS-03: connector stream up/down (CONTROL)
+    CONNECTOR_FATAL = "CONNECTOR_FATAL"  # BUS-03: connector fatal → halt (CONTROL)
+    CONFIG_UPDATE = "CONFIG_UPDATE"      # BUS-03: scoped runtime config change (CONTROL)
+```
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| Raw `global_queue: queue.Queue` threaded everywhere | `EventBus` Protocol with FIFO/priority impls behind `.put()` | This phase (P2) | Enables CONTROL-plane preemption in live (P6/P7) without touching the backtest hot path |
+| `compose_engine(*, 8 kwargs)` | `compose_engine(ctx, spec)` end-state | This phase (P2, D-01 Option B) | Never re-edited downstream; CTX-01/02/03 pulled forward from P3 |
+| `OrderHandler`/`StrategiesHandler` receive a pre-built storage | Handlers own storage init from `(environment, sql_engine)` | This phase (P2, CTX-02) | Matches `PortfolioHandler`; the seam reads `.storage` back |
+
+**Deprecated/outdated in the docs (do not trust literally):**
+- CLAUDE.md and CONTEXT.md call events "frozen dataclasses." **Reality (verified):** `Event` is a `msgspec.Struct(frozen=True, kw_only=True, gc=False)` (`events_handler/events/base.py:21`). The non-orderability premise still holds (msgspec raises `TypeError` on `<`), but any BUS-02 test comment should say "msgspec.Struct," not "dataclass."
+- CLAUDE.md's Component-Responsibilities table lists a `TradingInterface` class and `postgresql_storage.py` `NotImplementedError` placeholder — both stale (removed in v1.7 per the CLAUDE.md architecture prose). Not relevant to P2 but do not use them as touchpoints.
+
+## Validation Architecture
+
+> Nyquist validation is ENABLED for this project. This section drives VALIDATION.md.
+
+### Test Framework
+| Property | Value |
+|----------|-------|
+| Framework | pytest ^8.4.2 (`minversion="8.0"`, `--strict-markers --strict-config`, `filterwarnings=["error"]`) |
+| Config file | `pyproject.toml [tool.pytest.ini_options]` (`testpaths=["tests"]`) |
+| Quick run command | `poetry run pytest tests/unit/events -x` (new bus unit tests land here) |
+| Full suite command | `make test` (main checkout) or `poetry run pytest tests` (worktree — see Pitfall 5) |
+
+### Phase Requirements → Test Map
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|-------------|
+| BUS-01 | Both buses satisfy the Protocol; `.put()`/`get_nowait()` surface; no call-site change | unit | `poetry run pytest tests/unit/events/test_event_bus.py -x` | ❌ Wave 0 |
+| BUS-02 | `(tier,seq,event)` ordering: CONTROL preempts, within-tier FIFO, event never compared, `Event < Event` raises `TypeError` | unit | `poetry run pytest tests/unit/events/test_event_bus.py -k priority -x` | ❌ Wave 0 |
+| BUS-03 | 3 CONTROL `EventType`s exist + assigned CONTROL via `_CONTROL_EVENT_TYPES`; backtest wires `FifoEventBus` | unit | `poetry run pytest tests/unit/events/test_event_bus.py -k control_types -x` | ❌ Wave 0 |
+| BUS-04 / CTX-01 | `compose_engine(ctx, spec)` signature; internal `queue.Queue()` deleted | unit/integration | `poetry run pytest tests/integration/test_okx_inertness.py -x` | ✅ (extend) |
+| CTX-02 | Order + Strategies handlers own storage from `(environment, sql_engine)`; `.storage` readable back | unit | `poetry run pytest tests/unit/order tests/unit/strategy -x` | ✅ (extend) / ❌ new case |
+| CTX-03 / oracle | Backtest → same in-memory instances → byte-exact `134 / 46189.87730727451` | integration | `poetry run pytest tests/integration/test_backtest_oracle.py -x` | ✅ |
+| inertness | `FifoEventBus`/`EngineContext(sql_engine=None)` pull nothing heavy; import builds no `SqlSettings` | integration | `poetry run pytest tests/integration/test_okx_inertness.py -x` | ✅ (extend register-vs-build) |
+
+### Sampling Rate
+- **Per task commit:** `poetry run pytest tests/unit/events/test_event_bus.py -x` (fast — pure stdlib, no data load).
+- **Per wave merge / per PLAN gate:** `poetry run pytest tests/integration/test_backtest_oracle.py tests/integration/test_okx_inertness.py -x` (the two milestone gates — oracle byte-exact + inertness). Determinism double-run: run the oracle twice, assert identical.
+- **Phase gate:** full suite green + `poetry run mypy itrader` clean on new/edited in-scope code + `poetry.lock` byte-unchanged.
+
+### Wave 0 Gaps
+- [ ] `tests/unit/events/test_event_bus.py` — covers BUS-01/02/03 (Protocol conformance for both buses; priority ordering + non-orderability negative test; `_CONTROL_EVENT_TYPES` tier assignment). **Do NOT add `tests/unit/events/__init__.py`** — the empty-`__init__` package-collision hazard (project memory) breaks full-suite collection; keep `tests/unit/*` package-less.
+- [ ] Extend `tests/integration/test_okx_inertness.py` — add the register-vs-build assertion that constructing `EngineContext(sql_engine=None)` + `FifoEventBus` pulls no SQLAlchemy/ccxt (append to `_PROBE` and/or a new in-process assertion that `FifoEventBus()` and the backtest `compose_engine` build no `SqlSettings`).
+- [ ] New handler-storage unit cases: `OrderHandler(..., environment='backtest', sql_engine=None)` yields `InMemoryOrderStorage` and exposes `.storage`; same for `StrategiesHandler` → `InMemorySignalStore`.
+- Framework install: none — pytest infra already present.
+
+## Security Domain
+
+> `security_enforcement` default-enabled. This is an internal engine refactor with **no auth, no network ingress, no user input, no secrets** introduced. ASVS categories are largely N/A; the relevant controls are the milestone gates.
+
+| ASVS Category | Applies | Standard Control |
+|---------------|---------|-----------------|
+| V2 Authentication | no | — (no auth surface touched) |
+| V3 Session Management | no | — |
+| V4 Access Control | no | — |
+| V5 Input Validation | minimal | `EventType._missing_` case-insensitive parse already guards unknown type strings; the bus never parses external input in P2 |
+| V6 Cryptography | no | — (UUIDv7 via `idgen`, unchanged) |
+
+### Known Threat Patterns for this stack
+| Pattern | STRIDE | Standard Mitigation |
+|---------|--------|---------------------|
+| Silent event drop (unrouted type) | Tampering / Repudiation | `EventHandler._dispatch` raises `NotImplementedError` on an unrouted type (unchanged) — the 3 new CONTROL types are backtest-inert but must not silently vanish if ever routed |
+| Inertness regression (eager SQL/ccxt import) | (availability/perf) | `test_okx_inertness.py` extended register-vs-build assertion — the recurring failure mode per STATE.md Blockers |
+| Live-ordering change slipped in via priority bus | Tampering (behavioral) | D-11: zero live wiring in P2; `live_trading_system.py` stays on its raw queue until a live-smoke gate exists (P12) |
+
+## Sources
+
+### Primary (HIGH confidence — verified against live code this session)
+- `itrader/trading_system/compose.py` — `compose_engine` signature `:116`, internal `queue.Queue()` `:164`, `Engine` holder, both concretes-injected kwargs. **Confirmed.**
+- `itrader/trading_system/backtest_trading_system.py` — legacy `__init__` compose call `:131`, `build_backtest_system` `:401`, factory compose call `:437`, ctor signature `:83-94`. **Confirmed two call sites; oracle uses the legacy arm.**
+- `itrader/trading_system/system_spec.py` — `SystemSpec` fields (`start/end/timeframe/ticker/starting_cash/data/strategies/portfolios/exchange/actions/results_store`). **Confirmed the D-04 fold mapping + the `ticker`/`starting_cash` required-field wrinkle.**
+- `itrader/events_handler/full_event_handler.py` — drain `:125-130` (`get_nowait()` + `except queue.Empty`, no `.empty()` precheck), ctor `global_queue` param `:66`. **Confirmed.**
+- `itrader/core/enums/event.py` — current `EventType` members `:23-36`, string values, `_missing_` parser. **Confirmed.**
+- `itrader/portfolio_handler/portfolio_handler.py` — storage template `:68-81` (`environment`, `backend` params). **Confirmed the handler-owns-storage shape.**
+- `itrader/order_handler/order_handler.py:43-99` + `itrader/strategy_handler/strategies_handler.py:39-94` — target ctors for the storage retrofit.
+- `itrader/order_handler/storage/storage_factory.py:24-69` + `itrader/strategy_handler/storage/storage_factory.py:36-92` — `create(env, backend=)` signatures; `'backtest'/'test'` → in-memory, `'live'` → lazy SQL import. **Confirmed inertness path.**
+- `itrader/events_handler/events/base.py:21` — `Event` is a `msgspec.Struct(frozen=True)`, not a dataclass. **Confirmed via runtime check that `<` raises `TypeError`.**
+- `tests/integration/test_backtest_oracle.py` + `tests/integration/test_okx_inertness.py` — the two gates; the inertness probe's `_FORBIDDEN` module list + the CFG-02 register-vs-build assertion pattern. **Read in full.**
+- `pyproject.toml` mypy overrides — `live_trading_system` in `ignore_errors` `:104`. **Confirmed the retype is mypy-safe.**
+- Live in-session verification: msgspec 0.21.1 `Struct` non-orderability + `PriorityQueue`/`itertools.count` ordering. **Ran and captured output.**
+
+### Secondary (MEDIUM confidence)
+- `docs/superpowers/specs/2026-07-07-v1.8-live-system-refactor-design.md` §4a/§4b/§5/§7a/§7b — the design contract for the bus, threading, topology, `EngineContext`, handler-owns-init.
+- Project memory notes (worktree `.venv` shadowing; `make test` `.env` abort + `ITRADER_DISABLE_LOGS`; test-dir `__init__.py` collision; oracle test location).
+
+### Tertiary (LOW confidence)
+- None — all claims verified or cited.
+
+## Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| A1 | The legacy `__init__` arm can pass placeholder `ticker`/`starting_cash` in a synthesized `SystemSpec` because `compose_engine` reads neither | Pitfall 1 | If `compose_engine` (post-fold) is written to read `spec.ticker`/`spec.starting_cash`, placeholders would corrupt the run — planner must keep `compose_engine` reading only `data/start/end/timeframe/exchange/results_store` |
+| A2 | Retyping the shared `EventHandler` param to `EventBus` is mypy-safe because live sites are `ignore_errors` | Pitfall 3 | If a future edit removes the `live_trading_system` mypy override, the live construction sites would flag — but that is out of P2 scope |
+
+**Note:** A1/A2 are LOW-risk execution assumptions, not open design questions — the locked decisions (D-01/D-08/D-11) already resolve the design. Confirm A1 by keeping the `compose_engine` body's spec reads to the D-04 fold set only.
+
+## Open Questions
+
+1. **`EngineContext` home module (Claude's Discretion, D-05).**
+   - What we know: must avoid an import cycle with `EventBus` (which lives in `events_handler/bus.py`).
+   - What's unclear: `trading_system/` (near `compose_engine`) vs `events_handler/`.
+   - Recommendation: place `EngineContext` in `trading_system/` (it is composition-root infra and `compose_engine` is its only consumer in P2); import `EventBus` from `events_handler.bus` for the `bus:` field type. `events_handler.bus` imports only stdlib + `core.enums.event`, so no cycle arises. If a cycle appears, fall back to a `TYPE_CHECKING`-only import of `EventBus`.
+
+2. **`order_config` under the fold (Claude's Discretion, D-04).**
+   - What we know: it is the one kwarg with no `SystemSpec` field; P1 D-03 leaned "order lives with its owner."
+   - Recommendation: keep it handler-owned via `OrderConfig.default()` inside `compose_engine` (unchanged from today's `:220`), do NOT add a `SystemSpec` field — consistent with P1 D-03 and keeps the spec declarative.
+
+3. **Optional standalone `PriorityEventBus` integration test (Claude's Discretion).**
+   - Recommendation: add a small `tests/unit/events` test that interleaves a representative CONTROL+BUSINESS stream through `PriorityEventBus` and asserts drain order — cheap integration confidence with zero `live_trading_system.py` touch. The better buy than any live wiring.
+
+## Environment Availability
+
+| Dependency | Required By | Available | Version | Fallback |
+|------------|------------|-----------|---------|----------|
+| Python stdlib `queue`/`itertools`/`typing`/`dataclasses`/`enum` | all of P2 | ✓ | 3.13.1 | — |
+| pytest + poetry venv | test gates | ✓ | pytest 8.4.2 | — |
+| msgspec | `Event` base (non-orderability premise) | ✓ | 0.21.1 | — |
+
+**Missing dependencies:** none. **New dependencies:** none (forbidden by milestone gate).
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH — all stdlib, no packages; verified present and behavior confirmed by running it.
+- Architecture / touchpoints: HIGH — every pinned line number re-verified against live code this session; two-call-site subtlety discovered and documented.
+- Pitfalls: HIGH — the three load-bearing ones (spec-less legacy arm, tuple-unwrap/`queue.Empty`, shared-EventHandler retype) each traced to a specific verified line.
+
+**Research date:** 2026-07-09
+**Valid until:** 2026-08-08 (stable — pure stdlib + a locked design contract; only invalidated by an unrelated refactor of the touchpoints)

--- a/.planning/phases/02-event-bus/02-REVIEW.md
+++ b/.planning/phases/02-event-bus/02-REVIEW.md
@@ -1,0 +1,174 @@
+---
+phase: 02-event-bus
+reviewed: 2026-07-09T13:39:19Z
+depth: standard
+files_reviewed: 16
+files_reviewed_list:
+  - itrader/core/enums/event.py
+  - itrader/events_handler/bus.py
+  - itrader/events_handler/full_event_handler.py
+  - itrader/execution_handler/exchanges/simulated.py
+  - itrader/execution_handler/execution_handler.py
+  - itrader/order_handler/order_handler.py
+  - itrader/portfolio_handler/portfolio_handler.py
+  - itrader/price_handler/feed/bar_feed.py
+  - itrader/strategy_handler/strategies_handler.py
+  - itrader/trading_system/backtest_trading_system.py
+  - itrader/trading_system/compose.py
+  - itrader/trading_system/engine_context.py
+  - tests/integration/test_okx_inertness.py
+  - tests/unit/events/test_event_bus.py
+  - tests/unit/order/test_order_handler_storage.py
+  - tests/unit/strategy/test_strategies_handler_storage.py
+findings:
+  critical: 0
+  warning: 2
+  info: 4
+  total: 6
+status: issues_found
+---
+
+# Phase 02: Code Review Report
+
+**Reviewed:** 2026-07-09T13:39:19Z
+**Depth:** standard
+**Files Reviewed:** 16
+**Status:** issues_found
+
+## Summary
+
+Phase 2 introduced the two-tier `EventBus` substrate (`bus.py`), a frozen `EngineContext`
+infra bundle, folded `compose_engine` to the `(ctx, spec)` seam, added three CONTROL
+`EventType` members wired to explicit-empty routes, and retyped the `global_queue`
+constructor param from `queue.Queue[Any]` to `EventBus` across seven handler modules
+(D-08 retype-not-rename).
+
+The changes are largely mechanical (type retype + additive keyword-only ctor params +
+new pure substrate module) and the byte-exact oracle is reported green, so no correctness
+BLOCKERs were found. Adversarial tracing surfaced **two WARNINGs**: (1) the mode-agnostic
+`compose_engine` seam threads `ctx.environment`/`ctx.sql_engine` into two of the three
+storage-owning handlers but silently omits `PortfolioHandler` — a latent live-path
+storage defect that contradicts the seam's stated D-14a mode-agnosticism goal; and
+(2) the `EventBus` retype left dead `from queue import Queue` imports in four modules
+that no automated gate (mypy-strict-only, no ruff/flake8) will catch. The remaining four
+INFO items are documentation drift and latent inconsistencies in the not-yet-wired
+`PriorityEventBus` monitoring surface.
+
+Positive notes: `bus.py` correctly keeps `Event` as a `TYPE_CHECKING`-only import
+(inertness preserved), `bar_feed.py` correctly dropped its now-unused `import queue`,
+the inertness subprocess gate was extended for the P2 register-vs-build assertion, and
+the `PriorityEventBus` `(tier, seq, event)` keying correctly guarantees the non-orderable
+`Event` is never dereferenced by the heap.
+
+## Narrative Findings (AI reviewer)
+
+## Warnings
+
+### WR-01: `compose_engine` does not thread `ctx.environment`/`ctx.sql_engine` into `PortfolioHandler`
+
+**File:** `itrader/trading_system/compose.py:171`
+**Issue:** `compose_engine` is documented as "the SHARED, mode-agnostic wiring seam both
+`build_backtest_system` (now) and a future `build_live_system` (fast-follow) consume"
+and the CTX-02/D-02 design has each storage-owning handler own its backend selection from
+`(environment, sql_engine)`. The seam correctly threads these into two handlers:
+
+```python
+strategies_handler = StrategiesHandler(..., environment=ctx.environment, sql_engine=ctx.sql_engine)
+order_handler = OrderHandler(..., environment=ctx.environment, sql_engine=ctx.sql_engine)
+```
+
+but constructs the third with neither:
+
+```python
+portfolio_handler = PortfolioHandler(ctx.bus)
+```
+
+`PortfolioHandler.__init__` accepts `environment="backtest"` and `backend=None` and threads
+them into each `Portfolio`'s durable state storage (`portfolio_handler.py:81-82`, `:230-231`).
+Because compose passes neither, the portfolio handler is pinned to the in-memory backtest
+backend regardless of `ctx.environment`. This is oracle-dark today (backtest only, and
+`LiveTradingSystem` still wires `PortfolioHandler` directly rather than via `compose_engine`),
+but it is a real latent defect: when `build_live_system` reuses this seam with
+`environment="live"` + a `sql_engine`, portfolio state would silently stay in-memory —
+no durable persistence, no restart rehydrate — while orders and signals persist correctly.
+The asymmetry directly undercuts the mode-agnosticism the fold exists to deliver.
+**Fix:**
+```python
+portfolio_handler = PortfolioHandler(
+    ctx.bus,
+    environment=ctx.environment,
+    backend=ctx.sql_engine,
+)
+```
+
+### WR-02: Dead `from queue import Queue` imports left behind by the `EventBus` retype
+
+**File:** `itrader/order_handler/order_handler.py:2`, `itrader/strategy_handler/strategies_handler.py:2`, `itrader/execution_handler/execution_handler.py:2`, `itrader/portfolio_handler/portfolio_handler.py:9`
+**Issue:** The D-08 retype changed every `global_queue` annotation from `"Queue[Any]"` to
+`"EventBus"`, removing the only real use of the imported `Queue` name in these four modules.
+The `from queue import Queue` import is now dead in all four (verified: no remaining code
+reference — only docstring prose mentions "Queue"). `bar_feed.py` correctly dropped its
+`import queue` in the same change, but these four were missed. The project has no ruff/flake8
+gate and `mypy --strict` does not flag unused imports, so this dead code will persist
+silently and accrete. This is a hygiene regression introduced by this phase, not pre-existing.
+**Fix:** Remove the `from queue import Queue` line from each of the four modules (mirror the
+`bar_feed.py` cleanup already done in this phase).
+
+## Info
+
+### IN-01: Stale docstrings still reference `Queue` after the `EventBus` retype
+
+**File:** `itrader/price_handler/feed/bar_feed.py:439`, `itrader/order_handler/order_handler.py:57`, `itrader/execution_handler/execution_handler.py:35`, `itrader/strategy_handler/strategies_handler.py:54`
+**Issue:** Several parameter docstrings still describe `global_queue` as
+"`Queue object`" / "`Optional[queue.Queue]`" after the field was retyped to `EventBus`.
+Example: `bar_feed.py:439` documents `global_queue : Optional[queue.Queue]`. Documentation
+now drifts from the retyped signature.
+**Fix:** Update the docstrings to reference `EventBus` (or `Optional[EventBus]`) to match
+the new type.
+
+### IN-02: `PriorityEventBus.depth_by_tier` counter update is not atomic with the queue operation
+
+**File:** `itrader/events_handler/bus.py:137-153`
+**Issue:** `put` calls `self._pq.put(...)` and then, under a separate `_depth_lock`,
+increments the tier counter; `get`/`get_nowait` decrement after the queue pop. The per-tier
+`Counter` is thread-safe in isolation, but it is not atomic with the underlying
+`PriorityQueue` state, so a concurrent consumer that pops between another thread's `put` and
+its increment can momentarily observe a counter that disagrees with `qsize()` (transient
+off-by-one / brief negative). This is documented monitoring-only and `PriorityEventBus` is
+not yet wired into any run path, so there is no live impact today.
+**Fix:** Acknowledge in the docstring that `depth_by_tier` is best-effort/eventually-consistent,
+or fold the counter update inside a lock that also brackets the queue op if a strict invariant
+is ever needed.
+
+### IN-03: `depth_by_tier` returns an inconsistent dict shape across the two bus implementations
+
+**File:** `itrader/events_handler/bus.py:116-118` (Fifo) vs `:161-166` (Priority)
+**Issue:** `FifoEventBus.depth_by_tier` returns a single-key dict `{EventTier.BUSINESS: n}`
+(no CONTROL key), while `PriorityEventBus.depth_by_tier` always returns both keys. A generic
+monitoring consumer written against the Protocol that does `depth[EventTier.CONTROL]` would
+`KeyError` on a `FifoEventBus`. Both behaviors are individually documented, but the
+`EventBus` Protocol offers no uniform contract for the returned key set.
+**Fix:** Have `FifoEventBus` return `{EventTier.CONTROL: 0, EventTier.BUSINESS: n}` for a
+uniform shape, or document on the Protocol that consumers must use `.get(tier, 0)`.
+
+### IN-04: `UNIVERSE_POLL` documented as "control-plane" but tiered BUSINESS
+
+**File:** `itrader/core/enums/event.py:32` vs `itrader/events_handler/bus.py:48-53`
+**Issue:** `EventType.UNIVERSE_POLL` carries the comment `# D-06: control-plane poll tick`,
+yet it is not a member of `_CONTROL_EVENT_TYPES`, so `_tier(UNIVERSE_POLL)` resolves to
+`BUSINESS`. `STRATEGY_COMMAND` (also a control-plane command) IS enumerated as CONTROL.
+When `PriorityEventBus` is eventually wired, a `UNIVERSE_POLL` follow-on emitted by a
+CONTROL-tier `STRATEGY_COMMAND` (see `strategies_handler.on_strategy_command`) would sit at
+BUSINESS tier behind all pending business events. This is plausibly intentional (only
+connector-lifecycle + operator commands preempt; routine poll ticks do not), but the enum
+comment and the tier set disagree. Latent — the priority bus is defined and unit-tested this
+phase but wired into no path.
+**Fix:** Either add `UNIVERSE_POLL` to `_CONTROL_EVENT_TYPES` if it should preempt, or update
+the enum comment to clarify it is a BUSINESS-tier control-plane event, so the classification
+intent is unambiguous when the priority bus lands.
+
+---
+
+_Reviewed: 2026-07-09T13:39:19Z_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: standard_

--- a/.planning/phases/02-event-bus/02-REVIEW.md
+++ b/.planning/phases/02-event-bus/02-REVIEW.md
@@ -25,7 +25,11 @@ findings:
   warning: 2
   info: 4
   total: 6
-status: issues_found
+  warning_open: 0
+  warning_resolved: 2
+  info_open: 4
+status: resolved
+resolution: "WR-01 + WR-02 fixed in 51febb94 (2026-07-09), oracle byte-exact + mypy --strict re-verified. 4 INFO items deferred as advisory (priority-bus monitoring / docstring cosmetics)."
 ---
 
 # Phase 02: Code Review Report
@@ -33,7 +37,22 @@ status: issues_found
 **Reviewed:** 2026-07-09T13:39:19Z
 **Depth:** standard
 **Files Reviewed:** 16
-**Status:** issues_found
+**Status:** resolved (2 warnings fixed in `51febb94`; 4 info deferred as advisory)
+
+## Resolution (2026-07-09)
+
+Both WARNINGs were fixed in commit `51febb94` after owner sign-off:
+- **WR-01 ✅ RESOLVED** — `compose_engine` now threads `environment=ctx.environment,
+  backend=ctx.sql_engine` into `PortfolioHandler` (all three storage-owning handlers uniformly
+  mode-agnostic). Byte-safe on the backtest path (`'backtest'`/`None` = prior defaults).
+- **WR-02 ✅ RESOLVED** — the 4 dead `from queue import Queue` imports were removed.
+
+Re-verified post-fix: SMA_MACD oracle byte-exact `134 / 46189.87730727451` (determinism
+double-run), inertness green, `mypy --strict` clean (237 files), handler+events suites 1186 pass,
+`live_trading_system.py` unchanged, `poetry.lock` unchanged.
+
+The **4 INFO items remain open by design** — advisory cosmetics on the not-yet-wired
+`PriorityEventBus` + docstring drift; sweep whenever the priority bus is wired (P6/P7).
 
 ## Summary
 
@@ -64,7 +83,7 @@ the `PriorityEventBus` `(tier, seq, event)` keying correctly guarantees the non-
 
 ## Warnings
 
-### WR-01: `compose_engine` does not thread `ctx.environment`/`ctx.sql_engine` into `PortfolioHandler`
+### WR-01 — ✅ RESOLVED (`51febb94`): `compose_engine` does not thread `ctx.environment`/`ctx.sql_engine` into `PortfolioHandler`
 
 **File:** `itrader/trading_system/compose.py:171`
 **Issue:** `compose_engine` is documented as "the SHARED, mode-agnostic wiring seam both
@@ -101,7 +120,7 @@ portfolio_handler = PortfolioHandler(
 )
 ```
 
-### WR-02: Dead `from queue import Queue` imports left behind by the `EventBus` retype
+### WR-02 — ✅ RESOLVED (`51febb94`): Dead `from queue import Queue` imports left behind by the `EventBus` retype
 
 **File:** `itrader/order_handler/order_handler.py:2`, `itrader/strategy_handler/strategies_handler.py:2`, `itrader/execution_handler/execution_handler.py:2`, `itrader/portfolio_handler/portfolio_handler.py:9`
 **Issue:** The D-08 retype changed every `global_queue` annotation from `"Queue[Any]"` to

--- a/.planning/phases/02-event-bus/02-VALIDATION.md
+++ b/.planning/phases/02-event-bus/02-VALIDATION.md
@@ -1,0 +1,82 @@
+---
+phase: 2
+slug: event-bus
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-07-09
+---
+
+# Phase 2 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+> Derived from `02-RESEARCH.md` § Validation Architecture. Task IDs are seeded at
+> requirement granularity; the planner/executor refines exact `NN-PP-TT` IDs once plans exist.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | pytest ^8.4.2 (`minversion="8.0"`, `--strict-markers --strict-config`, `filterwarnings=["error"]`) |
+| **Config file** | `pyproject.toml [tool.pytest.ini_options]` (`testpaths=["tests"]`) |
+| **Quick run command** | `poetry run pytest tests/unit/events -x` |
+| **Full suite command** | `make test` (main checkout) or `poetry run pytest tests` (worktree — see worktree `.env` memory) |
+| **Estimated runtime** | ~8 seconds full unit suite; oracle+inertness integration ~a few seconds |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run `poetry run pytest tests/unit/events/test_event_bus.py -x` (fast — pure stdlib, no data load)
+- **After every plan wave / per-PLAN gate:** Run `poetry run pytest tests/integration/test_backtest_oracle.py tests/integration/test_okx_inertness.py -x` (the two milestone gates — oracle byte-exact + import inertness). **Determinism double-run:** run the oracle twice, assert identical `134 / 46189.87730727451`.
+- **Before `/gsd-verify-work` (phase gate):** Full suite green + `poetry run mypy itrader` clean on new/edited in-scope code + `poetry.lock` byte-unchanged (no new dependency in P1–P12).
+- **Max feedback latency:** ~10 seconds (quick unit run)
+
+---
+
+## Per-Task Verification Map
+
+> Seeded at requirement granularity from RESEARCH § Phase Requirements → Test Map.
+> Planner substitutes concrete Task IDs (`02-PP-TT`) during planning.
+
+| Task ID | Plan | Wave | Requirement | Threat Ref | Secure Behavior | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|------------|-----------------|-----------|-------------------|-------------|--------|
+| 02-*-* | TBD | 1 | BUS-01 | — | Both buses satisfy Protocol; `.put()`/`get_nowait()` surface; no call-site change | unit | `poetry run pytest tests/unit/events/test_event_bus.py -x` | ❌ W0 | ⬜ pending |
+| 02-*-* | TBD | 1 | BUS-02 | — | `(tier,seq,event)` ordering: CONTROL preempts, within-tier FIFO, event never compared, `Event < Event` raises `TypeError` | unit | `poetry run pytest tests/unit/events/test_event_bus.py -k priority -x` | ❌ W0 | ⬜ pending |
+| 02-*-* | TBD | 1 | BUS-03 | — | 3 CONTROL `EventType`s exist + assigned CONTROL via `_CONTROL_EVENT_TYPES`; backtest wires `FifoEventBus` | unit | `poetry run pytest tests/unit/events/test_event_bus.py -k control_types -x` | ❌ W0 | ⬜ pending |
+| 02-*-* | TBD | 2 | BUS-04 / CTX-01 | — | `compose_engine(ctx, spec)` signature; internal `queue.Queue()` deleted | unit/integration | `poetry run pytest tests/integration/test_okx_inertness.py -x` | ✅ (extend) | ⬜ pending |
+| 02-*-* | TBD | 2 | CTX-02 | — | Order + Strategies handlers own storage from `(environment, sql_engine)`; `.storage` readable back | unit | `poetry run pytest tests/unit/order tests/unit/strategy -x` | ✅/❌ new case | ⬜ pending |
+| 02-*-* | TBD | 2 | CTX-03 / oracle | — | Backtest → same in-memory instances → byte-exact `134 / 46189.87730727451` | integration | `poetry run pytest tests/integration/test_backtest_oracle.py -x` | ✅ | ⬜ pending |
+| 02-*-* | TBD | 2 | inertness | — | `FifoEventBus`/`EngineContext(sql_engine=None)` pull nothing heavy; import builds no `SqlSettings` | integration | `poetry run pytest tests/integration/test_okx_inertness.py -x` | ✅ (extend register-vs-build) | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Wave 0 Requirements
+
+- [ ] `tests/unit/events/test_event_bus.py` — covers BUS-01/02/03 (Protocol conformance for both buses; priority ordering + non-orderability negative test; `_CONTROL_EVENT_TYPES` tier assignment). **Do NOT add `tests/unit/events/__init__.py`** — the empty-`__init__` package-collision hazard (project memory) breaks full-suite collection; keep `tests/unit/*` package-less.
+- [ ] Extend `tests/integration/test_okx_inertness.py` — add the register-vs-build assertion that constructing `EngineContext(sql_engine=None)` + `FifoEventBus` pulls no SQLAlchemy/ccxt (append to `_PROBE` and/or an in-process assertion that `FifoEventBus()` and the backtest `compose_engine` build no `SqlSettings`).
+- [ ] New handler-storage unit cases: `OrderHandler(..., environment='backtest', sql_engine=None)` yields `InMemoryOrderStorage` and exposes `.storage`; same for `StrategiesHandler` → in-memory signal store.
+- Framework install: none — pytest infra already present.
+
+---
+
+## Manual-Only Verifications
+
+All phase behaviors have automated verification. The two milestone gates (`test_backtest_oracle.py`, `test_okx_inertness.py`) plus new `tests/unit/events/test_event_bus.py` cover every requirement.
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers all MISSING references
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 10s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending

--- a/.planning/phases/02-event-bus/02-VERIFICATION.md
+++ b/.planning/phases/02-event-bus/02-VERIFICATION.md
@@ -1,0 +1,141 @@
+---
+phase: 02-event-bus
+verified: 2026-07-09T16:00:00Z
+status: passed
+score: 12/12 must-haves verified
+behavior_unverified: 0
+overrides_applied: 0
+---
+
+# Phase 2: Event Bus Verification Report
+
+**Phase Goal:** Introduce a stdlib two-tier `EventBus` (CONTROL > BUSINESS) with FIFO and priority
+implementations behind one `.put()` surface, add the new CONTROL `EventType` members, and settle the
+`compose_engine` signature to its end-state `(ctx, spec)` form via a frozen `EngineContext` with
+handler-owned storage — backtest wiring `FifoEventBus` at zero oracle risk. (Phase 2 D-03: CTX-01/CTX-02/CTX-03
+pulled forward from P3 into P2; only SqlBackend→SqlEngine (CTX-04) stays in P3.)
+
+**Verified:** 2026-07-09T16:00:00Z
+**Status:** passed
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | `EventBus` Protocol + `FifoEventBus` + `PriorityEventBus` both satisfy `isinstance(bus, EventBus)` (BUS-01) | ✓ VERIFIED | Ran independently: `isinstance(FifoEventBus(), EventBus)` → True, `isinstance(PriorityEventBus(), EventBus)` → True. `bus.py` inspected directly — Protocol has `put/get/get_nowait/qsize/empty/depth_by_tier`, `@runtime_checkable`. |
+| 2 | `PriorityEventBus` dequeues CONTROL before BUSINESS, strict within-tier FIFO via `itertools.count()` seq, never dereferences `Event` in comparison (BUS-02) | ✓ VERIFIED | `bus.py` code inspected: `(tier, next(self._seq), event)` tuple keying. 18/18 unit tests pass incl. `test_priority_control_preempts_business_then_fifo`, `test_priority_never_compares_events`, `test_priority_stable_fifo_under_many_same_tier_puts`. |
+| 3 | `EventType` gains `STREAM_STATE`/`CONNECTOR_FATAL`/`CONFIG_UPDATE`; `_CONTROL_EVENT_TYPES` frozenset assigns CONTROL tier to those 3 + `STRATEGY_COMMAND` (BUS-03) | ✓ VERIFIED | Ran independently: all 3 members present, `EventType('stream_state') is EventType.STREAM_STATE`. `_CONTROL_EVENT_TYPES` frozenset in `bus.py` contains exactly the 4 expected members. Tests `test_control_types_*` (4 tests) pass. |
+| 4 | The 3 new CONTROL EventTypes are registered in `full_event_handler._routes` (no silent dispatch gap) | ✓ VERIFIED | `grep` confirms `EventType.STREAM_STATE/CONNECTOR_FATAL/CONFIG_UPDATE: []` explicit empty routes at lines 113-115. `tests/unit/events/test_dispatch_registry.py::test_registry_covers_every_event_type` passes (ran independently). Wave-1 post-merge fix commit `a7b4d9d9` confirmed in git log. |
+| 5 | A frozen `EngineContext` dataclass carries exactly 4 fields `bus`/`config`/`environment`/`sql_engine` (BUS-04) | ✓ VERIFIED | `engine_context.py` read directly — `@dataclass(frozen=True)` with exactly `bus: EventBus`, `config: Any`, `environment: str`, `sql_engine: Optional[Any] = None`, in order. |
+| 6 | `compose_engine(ctx, spec)` is the two-arg end-state signature; internal `queue.Queue()` deleted (CTX-01) | ✓ VERIFIED | `inspect.signature` not re-run but `grep -c 'queue.Queue()' compose.py` == 0 (ran independently). `def compose_engine(ctx: "EngineContext", spec: "SystemSpec") -> Engine:` confirmed in file. |
+| 7 | `compose_engine` reads only `{spec.data, spec.start, spec.end, spec.timeframe, spec.exchange, spec.results_store}`, never `spec.ticker`/`spec.starting_cash`/`spec.strategies`/`spec.portfolios`; `order_config` stays handler-owned via `OrderConfig.default()` (D-04/A1) | ✓ VERIFIED | `grep -c 'spec.ticker\|spec.starting_cash\|spec.strategies\|spec.portfolios' compose.py` == 0 (ran independently). `resolved_order_config = OrderConfig.default()` confirmed at line 214. |
+| 8 | Every in-scope handler's `global_queue` param retyped to `EventBus` (name unchanged); `EventHandler` drains via `bus.get_nowait()` catching `queue.Empty` (D-07/D-08) | ✓ VERIFIED | `mypy --strict` clean (237 source files, ran independently). No `.put()`/`.get_nowait()` call-site changes confirmed by mypy passing without adjusting call sites. |
+| 9 | CTX-02: `OrderHandler`/`StrategiesHandler` own their storage init from `(environment, sql_engine)`, expose `.storage`/`.signal_store`, backtest yields in-memory concretes; `compose_engine` reads them back | ✓ VERIFIED | `tests/unit/order/test_order_handler_storage.py` + `tests/unit/strategy/test_strategies_handler_storage.py` (5 tests) pass independently, including identity check `.storage` == instance forwarded to `OrderManager`. `compose.py` confirmed reading `order_handler.storage` / `strategies_handler.signal_store` back. |
+| 10 | Backtest wiring uses `FifoEventBus` at zero oracle risk — SMA_MACD stays byte-exact `134 / 46189.87730727451` (CTX-03) | ✓ VERIFIED | `poetry run pytest tests/integration/test_backtest_oracle.py -x` → 3 passed, `check_exact=True` against `tests/golden/summary.json` (`final_equity: 46189.87730727451`). Ran independently, not just SUMMARY claim. |
+| 11 | D-11: `live_trading_system.py` unchanged in P2 | ✓ VERIFIED | `git diff --exit-code b3eb2d18 -- itrader/trading_system/live_trading_system.py` → exit code 0 (no diff), ran independently. |
+| 12 | `poetry.lock` unchanged since phase start | ✓ VERIFIED | `git diff --stat b3eb2d18 -- poetry.lock` → empty, ran independently. |
+
+**Score:** 12/12 truths verified (0 present, behavior-unverified)
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `itrader/events_handler/bus.py` | `EventBus` Protocol + `EventTier` + `_CONTROL_EVENT_TYPES` + `FifoEventBus` + `PriorityEventBus` | ✓ VERIFIED | 167 lines, all symbols present, matches PLAN spec exactly (read in full). |
+| `itrader/core/enums/event.py` | 3 new CONTROL EventType members | ✓ VERIFIED | Members present, importable, case-insensitive parse round-trips. |
+| `tests/unit/events/test_event_bus.py` | BUS-01/02/03 proof suite | ✓ VERIFIED | 18 tests, all pass independently. |
+| `tests/unit/events/test_dispatch_registry.py` | Registry conformance (pre-existing, from Phase 4) | ✓ VERIFIED | `test_registry_covers_every_event_type` passes — the 3 new CONTROL types are covered by the wave-1 fix. |
+| `itrader/order_handler/order_handler.py` | `.storage` attribute, `(environment, sql_engine)` kwargs | ✓ VERIFIED | Confirmed via independent test run + mypy. |
+| `itrader/strategy_handler/strategies_handler.py` | `.signal_store` attribute, `(environment, sql_engine)` kwargs, optional `signal_store` | ✓ VERIFIED | Confirmed via independent test run + mypy. |
+| `tests/unit/order/test_order_handler_storage.py` | Handler-storage unit cases | ✓ VERIFIED | 3 tests pass. |
+| `tests/unit/strategy/test_strategies_handler_storage.py` | Handler-storage unit cases | ✓ VERIFIED | 2 tests pass. |
+| `itrader/trading_system/engine_context.py` | Frozen `EngineContext` (4 fields) | ✓ VERIFIED | Read in full — matches spec exactly. |
+| `itrader/trading_system/compose.py` | Two-arg `compose_engine(ctx, spec)`, queue deleted, storage read-back | ✓ VERIFIED | Confirmed via grep + code read. |
+| `itrader/trading_system/backtest_trading_system.py` | Both call sites rewired to `(ctx, spec)` | ✓ VERIFIED | `grep -c 'compose_engine(ctx'` == 2. |
+| `tests/integration/test_okx_inertness.py` | Extended register-vs-build assertion | ✓ VERIFIED | New assertion present (`FifoEventBus`/`EngineContext` construction, no sqlalchemy/ccxt pull); test passes independently. |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|-----|-----|--------|---------|
+| `_CONTROL_EVENT_TYPES` | 3 new members + `STRATEGY_COMMAND` | frozenset membership | ✓ WIRED | Verified by direct code read + `test_control_types_*` tests. |
+| `PriorityEventBus.put` | `_tier(event.type)` | tier lookup + tuple enqueue | ✓ WIRED | Code confirms `tier = _tier(event.type)`, `self._pq.put((tier, next(self._seq), event))`. |
+| `PriorityEventBus.get/get_nowait` | bare `Event` return | tuple unwrap `item[2]` | ✓ WIRED | Code confirms unwrap; test `test_priority_get_returns_bare_event_not_tuple` passes. |
+| `OrderHandler.storage` | `compose_engine`'s `portfolio_handler.set_order_storage(...)` | back-read | ✓ WIRED | `compose.py:232-233` confirmed: `order_storage = order_handler.storage; portfolio_handler.set_order_storage(order_storage)`. |
+| `StrategiesHandler.signal_store` | `Engine` holder | back-read | ✓ WIRED | `compose.py:252` confirmed: `signal_store=strategies_handler.signal_store`. |
+| `EngineContext.bus` | 6 handler ctors + `Engine.global_queue` | `ctx.bus` injection | ✓ WIRED | `grep -c 'ctx.bus' compose.py` matches PLAN's ≥6 requirement (confirmed present across handler ctors). |
+| Both backtest call sites | `compose_engine(ctx, spec)` | direct call | ✓ WIRED | `grep -c 'compose_engine(ctx' backtest_trading_system.py` == 2. |
+
+### Data-Flow Trace (Level 4)
+
+Not applicable — this phase is pure backend/infrastructure wiring (no UI, no dynamic-data rendering
+components). Oracle byte-exactness (Truth #10) is the equivalent end-to-end data-flow proof: the full
+component graph is exercised through `compose_engine` and produces the exact frozen golden numbers.
+
+### Behavioral Spot-Checks / Probe Execution
+
+| Behavior | Command | Result | Status |
+|----------|---------|--------|--------|
+| Oracle byte-exact | `poetry run pytest tests/integration/test_backtest_oracle.py -x` | 3 passed, `check_exact=True` against golden `134 / 46189.87730727451` | ✓ PASS |
+| Inertness (register-vs-build) | `poetry run pytest tests/integration/test_okx_inertness.py -x` | 2 passed, incl. new `FifoEventBus`/`EngineContext` assertion | ✓ PASS |
+| `mypy --strict` | `poetry run mypy itrader` | Success: no issues found in 237 source files | ✓ PASS |
+| D-11 non-change | `git diff --exit-code b3eb2d18 -- itrader/trading_system/live_trading_system.py` | exit 0, no diff | ✓ PASS |
+| `poetry.lock` unchanged | `git diff --stat b3eb2d18 -- poetry.lock` | empty | ✓ PASS |
+| Structural: no internal queue | `grep -c 'queue.Queue()' itrader/trading_system/compose.py` | 0 | ✓ PASS |
+| Structural: both arms folded | `grep -c 'compose_engine(ctx' itrader/trading_system/backtest_trading_system.py` | 2 | ✓ PASS |
+| Both buses satisfy Protocol | `isinstance(bus, EventBus)` for both concretes | True, True | ✓ PASS |
+| CONTROL types registered | `test_dispatch_registry.py::test_registry_covers_every_event_type` | passed | ✓ PASS |
+| Bus substrate unit suite | `pytest tests/unit/events/test_event_bus.py -v` | 18/18 passed | ✓ PASS |
+| Handler-storage unit suite | `pytest tests/unit/order/test_order_handler_storage.py tests/unit/strategy/test_strategies_handler_storage.py` | 5/5 passed | ✓ PASS |
+| No regression in events/order/strategy suites | `pytest tests/unit/events tests/unit/order tests/unit/strategy -q` | 566 passed | ✓ PASS |
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+|-------------|-------------|-------------|--------|----------|
+| BUS-01 | 02-01, 02-03 | `EventBus` Protocol + FIFO/Priority implementations, shared `.put()` surface | ✓ SATISFIED | `isinstance` checks, mypy strict clean across retyped handlers. |
+| BUS-02 | 02-01 | `PriorityEventBus` tier ordering + non-orderable-event guarantee | ✓ SATISFIED | 9 priority-marked unit tests pass. |
+| BUS-03 | 02-01 | 3 new CONTROL EventTypes, backtest stays on `FifoEventBus` | ✓ SATISFIED | Members present + registered in dispatch routes. |
+| BUS-04 | 02-03 | Minimal `EngineContext` skeleton settling `compose_engine` signature once | ✓ SATISFIED | `engine_context.py` — 4 fields, frozen, exactly as specified. |
+| CTX-01 | 02-03 | `EngineContext` threaded once into `compose_engine(ctx, spec)` | ✓ SATISFIED | Signature confirmed; internal queue deleted. |
+| CTX-02 | 02-02 | Order/Strategies handlers own storage init, expose concrete on `.storage`/`.signal_store` | ✓ SATISFIED | 5 handler-storage unit tests pass; back-read confirmed in compose.py. |
+| CTX-03 | 02-03 | Backtest yields same in-memory instances; oracle byte-exact; inertness green | ✓ SATISFIED | Oracle + inertness tests pass independently. |
+
+No orphaned requirements — REQUIREMENTS.md maps exactly these 7 IDs to Phase 2 (CTX-04 correctly deferred to P3, confirmed in REQUIREMENTS.md traceability table).
+
+### Anti-Patterns Found
+
+| File | Line | Pattern | Severity | Impact |
+|------|------|---------|----------|--------|
+| `itrader/order_handler/order_handler.py:2` | 2 | Dead `from queue import Queue` import (WR-02, advisory review) | ℹ️ Info | Hygiene only — no ruff/flake8 gate catches it; mypy doesn't flag unused imports. Does not affect correctness or the oracle. Non-blocking per emphasis note. |
+| `itrader/strategy_handler/strategies_handler.py:2` | 2 | Same dead import | ℹ️ Info | Same as above. |
+| `itrader/execution_handler/execution_handler.py:2` | 2 | Same dead import | ℹ️ Info | Same as above. |
+| `itrader/portfolio_handler/portfolio_handler.py:9` | 9 | Same dead import | ℹ️ Info | Same as above. |
+| `itrader/trading_system/compose.py:171` | 171 | `PortfolioHandler(ctx.bus)` omits `environment`/`sql_engine` threading (WR-01, advisory review) | ⚠️ Warning (deferred) | Backtest-dark today (in-memory only path used); a latent defect for a future live-mode `compose_engine` reuse (P3/P6 scope per project explicit note). Not a P2 requirement — P2 does not require `PortfolioHandler` mode-agnosticism. |
+
+Both items were independently confirmed present in the current codebase (not just SUMMARY claims) and match the advisory `02-REVIEW.md` (0 blockers, 2 warnings) exactly. Per the phase's explicit verification-emphasis instructions, these are non-blocking and do not represent P2 goal failures — WR-01 is explicitly deferred scope (P3/P6), WR-02 is a hygiene nit with no automated gate and no behavioral impact.
+
+### Human Verification Required
+
+None. This phase is pure backend/infrastructure wiring with no UI, no user-facing behavior, and fully
+mechanical/testable success criteria (byte-exact oracle, inertness assertions, mypy strict, structural
+greps). All must-haves were verified programmatically by running the actual commands independently
+against the live codebase.
+
+### Gaps Summary
+
+No gaps found. All 12 derived must-have truths (roadmap goal decomposed + PLAN frontmatter must_haves
+merged across all 3 plans) verified against the live codebase by running the actual test/grep/mypy
+commands myself — not accepted from SUMMARY.md narrative. All 7 requirement IDs (BUS-01..04, CTX-01..03)
+are SATISFIED with independent evidence; CTX-04 correctly remains scoped to Phase 3. The 2 advisory-review
+warnings (WR-01 PortfolioHandler mode-agnosticism, WR-02 dead imports) are real but explicitly non-blocking
+per the phase's own scope boundaries — WR-01 is deferred to P3/P6, WR-02 is a hygiene-only nit with no
+correctness or oracle impact.
+
+---
+
+_Verified: 2026-07-09T16:00:00Z_
+_Verifier: Claude (gsd-verifier)_

--- a/itrader/core/enums/event.py
+++ b/itrader/core/enums/event.py
@@ -33,6 +33,9 @@ class EventType(Enum):
     STRATEGY_COMMAND = "STRATEGY_COMMAND"    # D-09: add/remove-ticker command
     BARS_LOADED = "BARS_LOADED"              # D-03: warmup bulk-transport
     BARS_LOAD_FAILED = "BARS_LOAD_FAILED"    # D-04: warmup backfill failure
+    STREAM_STATE = "STREAM_STATE"            # BUS-03: connector stream up/down (CONTROL)
+    CONNECTOR_FATAL = "CONNECTOR_FATAL"      # BUS-03: connector fatal -> halt (CONTROL)
+    CONFIG_UPDATE = "CONFIG_UPDATE"          # BUS-03: scoped runtime config change (CONTROL)
     ERROR = "ERROR"
 
     @classmethod

--- a/itrader/events_handler/bus.py
+++ b/itrader/events_handler/bus.py
@@ -1,0 +1,166 @@
+"""Two-tier event-bus substrate for the iTrader event system (D-09/D-10).
+
+This module is a pure, import-inert transport substrate. It defines the
+``EventBus`` structural interface plus two concrete implementations:
+
+* ``FifoEventBus`` — a thin ``queue.Queue`` wrapper; the byte-exact backtest
+  buffer (D-07). Its FIFO semantics are identical to the raw queue it replaces,
+  so wiring it into the backtest path carries zero oracle risk.
+* ``PriorityEventBus`` — a ``queue.PriorityQueue`` wrapper keyed by
+  ``(tier, seq, event)`` so CONTROL-tier events (tier 0) preempt BUSINESS-tier
+  events (tier 1) while preserving strict within-tier FIFO. Defined and
+  unit-tested ONLY in Phase 2 (D-10/D-11): it is wired into no live path here.
+
+Inertness discipline (D-09): this module imports only stdlib plus
+``itrader.core.enums.event``. ``Event`` is a ``TYPE_CHECKING``-only import —
+the events package pulls pandas at runtime, so it is kept off this substrate.
+"""
+
+import itertools
+import queue
+import threading
+from collections import Counter
+from enum import IntEnum
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from itrader.core.enums.event import EventType
+
+if TYPE_CHECKING:
+    # Annotation-only: the events package pulls pandas at runtime, so the
+    # concrete Event never crosses this module's runtime import surface (D-09).
+    from itrader.events_handler.events import Event
+
+
+class EventTier(IntEnum):
+    """Dequeue priority tier — int-comparable so it sorts as the first
+    element of the ``(tier, seq, event)`` priority tuple.
+
+    CONTROL (0) is dequeued before BUSINESS (1). BUSINESS is the default
+    fall-through tier; only CONTROL is ever enumerated.
+    """
+
+    CONTROL = 0
+    BUSINESS = 1
+
+
+# BUSINESS is the default fall-through — only CONTROL is enumerated so the
+# tiering stays robust to future EventType additions (never enumerate BUSINESS).
+_CONTROL_EVENT_TYPES: frozenset[EventType] = frozenset({
+    EventType.STREAM_STATE,
+    EventType.CONNECTOR_FATAL,
+    EventType.CONFIG_UPDATE,
+    EventType.STRATEGY_COMMAND,
+})
+
+
+def _tier(event_type: EventType) -> EventTier:
+    """Map an ``EventType`` to its dequeue tier (CONTROL if enumerated, else BUSINESS)."""
+    return EventTier.CONTROL if event_type in _CONTROL_EVENT_TYPES else EventTier.BUSINESS
+
+
+@runtime_checkable
+class EventBus(Protocol):
+    """Structural interface for the event transport substrate (D-09).
+
+    A ``runtime_checkable`` ``Protocol`` (no ABC inheritance), mirroring the
+    house read-model seam (``core.portfolio_read_model.PortfolioReadModel``).
+    Both ``FifoEventBus`` and ``PriorityEventBus`` satisfy it structurally.
+    """
+
+    def put(self, event: "Event") -> None:
+        ...
+
+    def get(self, timeout: "float | None" = None) -> "Event":
+        ...
+
+    def get_nowait(self) -> "Event":
+        ...
+
+    def qsize(self) -> int:
+        ...
+
+    def empty(self) -> bool:
+        ...
+
+    def depth_by_tier(self) -> "dict[EventTier, int]":
+        ...
+
+
+class FifoEventBus:
+    """Thin ``queue.Queue`` wrapper — the byte-exact backtest buffer (D-07).
+
+    FIFO is tierless: every method delegates to the wrapped stdlib queue, so
+    ``get_nowait`` raises ``queue.Empty`` unchanged. ``depth_by_tier`` reports
+    a single BUSINESS bucket (monitoring-only — FIFO has no CONTROL tier).
+    """
+
+    def __init__(self) -> None:
+        self._q: "queue.Queue[Event]" = queue.Queue()
+
+    def put(self, event: "Event") -> None:
+        self._q.put(event)
+
+    def get(self, timeout: "float | None" = None) -> "Event":
+        return self._q.get(timeout=timeout)
+
+    def get_nowait(self) -> "Event":
+        # Delegates to the stdlib queue — raises queue.Empty on empty (D-07).
+        return self._q.get_nowait()
+
+    def qsize(self) -> int:
+        return self._q.qsize()
+
+    def empty(self) -> bool:
+        return self._q.empty()
+
+    def depth_by_tier(self) -> "dict[EventTier, int]":
+        # FIFO is tierless — single-bucket, documented monitoring-only.
+        return {EventTier.BUSINESS: self._q.qsize()}
+
+
+class PriorityEventBus:
+    """``queue.PriorityQueue`` wrapper: CONTROL preempts BUSINESS, FIFO within tier.
+
+    Keyed by ``(tier, seq, event)`` where ``seq`` comes from one per-instance
+    ``itertools.count()``. Each ``next()`` is C-atomic (thread-safe, globally
+    unique per bus), so the tuple's first two elements are always unique — the
+    heap NEVER dereferences the non-orderable ``Event`` (D-10). ``get*()``
+    unwrap the tuple and return the bare ``Event`` the drain expects.
+    """
+
+    def __init__(self) -> None:
+        self._pq: "queue.PriorityQueue[tuple[EventTier, int, Event]]" = queue.PriorityQueue()
+        self._seq = itertools.count()
+        self._depth: "Counter[EventTier]" = Counter()
+        self._depth_lock = threading.Lock()
+
+    def put(self, event: "Event") -> None:
+        tier = _tier(event.type)
+        self._pq.put((tier, next(self._seq), event))
+        with self._depth_lock:
+            self._depth[tier] += 1
+
+    def get(self, timeout: "float | None" = None) -> "Event":
+        item = self._pq.get(timeout=timeout)
+        with self._depth_lock:
+            self._depth[item[0]] -= 1
+        return item[2]  # bare Event — never the (tier, seq, event) tuple
+
+    def get_nowait(self) -> "Event":
+        item = self._pq.get_nowait()  # raises queue.Empty on empty (inherited)
+        with self._depth_lock:
+            self._depth[item[0]] -= 1
+        return item[2]  # bare Event — never the tuple
+
+    def qsize(self) -> int:
+        return self._pq.qsize()
+
+    def empty(self) -> bool:
+        return self._pq.empty()
+
+    def depth_by_tier(self) -> "dict[EventTier, int]":
+        with self._depth_lock:
+            return {
+                EventTier.CONTROL: self._depth[EventTier.CONTROL],
+                EventTier.BUSINESS: self._depth[EventTier.BUSINESS],
+            }

--- a/itrader/events_handler/full_event_handler.py
+++ b/itrader/events_handler/full_event_handler.py
@@ -109,6 +109,9 @@ class EventHandler(object):
 			EventType.STRATEGY_COMMAND: [],    # NEW — live-only consumers wired live-only in plan 07 (backtest stays inert)
 			EventType.BARS_LOADED: [],         # NEW — live-only consumers wired live-only in plan 07 (backtest stays inert)
 			EventType.BARS_LOAD_FAILED: [],    # NEW — live-only consumers wired live-only in plan 07 (backtest stays inert)
+			EventType.STREAM_STATE: [],        # NEW (BUS-03) — CONTROL-plane connector stream up/down; live-only consumers wired in later phases (backtest stays inert)
+			EventType.CONNECTOR_FATAL: [],     # NEW (BUS-03) — CONTROL-plane connector fatal -> halt; live-only consumers wired in later phases (backtest stays inert)
+			EventType.CONFIG_UPDATE: [],       # NEW (BUS-03) — CONTROL-plane scoped runtime config change; live-only consumers wired in later phases (backtest stays inert)
 			EventType.ERROR: [self._log_error_event],   # D-16: real log consumer
 		}
 

--- a/itrader/events_handler/full_event_handler.py
+++ b/itrader/events_handler/full_event_handler.py
@@ -8,6 +8,7 @@ from itrader.screeners_handler.screeners_handler import ScreenersHandler
 from itrader.order_handler.order_handler import OrderHandler
 from itrader.portfolio_handler.portfolio_handler import PortfolioHandler
 from itrader.execution_handler.execution_handler import ExecutionHandler
+from itrader.events_handler.bus import EventBus
 from itrader.core.enums import ErrorSeverity, EventType
 
 from itrader.logger import get_itrader_logger
@@ -63,7 +64,7 @@ class EventHandler(object):
 		order_handler: OrderHandler,
 		execution_handler: ExecutionHandler,
 		bar_event_source: Callable[[Any], Any],
-		global_queue: "queue.Queue[Any]",
+		global_queue: "EventBus",
 	) -> None:
 		self.strategies_handler = strategies_handler
 		self.screeners_handler = screeners_handler

--- a/itrader/execution_handler/exchanges/simulated.py
+++ b/itrader/execution_handler/exchanges/simulated.py
@@ -18,6 +18,7 @@ from ..matching_engine import MatchingEngine
 from itrader.core.enums.execution import ExecutionErrorCode, ExchangeConnectionStatus, ExchangeType
 from itrader.core.enums import OrderType, OrderCommand
 from itrader.core.money import to_money
+from itrader.events_handler.bus import EventBus
 from itrader.events_handler.events import BarEvent, FillEvent, OrderEvent
 from itrader.logger import get_itrader_logger
 from itrader.universe import Universe
@@ -46,7 +47,7 @@ class SimulatedExchange(AbstractExchange):
 	thread; queue.Queue is the thread boundary — other threads only put events.
 	"""
 
-	def __init__(self, global_queue: "Queue[Any]", config: Optional[ExchangeConfig] = None,
+	def __init__(self, global_queue: "EventBus", config: Optional[ExchangeConfig] = None,
 				rng: Optional[random.Random] = None) -> None:
 		"""
 		Initialize the simulated exchange with minimal setup.

--- a/itrader/execution_handler/execution_handler.py
+++ b/itrader/execution_handler/execution_handler.py
@@ -1,5 +1,4 @@
 import random
-from queue import Queue
 from typing import Any, Dict, Optional
 
 from .base import AbstractExecutionHandler

--- a/itrader/execution_handler/execution_handler.py
+++ b/itrader/execution_handler/execution_handler.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 
 from .base import AbstractExecutionHandler
 from .exchanges.base import AbstractExchange
+from itrader.events_handler.bus import EventBus
 from itrader.events_handler.events import BarEvent, FillEvent, OrderEvent
 from itrader.execution_handler.exchanges.simulated import SimulatedExchange
 
@@ -26,7 +27,7 @@ class ExecutionHandler(AbstractExecutionHandler):
 	while maintaining backward compatibility with existing systems.
 	"""
 
-	def __init__(self, global_queue: "Queue[Any]",
+	def __init__(self, global_queue: "EventBus",
 				exchange_config: Optional[ExchangeConfig] = None) -> None:
 		"""
 		Parameters

--- a/itrader/order_handler/order_handler.py
+++ b/itrader/order_handler/order_handler.py
@@ -46,7 +46,10 @@ class OrderHandler:
 	             commission_estimator: Optional[CommissionEstimator] = None,
 	             order_config: Optional[OrderConfig] = None,
 	             enable_margin: bool = False,
-	             portfolio_max_leverage: Decimal = Decimal("1")) -> None:
+	             portfolio_max_leverage: Decimal = Decimal("1"),
+	             *,
+	             environment: str = "backtest",
+	             sql_engine: "Optional[Any]" = None) -> None:
 		"""
 		Parameters
 		----------
@@ -77,11 +80,22 @@ class OrderHandler:
 		# Initialize logger first
 		self.logger = get_itrader_logger().bind(component="OrderHandler")
 
-		# D-18: manager owns storage — the handler forwards the injected storage
-		# to OrderManager and retains NO reference to it. Every read path
-		# delegates through the manager (facade -> manager -> storage).
+		# CTX-02/D-02: the handler now OWNS its storage init from
+		# (environment, sql_engine), mirroring the PortfolioHandler template
+		# (LR-13). `OrderStorageFactory.create('backtest', backend=None)` returns
+		# the same `InMemoryOrderStorage` concrete `create_in_memory()` did, so
+		# the backtest slice is byte-exact. The explicit `order_storage=` override
+		# still wins (back-compat with current positional compose call until 02-03).
+		# `.storage` is a wiring seam `compose_engine` reads back for
+		# `portfolio_handler.set_order_storage(...)` in plan 02-03 — NOT a new read
+		# path: D-18 still holds, the manager owns storage for all reads.
+		self.storage = order_storage or OrderStorageFactory.create(environment, backend=sql_engine)
+
+		# D-18: manager owns storage — the handler forwards the SAME instance now
+		# referenced by `self.storage` to OrderManager. Every read path delegates
+		# through the manager (facade -> manager -> storage).
 		self.order_manager = OrderManager(
-			order_storage or OrderStorageFactory.create_in_memory(),
+			self.storage,
 			self.logger,
 			market_execution,
 			portfolio_handler,  # Pass portfolio_handler for position-aware logic

--- a/itrader/order_handler/order_handler.py
+++ b/itrader/order_handler/order_handler.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from queue import Queue
 from typing import Any, Callable, List, Dict, Optional
 
 from itrader.core.commission_estimator import CommissionEstimator

--- a/itrader/order_handler/order_handler.py
+++ b/itrader/order_handler/order_handler.py
@@ -11,6 +11,7 @@ from ..core.enums import OrderStatus, MarketExecution
 from ..core.ids import OrderId, PortfolioId
 from .order_validator import EnhancedOrderValidator
 from .order_manager import OrderManager
+from ..events_handler.bus import EventBus
 from ..events_handler.events import SignalEvent, OrderEvent, OrderAckEvent, FillEvent, PortfolioUpdateEvent
 from .storage import OrderStorageFactory
 from ..universe import Universe
@@ -40,7 +41,7 @@ class OrderHandler:
 	- Position-aware operations (when portfolio_handler is available)
 	- Validation and state management
 	"""
-	def __init__(self, global_queue: "Queue[Any]", portfolio_handler: PortfolioReadModel,
+	def __init__(self, global_queue: "EventBus", portfolio_handler: PortfolioReadModel,
 	             order_storage: Optional[OrderStorage] = None,
 	             market_execution: "str | MarketExecution | None" = None,
 	             commission_estimator: Optional[CommissionEstimator] = None,

--- a/itrader/portfolio_handler/portfolio_handler.py
+++ b/itrader/portfolio_handler/portfolio_handler.py
@@ -29,6 +29,7 @@ from itrader.core.enums import (
 from itrader.core.ids import OrderId, PortfolioId, TransactionId, CorrelationId, StrategyId
 from itrader.order_handler.base import OrderStorage
 from itrader.order_handler.order import Order
+from itrader.events_handler.bus import EventBus
 from itrader.events_handler.events import OrderEvent
 from itrader.core.portfolio_read_model import PositionView
 from itrader.core.money import to_money, quantize
@@ -65,9 +66,9 @@ class PortfolioHandler:
     concurrently. Live cross-thread reads are a D-live design item.
     """
     
-    def __init__(self, global_queue: "Queue[Any]", config_dir: str = "settings",
+    def __init__(self, global_queue: "EventBus", config_dir: str = "settings",
                  environment: str = "backtest", backend: "Optional[Any]" = None) -> None:
-        self.global_queue: "Queue[Any]" = global_queue
+        self.global_queue: "EventBus" = global_queue
         self.current_time: Any = 0
 
         # D-07 (05.2-05): the durable portfolio-storage selector threaded down

--- a/itrader/portfolio_handler/portfolio_handler.py
+++ b/itrader/portfolio_handler/portfolio_handler.py
@@ -6,7 +6,6 @@ engine thread; queue.Queue is the thread boundary — other threads only put
 events. Composite reads are consistent because nothing mutates concurrently.
 Live cross-thread reads are a D-live design item.
 """
-from queue import Queue
 from collections import OrderedDict
 from datetime import datetime, UTC
 from decimal import Decimal

--- a/itrader/price_handler/feed/bar_feed.py
+++ b/itrader/price_handler/feed/bar_feed.py
@@ -55,7 +55,6 @@ log the missing-ticker warning (RESEARCH OQ4).
 """
 
 import functools
-import queue
 from collections.abc import Iterable
 from datetime import datetime, timedelta
 from decimal import Decimal
@@ -70,6 +69,7 @@ from itrader.core.exceptions import (
     MalformedDataError,
     MissingPriceDataError,
 )
+from itrader.events_handler.bus import EventBus
 from itrader.events_handler.events import BarEvent, TimeEvent
 from itrader.logger import get_itrader_logger
 from itrader.price_handler.store.base import PriceStore
@@ -331,7 +331,7 @@ class BacktestBarFeed(BarFeed):
         # set by the trading system at wiring time via ``bind``. The queue
         # is optional (unbound: the factory RETURNS the event); membership
         # is used ONLY for the missing-ticker warning (RESEARCH OQ4).
-        self.global_queue: "Optional[queue.Queue[Any]]" = None
+        self.global_queue: "Optional[EventBus]" = None
         self.membership: list[str] = []
 
         self.logger = get_itrader_logger().bind(component="BacktestBarFeed")
@@ -425,7 +425,7 @@ class BacktestBarFeed(BarFeed):
 
     # -- BarEvent factory (relocated from the legacy universe — Plan 07-02, D-20) --
 
-    def bind(self, global_queue: "Optional[queue.Queue[Any]]",
+    def bind(self, global_queue: "Optional[EventBus]",
              membership: list[str]) -> None:
         """Bind the run-path event sink and membership set (wiring time).
 

--- a/itrader/strategy_handler/strategies_handler.py
+++ b/itrader/strategy_handler/strategies_handler.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from queue import Queue
 from typing import Any, Optional, TYPE_CHECKING, cast
 
 from itrader.core.enums import OrderType

--- a/itrader/strategy_handler/strategies_handler.py
+++ b/itrader/strategy_handler/strategies_handler.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from queue import Queue
-from typing import Any, TYPE_CHECKING, cast
+from typing import Any, Optional, TYPE_CHECKING, cast
 
 from itrader.core.enums import OrderType
 from itrader.core.exceptions import ConfigurationError
@@ -11,7 +11,7 @@ from itrader.price_handler.feed.base import BarFeed
 from itrader.strategy_handler.base import Strategy
 from itrader.strategy_handler.pair_base import PairStrategy
 from itrader.strategy_handler.signal_record import SignalRecord
-from itrader.strategy_handler.storage import SignalStore
+from itrader.strategy_handler.storage import SignalStorageFactory, SignalStore
 from itrader.events_handler.events import (
 	BarEvent,
 	BarsLoaded,
@@ -40,9 +40,12 @@ class StrategiesHandler(object):
 		self,
 		global_queue: "Queue[Any]",
 		feed: BarFeed,
-		signal_store: SignalStore,
+		signal_store: "Optional[SignalStore]" = None,
 		allow_short_selling: bool = False,
 		enable_margin: bool = False,
+		*,
+		environment: str = "backtest",
+		sql_engine: "Optional[Any]" = None,
 	) -> None:
 		"""
 		Parameters
@@ -73,7 +76,17 @@ class StrategiesHandler(object):
 		"""
 		self.global_queue: "Queue[Any]" = global_queue
 		self.feed: BarFeed = feed
-		self.signal_store: SignalStore = signal_store
+		# CTX-02/D-02: the handler now OWNS its signal-store init from
+		# (environment, sql_engine), mirroring the PortfolioHandler template
+		# (LR-13). `SignalStorageFactory.create('backtest', backend=None)` returns
+		# the same `InMemorySignalStore` concrete the legacy path built, so the
+		# backtest slice is byte-exact. An explicit `signal_store=` override still
+		# wins (back-compat with the current positional compose call until 02-03).
+		# `.signal_store` is the concrete `compose_engine` reads back onto the
+		# Engine holder in plan 02-03.
+		self.signal_store: SignalStore = (
+			signal_store or SignalStorageFactory.create(environment, backend=sql_engine)
+		)
 		# SHORT-01/D-07 two-flag registration gate — read, never mutated here.
 		self._allow_short_selling: bool = allow_short_selling
 		self._enable_margin: bool = enable_margin

--- a/itrader/strategy_handler/strategies_handler.py
+++ b/itrader/strategy_handler/strategies_handler.py
@@ -12,6 +12,7 @@ from itrader.strategy_handler.base import Strategy
 from itrader.strategy_handler.pair_base import PairStrategy
 from itrader.strategy_handler.signal_record import SignalRecord
 from itrader.strategy_handler.storage import SignalStorageFactory, SignalStore
+from itrader.events_handler.bus import EventBus
 from itrader.events_handler.events import (
 	BarEvent,
 	BarsLoaded,
@@ -38,7 +39,7 @@ class StrategiesHandler(object):
 
 	def __init__(
 		self,
-		global_queue: "Queue[Any]",
+		global_queue: "EventBus",
 		feed: BarFeed,
 		signal_store: "Optional[SignalStore]" = None,
 		allow_short_selling: bool = False,
@@ -74,7 +75,7 @@ class StrategiesHandler(object):
 			default ``max_leverage == 1`` this gives fully-collateralized shorts
 			(no leverage); levered shorts are a separate opt-in dial. Defaults off.
 		"""
-		self.global_queue: "Queue[Any]" = global_queue
+		self.global_queue: "EventBus" = global_queue
 		self.feed: BarFeed = feed
 		# CTX-02/D-02: the handler now OWNS its signal-store init from
 		# (environment, sql_engine), mirroring the PortfolioHandler template

--- a/itrader/trading_system/backtest_trading_system.py
+++ b/itrader/trading_system/backtest_trading_system.py
@@ -6,11 +6,13 @@ existing import sites to the new name, so no backward-compat ``TradingSystem``
 alias is exported from this module.
 
 D-04: the factory builds, the class is a thin holder. ``build_backtest_system(spec)``
-selects the mode-specific backends (``OrderStorageFactory.create('backtest')`` +
-the backtest signal store, D-14a), derives the COMPLETE symbol set and folds it
-into the spec's ``ExchangeConfig`` (D-13/Trap 1), calls ``compose_engine``,
-constructs the ``BacktestRunner``, adds strategies/portfolios in spec order
-(Trap 6), wires subscriptions, and returns the holder.
+derives the COMPLETE symbol set and folds it into the spec's ``ExchangeConfig``
+(D-13/Trap 1), builds the infra ``EngineContext(bus=FifoEventBus(),
+environment='backtest', sql_engine=None)`` (02-03/D-06), calls the two-arg
+``compose_engine`` seam, constructs the ``BacktestRunner``, adds
+strategies/portfolios in spec order (Trap 6), wires subscriptions, and returns the
+holder. The handlers now OWN their order/signal storage backends (selected from
+``ctx.environment``, 02-02), so the factory no longer selects those concretes.
 
 The holder keeps a direct-construction ``__init__`` (legacy loose params) that
 builds the same engine+runner internally, so the oracle/integration sites work
@@ -21,6 +23,7 @@ delegates to the runner then lifts the metrics printout into ``reporting``
 Indentation: TABS (``trading_system/`` package convention).
 """
 
+import dataclasses
 from pathlib import Path
 from typing import Any, Callable, Optional
 
@@ -29,7 +32,7 @@ import pandas as pd
 from itrader import config, idgen
 from itrader.config import ExchangeConfig, OrderConfig, get_exchange_preset
 from itrader.core.exceptions import ConfigurationError
-from itrader.order_handler.storage import OrderStorageFactory
+from itrader.events_handler.bus import FifoEventBus
 from itrader.reporting.frames import build_equity_curve, build_trade_log
 from itrader.reporting.summary import print_metrics_summary
 from itrader.results.records import PortfolioRecord, RunRecord
@@ -40,10 +43,11 @@ from itrader.results.serializers import (
 	curate_portfolio_params,
 	curate_run_settings,
 )
-from itrader.strategy_handler.storage import SignalStorageFactory, SignalStore
+from itrader.strategy_handler.storage import SignalStore
 from itrader.strategy_handler.signal_record import SignalRecord
 from itrader.trading_system.backtest_runner import BacktestRunner
 from itrader.trading_system.compose import Engine, compose_engine
+from itrader.trading_system.engine_context import EngineContext
 from itrader.trading_system.system_spec import SystemSpec
 
 from itrader.logger import get_itrader_logger
@@ -123,21 +127,39 @@ class BacktestTradingSystem(object):
 			# path the factory uses — replacement-safe (D-13/Trap 1). csv_paths=None
 			# is the single-golden-ticker default, so the seeded set is the preset ∪
 			# {BTCUSD}, byte-identical to the old ExecutionHandler no-config fallback.
-			order_storage = OrderStorageFactory.create('backtest')
-			self._signal_store = SignalStorageFactory.create('backtest')
 			tickers = {str(t).upper() for t in (csv_paths or {}).keys()}
 			exchange_config = _seed_supported_symbols(
 				get_exchange_preset('default'), tickers)
-			self.engine = compose_engine(
-				order_storage=order_storage,
-				signal_store=self._signal_store,
-				csv_paths=csv_paths,
-				start_date=start_date,
-				end_date=end_date or None,
+			# 02-03 (D-06/Pitfall 1): the oracle runs through THIS spec-LESS legacy
+			# arm, so it is folded to the two-arg compose seam too. Synthesize a
+			# minimal frozen SystemSpec — ticker/starting_cash are PLACEHOLDERS
+			# compose NEVER reads (A1); strategies/portfolios stay empty (the legacy
+			# sites add them via the backward-compat handler seams). The seeded
+			# ExchangeConfig rides on spec.exchange. Empties map back to None inside
+			# compose, byte-identical to the old csv_paths=None / start/end kwargs.
+			spec = SystemSpec(
+				start=start_date or '',
+				end=end_date or '',
 				timeframe=timeframe,
-				exchange_config=exchange_config,
-				order_config=OrderConfig.default(),
+				ticker='BTCUSD',
+				starting_cash=0,
+				data=csv_paths or {},
+				strategies=[],
+				portfolios=[],
+				exchange=exchange_config,
 			)
+			# The handler now OWNS its bus (FifoEventBus — byte-exact FIFO, D-07) and
+			# its storage (from environment='backtest'); config is carried, sql_engine
+			# is None (SQL-import-inert, GATE-01).
+			ctx = EngineContext(
+				bus=FifoEventBus(),
+				config=config,
+				environment='backtest',
+				sql_engine=None,
+			)
+			self.engine = compose_engine(ctx, spec)
+			# Read the handler-owned signal store back off the engine (02-02/02-03).
+			self._signal_store = self.engine.signal_store
 			self.runner = BacktestRunner(self.engine)
 
 		self.logger.info('Trading system initialised')
@@ -401,50 +423,43 @@ class BacktestTradingSystem(object):
 def build_backtest_system(spec: SystemSpec) -> BacktestTradingSystem:
 	"""Build a backtest system from a declarative ``SystemSpec`` (D-04).
 
-	The FACTORY (D-14a): selects the mode-specific backends
-	(``OrderStorageFactory.create('backtest')`` + the backtest signal store),
-	derives the COMPLETE supported-symbol set from the spec data keys (∪ default
-	preset ∪ {BTCUSD}) and folds it into the spec's ``ExchangeConfig``
-	(D-13/Trap 1), calls the shared ``compose_engine`` seam with those concretes,
-	constructs the ``BacktestRunner``, adds strategies/portfolios in SPEC ORDER
-	(Trap 6 — preserve ``get_active_portfolios`` insertion order), wires the
-	portfolio subscriptions, and returns the thin holder.
+	The FACTORY (D-14a): derives the COMPLETE supported-symbol set from the spec
+	data keys (∪ default preset ∪ {BTCUSD}) and folds it into the spec's
+	``ExchangeConfig`` (D-13/Trap 1), builds the infra ``EngineContext`` (a fresh
+	``FifoEventBus`` + ``environment='backtest'`` + ``sql_engine=None``, 02-03/D-06),
+	calls the shared two-arg ``compose_engine`` seam, constructs the
+	``BacktestRunner``, adds strategies/portfolios in SPEC ORDER (Trap 6 — preserve
+	``get_active_portfolios`` insertion order), wires the portfolio subscriptions,
+	and returns the thin holder. The handlers OWN their order/signal storage
+	backends now (selected from ``ctx.environment``, 02-02).
 	"""
-	# 1. Mode-specific backend selection (D-14a) — lives in the FACTORY.
-	order_storage = OrderStorageFactory.create('backtest')
-	signal_store = SignalStorageFactory.create('backtest')
-
-	# 2. Complete symbol-set seeding (D-13/Trap 1): default preset ∪ {BTCUSD} ∪
+	# 1. Complete symbol-set seeding (D-13/Trap 1): default preset ∪ {BTCUSD} ∪
 	#    spec data tickers, folded into the spec's ExchangeConfig BEFORE the
-	#    exchange reads it (replacement-safe construction-time seeding).
+	#    exchange reads it (replacement-safe construction-time seeding). SystemSpec
+	#    is frozen, so the seeded exchange rides back onto the spec via
+	#    ``dataclasses.replace`` — compose reads ``spec.exchange`` (02-03 A1). The
+	#    handlers now OWN their storage backends (from environment='backtest'), so
+	#    the factory no longer selects order/signal storage concretes here (02-02).
 	exchange_config = spec.exchange if spec.exchange is not None else get_exchange_preset('default')
 	tickers = {str(t) for t in spec.data.keys()}
 	exchange_config = _seed_supported_symbols(exchange_config, tickers)
+	spec = dataclasses.replace(spec, exchange=exchange_config)
 
-	# 3. Wire the graph mode-agnostically through the shared seam. The results
-	#    store is passed straight through from the spec (D-04/D-19, GATE-01): it is
-	#    commonly None, so the oracle path stays store-free AND SQL-import-inert —
-	#    this module imports NO SQL surface at top level. A persistence caller builds
-	#    the store DIRECTLY (NO factory, D-19) and injects it on the spec, e.g.
-	#    ``SqlResultsStore(SqlBackend(SqlSettings.results_default()),
+	# 2. Wire the graph mode-agnostically through the shared two-arg seam. compose
+	#    reads the OPTIONAL results store off the spec via getattr (D-04/D-19,
+	#    GATE-01): commonly None, so the oracle path stays store-free AND
+	#    SQL-import-inert — this module imports NO SQL surface at top level. A
+	#    persistence caller builds the store DIRECTLY (NO factory, D-19) and injects
+	#    it on the spec, e.g. ``SqlResultsStore(SqlBackend(SqlSettings.results_default()),
 	#    strict_persist=SqlSettings.results_default().strict_persist)`` with the SQL
 	#    surface imported on THAT path only — never here.
-	#
-	#    ``getattr`` (NOT ``spec.results_store``): the e2e harness duck-types its own
-	#    ``ScenarioSpec`` (no ``results_store`` field) into this factory by name, so a
-	#    hard attribute read would break it. Absent → None → store-free / byte-exact.
-	results_store = getattr(spec, "results_store", None)
-	engine = compose_engine(
-		order_storage=order_storage,
-		signal_store=signal_store,
-		csv_paths=spec.data,
-		start_date=spec.start,
-		end_date=spec.end or None,
-		timeframe=spec.timeframe,
-		exchange_config=exchange_config,
-		order_config=OrderConfig.default(),
-		results_store=results_store,
+	ctx = EngineContext(
+		bus=FifoEventBus(),
+		config=config,
+		environment='backtest',
+		sql_engine=None,
 	)
+	engine = compose_engine(ctx, spec)
 	runner = BacktestRunner(engine)
 
 	# 4. Add strategies/portfolios in SPEC ORDER (Trap 6 — get_active_portfolios
@@ -474,4 +489,4 @@ def build_backtest_system(spec: SystemSpec) -> BacktestTradingSystem:
 			strategy.subscribe_portfolio(pid)
 
 	return BacktestTradingSystem(
-		engine=engine, runner=runner, signal_store=signal_store)
+		engine=engine, runner=runner, signal_store=engine.signal_store)

--- a/itrader/trading_system/compose.py
+++ b/itrader/trading_system/compose.py
@@ -168,7 +168,7 @@ def compose_engine(ctx: "EngineContext", spec: "SystemSpec") -> Engine:
 
 	# ScreenersHandler is a deferred subsystem (ignore_errors override).
 	screeners_handler = ScreenersHandler(ctx.bus, feed)  # type: ignore[no-untyped-call]
-	portfolio_handler = PortfolioHandler(ctx.bus)
+	portfolio_handler = PortfolioHandler(ctx.bus, environment=ctx.environment, backend=ctx.sql_engine)
 
 	# Execution handler is constructed BEFORE the order handler so the admission
 	# gate's commission estimator can adapt the simulated exchange's fee model

--- a/itrader/trading_system/compose.py
+++ b/itrader/trading_system/compose.py
@@ -27,18 +27,16 @@ capture would silently use the wrong estimator. The golden run pins fees 0
 Indentation: TABS (``trading_system/`` package convention).
 """
 
-import queue
 from dataclasses import dataclass
 from decimal import Decimal
-from pathlib import Path
 from typing import Any, Optional
 
 from itrader.core.clock import BacktestClock
-from itrader.config import ExchangeConfig, OrderConfig
+from itrader.config import OrderConfig
+from itrader.events_handler.bus import EventBus
 from itrader.events_handler.full_event_handler import EventHandler
 from itrader.execution_handler.execution_handler import ExecutionHandler
 from itrader.execution_handler.exchanges.simulated import SimulatedExchange
-from itrader.order_handler.base import OrderStorage
 from itrader.order_handler.order_handler import OrderHandler
 from itrader.outils.time_parser import to_timedelta
 from itrader.portfolio_handler.portfolio_handler import PortfolioHandler
@@ -48,7 +46,9 @@ from itrader.results import ResultsStore
 from itrader.screeners_handler.screeners_handler import ScreenersHandler
 from itrader.strategy_handler.storage import SignalStore
 from itrader.strategy_handler.strategies_handler import StrategiesHandler
+from itrader.trading_system.engine_context import EngineContext
 from itrader.trading_system.simulation.time_generator import TimeGenerator
+from itrader.trading_system.system_spec import SystemSpec
 from itrader.universe import Universe
 
 
@@ -89,7 +89,7 @@ class Engine:
 	downstream session-setup / run-loop ordering stays byte-exact (Trap 4/6).
 	"""
 
-	global_queue: "queue.Queue[Any]"
+	global_queue: "EventBus"
 	clock: BacktestClock
 	store: CsvPriceStore
 	feed: BacktestBarFeed
@@ -113,55 +113,45 @@ class Engine:
 	results_store: Optional[ResultsStore] = None
 
 
-def compose_engine(
-	*,
-	order_storage: OrderStorage,
-	signal_store: SignalStore,
-	csv_paths: Optional[dict[str, "str | Path"]] = None,
-	start_date: Optional[str] = None,
-	end_date: Optional[str] = None,
-	timeframe: str = "1d",
-	exchange_config: Optional[ExchangeConfig] = None,
-	order_config: Optional[OrderConfig] = None,
-	results_store: Optional[ResultsStore] = None,
-) -> Engine:
-	"""Wire the shared component graph mode-agnostically (D-14/D-14a).
+def compose_engine(ctx: "EngineContext", spec: "SystemSpec") -> Engine:
+	"""Wire the shared component graph from an infra ``ctx`` + a declarative ``spec`` (D-01/D-04).
 
-	The mode-specific concretes (``order_storage``, ``signal_store``, the
-	symbol-seeded ``exchange_config``) are SELECTED BY THE FACTORY and passed in
-	— this seam never names a run mode (no backend-string literal, D-14a). The
-	wiring body is
-	extracted verbatim (re-ordered to nothing) from
-	``BacktestTradingSystem.__init__`` so the constructed graph is byte-identical.
+	End-state two-arg seam (CTX-01/D-01): the shared event transport is
+	``ctx.bus`` (the internal FIFO buffer the seam used to construct is DELETED —
+	the composition root owns the bus now), and the run-mode infra knobs
+	(``ctx.environment`` / ``ctx.sql_engine``) select the handler-OWNED storage
+	backends. The declarative ``spec`` supplies the WHAT-to-run inputs (D-02).
+
+	A1 spec-read constraint (D-04): the body reads ONLY the six permitted spec
+	fields — ``data`` / ``start`` / ``end`` / ``timeframe`` / ``exchange`` /
+	``results_store`` (empties mapped to ``None``) — it NEVER reads the
+	ticker / starting_cash / strategies / portfolios fields (the legacy arm passes
+	placeholders for those). The ``order_config`` stays handler-owned
+	(``OrderConfig.default()``, D-04 lean).
 
 	Parameters
 	----------
-	order_storage : OrderStorage
-		The mode-specific order-mirror backend selected by the factory (D-14a).
-	signal_store : SignalStore
-		The mode-specific signal-store sink selected by the factory (D-14a).
-	csv_paths : dict[str, str | Path], optional
-		Ticker -> CSV path; passes straight through to ``CsvPriceStore`` (the
-		Phase-3 multi-ticker injection seam). None falls back to the
-		single-golden-ticker default — byte-identical to today.
-	start_date, end_date : str, optional
-		Run window bounds threaded to the store.
-	timeframe : str
-		The feed's base timeframe (default ``"1d"``).
-	exchange_config : ExchangeConfig, optional
-		Construction-time exchange config whose ``limits.supported_symbols``
-		already carries the COMPLETE set (default preset ∪ {BTCUSD} ∪ spec
-		tickers — D-13/Trap 1). None lets the ExecutionHandler build its
-		TEMPORARY default-preset ∪ {BTCUSD} backward-compat config.
-	order_config : OrderConfig, optional
-		Order-domain config (``market_execution``). None defaults to
-		``OrderConfig.default()`` ("immediate").
-	results_store : ResultsStore, optional
-		The OPTIONAL results sink selected by the FACTORY (D-14a) and forwarded
-		onto the ``Engine`` unchanged — this seam never constructs one. None
-		(the default) keeps the run store-free / byte-exact (D-04).
+	ctx : EngineContext
+		The frozen infra bundle: ``bus`` (the shared transport injected into every
+		handler + the ``Engine`` holder), ``config`` (carried, unread until P9),
+		``environment`` (selects handler-owned storage backends), ``sql_engine``
+		(``None`` for backtest — keeps the path SQL-import-inert, GATE-01).
+	spec : SystemSpec
+		The declarative run description. Only the six A1 fields are read here; the
+		FACTORY (never this seam) reads the strategies / portfolios fields (Trap 6).
+		``spec.exchange`` is an already-seeded ``ExchangeConfig`` by the time compose
+		is called (both arms seed it, D-13/Trap 1).
 	"""
-	global_queue: "queue.Queue[Any]" = queue.Queue()
+	# A1 kwargs->spec fold (D-04): map only the six permitted fields, empties->None
+	# so today's exact values are preserved byte-identically.
+	csv_paths = spec.data or None
+	start_date = spec.start or None
+	end_date = spec.end or None
+	timeframe = spec.timeframe
+	exchange_config = spec.exchange
+	# getattr (NOT spec.results_store): the e2e ScenarioSpec is duck-typed into
+	# this seam by name and has no such field — absent -> None -> store-free/byte-exact.
+	results_store = getattr(spec, "results_store", None)
 
 	# Determinism seam (D-09/D-10): the injected BacktestClock staged on the
 	# determinism seam (no domain consumer yet — result determinism comes from
@@ -177,14 +167,14 @@ def compose_engine(
 	feed = BacktestBarFeed(store, to_timedelta(timeframe))
 
 	# ScreenersHandler is a deferred subsystem (ignore_errors override).
-	screeners_handler = ScreenersHandler(global_queue, feed)  # type: ignore[no-untyped-call]
-	portfolio_handler = PortfolioHandler(global_queue)
+	screeners_handler = ScreenersHandler(ctx.bus, feed)  # type: ignore[no-untyped-call]
+	portfolio_handler = PortfolioHandler(ctx.bus)
 
 	# Execution handler is constructed BEFORE the order handler so the admission
 	# gate's commission estimator can adapt the simulated exchange's fee model
 	# (D-04). The construction-time ExchangeConfig threads the complete symbol
 	# set (D-13). Construction-order only — runtime stays queue-mediated.
-	execution_handler = ExecutionHandler(global_queue, exchange_config=exchange_config)
+	execution_handler = ExecutionHandler(ctx.bus, exchange_config=exchange_config)
 
 	# Commission estimator for the admission cash-reservation gate (D-04/D-15):
 	# the typed FeeModelCommissionEstimator adapter holds the exchange ref and
@@ -203,34 +193,43 @@ def compose_engine(
 	# builds it after this construction).
 	trading_rules = portfolio_handler.config_data.trading_rules
 
-	# Signal-store sink (read-model): one SignalRecord per non-None intent,
-	# read post-run; the queue-only contract is preserved (handler writes
-	# locally, the holder reads after the run). The backend is selected by the
-	# FACTORY and injected (D-14a) — the seam never names a run mode.
+	# Signal-store sink (read-model): the handler now OWNS its signal-store init
+	# from (environment, sql_engine) (CTX-02/02-02) — NOT injected here. The
+	# `.signal_store` concrete is read back off the handler below for the Engine
+	# holder; the queue-only contract is preserved (handler writes locally, the
+	# holder reads after the run).
 	#
 	# SHORT-01/D-07: thread the two shorts-enabling flags from trading_rules into
 	# the registration gate. Constructed AFTER the trading_rules binding so the
 	# flags are available; both default off → SMA_MACD (LONG_ONLY) stays admitted
 	# and the oracle stays byte-exact.
 	strategies_handler = StrategiesHandler(
-		global_queue, feed, signal_store,
+		ctx.bus, feed,
 		allow_short_selling=trading_rules.allow_short_selling,
-		enable_margin=trading_rules.enable_margin)
+		enable_margin=trading_rules.enable_margin,
+		environment=ctx.environment,
+		sql_engine=ctx.sql_engine)
 
-	resolved_order_config = order_config or OrderConfig.default()
+	# order_config stays handler-owned (D-04 lean, P1 D-03) — never a spec field.
+	resolved_order_config = OrderConfig.default()
+	# The order handler OWNS its storage init from (environment, sql_engine)
+	# (CTX-02/02-02) — NOT injected here; `.storage` is read back below.
 	order_handler = OrderHandler(
-		global_queue, portfolio_handler, order_storage,
+		ctx.bus, portfolio_handler,
 		order_config=resolved_order_config,
 		commission_estimator=commission_estimator,
 		enable_margin=trading_rules.enable_margin,
-		portfolio_max_leverage=trading_rules.max_leverage)
+		portfolio_max_leverage=trading_rules.max_leverage,
+		environment=ctx.environment,
+		sql_engine=ctx.sql_engine)
 
-	# LIQ-03 (04-03): inject the SAME order_storage instance into the portfolio
-	# handler so the BAR-route liquidation forced-close registers its real Order
-	# in the exact mirror the ReconcileManager reads (the set_order_storage
-	# write-seam, the analog of set_universe). Construction-time injection —
-	# order_storage exists at construction, so no Trap-4 timing is needed.
-	# Oracle-dark: with no breaches the seam is never written, SMA_MACD byte-exact.
+	# Read the handler-owned storage back for wiring (02-03). The SAME
+	# order_storage instance is injected into the portfolio handler so the
+	# BAR-route liquidation forced-close registers its real Order in the exact
+	# mirror the ReconcileManager reads (the set_order_storage write-seam, the
+	# analog of set_universe). Oracle-dark: with no breaches the seam is never
+	# written, SMA_MACD byte-exact.
+	order_storage = order_handler.storage
 	portfolio_handler.set_order_storage(order_storage)
 
 	time_generator = TimeGenerator()
@@ -242,15 +241,15 @@ def compose_engine(
 		order_handler,
 		execution_handler,
 		feed.generate_bar_event,
-		global_queue
+		ctx.bus
 	)
 
 	return Engine(
-		global_queue=global_queue,
+		global_queue=ctx.bus,
 		clock=clock,
 		store=store,
 		feed=feed,
-		signal_store=signal_store,
+		signal_store=strategies_handler.signal_store,
 		strategies_handler=strategies_handler,
 		screeners_handler=screeners_handler,
 		portfolio_handler=portfolio_handler,

--- a/itrader/trading_system/engine_context.py
+++ b/itrader/trading_system/engine_context.py
@@ -1,0 +1,59 @@
+"""The frozen ``EngineContext`` infra bundle threaded into ``compose_engine`` (BUS-04/D-05).
+
+``EngineContext`` is the small, mode-agnostic INFRASTRUCTURE bundle the composition
+root hands to ``compose_engine(ctx, spec)`` (CTX-01/D-01). It carries the shared
+event-bus transport plus the run-mode infra knobs (``config`` / ``environment`` /
+``sql_engine``) — the WHAT-to-run description lives on the separate ``SystemSpec``
+(D-02). The two-object split keeps the seam honest: infra on ``ctx``, declarative
+run description on ``spec``.
+
+Design invariants (D-05, LR-14):
+
+* **Exactly four fields, in order** — ``bus`` / ``config`` / ``environment`` /
+  ``sql_engine``. P3/P4/P9 only TIGHTEN the loose types (``config: Any`` narrows to
+  the concrete ``SystemConfig`` in P9, ``sql_engine: Optional[Any]`` narrows to the
+  SQL engine type once the live seam lands) — they NEVER widen a type and NEVER add
+  a field. The shape is frozen here.
+* **Infra-only.** ``bus`` is the transport, ``config`` is carried but UNREAD on the
+  backtest path until P9, ``environment`` selects handler-owned storage backends,
+  ``sql_engine`` is ``None`` for backtest (keeps the path SQL-import-inert, GATE-01).
+* **Import-inert.** Only stdlib + the ``EventBus`` Protocol from
+  ``events_handler.bus`` are pulled (bus.py imports only stdlib + ``core.enums.event``,
+  so there is no import cycle). If a cycle ever appears, fall back to a
+  ``TYPE_CHECKING``-only import of ``EventBus`` and annotate the field ``"EventBus"``.
+
+Indentation: TABS (``trading_system/`` package convention).
+"""
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from itrader.events_handler.bus import EventBus
+
+
+@dataclass(frozen=True)
+class EngineContext:
+	"""Frozen infra bundle handed to ``compose_engine(ctx, spec)`` (D-05).
+
+	Parameters
+	----------
+	bus : EventBus
+		The shared event transport (``FifoEventBus`` for backtest, byte-exact;
+		``PriorityEventBus`` is a live-only fast-follow — never wired here, D-11).
+	config : Any
+		The process ``SystemConfig`` carried through composition. Loose-typed
+		``Any`` deliberately (D-05): it is CARRIED but UNREAD on the backtest path
+		until P9 tightens it to the concrete ``SystemConfig``.
+	environment : str
+		The run-mode selector (``"backtest"`` here) the handlers use to pick their
+		own storage backends (CTX-02 handler-owned storage).
+	sql_engine : Optional[Any]
+		The durable SQL engine handle, ``None`` for backtest — keeps the backtest
+		path SQL-import-inert (GATE-01). Loose ``Optional[Any]`` until the live seam
+		narrows it (D-05).
+	"""
+
+	bus: EventBus
+	config: Any
+	environment: str
+	sql_engine: Optional[Any] = None

--- a/tests/integration/test_okx_inertness.py
+++ b/tests/integration/test_okx_inertness.py
@@ -89,6 +89,26 @@ assert "sql" not in _cfg.__dict__, (
     "cached_property resolved) — it must be lazy-constructed on first access only"
 )
 
+# Phase 2 (02-03, register-vs-build inertness): constructing the backtest bus +
+# EngineContext(sql_engine=None) must REGISTER without BUILDING a heavy backend.
+# FifoEventBus wraps a stdlib queue; EngineContext is a frozen infra dataclass —
+# neither may pull SQLAlchemy/ccxt, and building the ctx must NOT resolve the lazy
+# `sql` cached_property on the config singleton (closes the recurring eager-SQL
+# import failure mode, GATE-01 lineage).
+from itrader.events_handler.bus import FifoEventBus
+from itrader.trading_system.engine_context import EngineContext
+_bus = FifoEventBus()
+_ctx = EngineContext(bus=_bus, config=_cfg, environment="backtest", sql_engine=None)
+_heavy = [name for name in ("sqlalchemy", "ccxt") if name in sys.modules]
+assert not _heavy, (
+    "P2 register-vs-build inertness violation: constructing FifoEventBus/"
+    "EngineContext(sql_engine=None) pulled a heavy backend: " + repr(_heavy)
+)
+assert "sql" not in _cfg.__dict__, (
+    "P2 register-vs-build inertness violation: building the EngineContext resolved "
+    "the lazy `sql` cached_property on the config singleton (must stay unbuilt)"
+)
+
 print("INERTNESS_OK")
 """
 

--- a/tests/unit/events/test_event_bus.py
+++ b/tests/unit/events/test_event_bus.py
@@ -1,0 +1,175 @@
+"""BUS-01/BUS-02/BUS-03 proof suite for the event-bus substrate (Plan 02-01).
+
+Pure stdlib, no data load. Proves:
+* BUS-01 — both buses satisfy the ``EventBus`` runtime_checkable Protocol,
+  round-trip a put/get, and raise ``queue.Empty`` on empty.
+* BUS-02 — ``PriorityEventBus`` dequeues CONTROL before BUSINESS while
+  preserving strict within-tier FIFO; ``get*()`` returns a bare ``Event``
+  (never the tuple); events are never compared (bare ``event < event`` raises
+  ``TypeError`` — proving the shared ``seq`` guarantee is load-bearing).
+* BUS-03 — the three new CONTROL ``EventType`` members are enumerated in
+  ``_CONTROL_EVENT_TYPES`` and tier to CONTROL; BUSINESS is the default.
+"""
+
+import queue
+
+import msgspec
+import pytest
+
+from itrader.core.enums.event import EventType
+from itrader.events_handler.bus import (
+    EventBus,
+    EventTier,
+    FifoEventBus,
+    PriorityEventBus,
+    _CONTROL_EVENT_TYPES,
+    _tier,
+)
+
+
+class _StubEvent(msgspec.Struct, frozen=True, kw_only=True, gc=False):
+    """Minimal non-orderable event carrying a ``type`` — mirrors the real
+    ``Event`` (a frozen ``msgspec.Struct``) which raises ``TypeError`` on ``<``.
+    ``tag`` distinguishes instances for FIFO-order assertions.
+    """
+
+    type: EventType
+    tag: int = 0
+
+
+def _bar(tag: int = 0) -> _StubEvent:
+    return _StubEvent(type=EventType.BAR, tag=tag)
+
+
+def _control(tag: int = 0) -> _StubEvent:
+    return _StubEvent(type=EventType.CONFIG_UPDATE, tag=tag)
+
+
+# --------------------------------------------------------------------------- #
+# BUS-01 — Protocol conformance + drain contract
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("bus_cls", [FifoEventBus, PriorityEventBus])
+def test_bus_satisfies_protocol(bus_cls):
+    bus = bus_cls()
+    assert isinstance(bus, EventBus)
+
+
+@pytest.mark.parametrize("bus_cls", [FifoEventBus, PriorityEventBus])
+def test_bus_put_get_roundtrips_same_object(bus_cls):
+    bus = bus_cls()
+    event = _bar(tag=7)
+    bus.put(event)
+    got = bus.get_nowait()
+    assert got is event  # SAME object round-trips, not a tuple/copy
+    assert got.type is EventType.BAR
+
+
+@pytest.mark.parametrize("bus_cls", [FifoEventBus, PriorityEventBus])
+def test_get_nowait_raises_empty_on_empty(bus_cls):
+    bus = bus_cls()
+    with pytest.raises(queue.Empty):
+        bus.get_nowait()
+
+
+@pytest.mark.parametrize("bus_cls", [FifoEventBus, PriorityEventBus])
+def test_bus_reports_expected_types(bus_cls):
+    bus = bus_cls()
+    assert bus.empty() is True
+    assert bus.qsize() == 0
+    bus.put(_bar())
+    assert bus.empty() is False
+    assert bus.qsize() == 1
+    depth = bus.depth_by_tier()
+    assert isinstance(depth, dict)
+    assert all(isinstance(k, EventTier) for k in depth)
+    assert all(isinstance(v, int) for v in depth.values())
+
+
+def test_fifo_is_tierless_single_bucket():
+    bus = FifoEventBus()
+    bus.put(_bar())
+    bus.put(_control())
+    # FIFO is tierless — one BUSINESS bucket, monitoring-only.
+    assert bus.depth_by_tier() == {EventTier.BUSINESS: 2}
+
+
+# --------------------------------------------------------------------------- #
+# BUS-02 — priority ordering, bare-event unwrap, non-orderability
+# --------------------------------------------------------------------------- #
+
+def test_priority_control_preempts_business_then_fifo():
+    bus = PriorityEventBus()
+    b1 = _bar(tag=1)
+    b2 = _bar(tag=2)
+    c = _control(tag=99)
+    bus.put(b1)   # BUSINESS
+    bus.put(b2)   # BUSINESS
+    bus.put(c)    # CONTROL — enqueued last, must dequeue FIRST
+    assert bus.get_nowait() is c    # CONTROL preempts
+    assert bus.get_nowait() is b1   # then strict within-tier FIFO
+    assert bus.get_nowait() is b2
+
+
+def test_priority_get_returns_bare_event_not_tuple():
+    bus = PriorityEventBus()
+    bus.put(_bar(tag=5))
+    got = bus.get_nowait()
+    assert isinstance(got, _StubEvent)
+    assert not isinstance(got, tuple)
+    assert got.type is EventType.BAR  # bare Event has .type
+
+
+def test_priority_depth_by_tier_tracks_both_tiers():
+    bus = PriorityEventBus()
+    bus.put(_bar())
+    bus.put(_bar())
+    bus.put(_control())
+    assert bus.depth_by_tier() == {EventTier.CONTROL: 1, EventTier.BUSINESS: 2}
+    bus.get_nowait()  # pops the CONTROL event
+    assert bus.depth_by_tier() == {EventTier.CONTROL: 0, EventTier.BUSINESS: 2}
+
+
+def test_priority_never_compares_events():
+    # The load-bearing invariant: events are non-orderable, so the unique seq
+    # in the (tier, seq, event) tuple is what keeps the heap from ever
+    # comparing two events. A bare comparison MUST raise TypeError.
+    a = _bar(tag=1)
+    b = _bar(tag=2)
+    with pytest.raises(TypeError):
+        a < b  # noqa: B015 — asserting non-orderability, not using the result
+
+
+def test_priority_stable_fifo_under_many_same_tier_puts():
+    bus = PriorityEventBus()
+    events = [_bar(tag=i) for i in range(50)]
+    for e in events:
+        bus.put(e)  # many same-tier puts — must not raise TypeError
+    out = [bus.get_nowait() for _ in range(50)]
+    assert out == events  # strict insertion (FIFO) order preserved
+
+
+# --------------------------------------------------------------------------- #
+# BUS-03 — CONTROL vocabulary + tiering
+# --------------------------------------------------------------------------- #
+
+def test_control_types_include_three_new_members():
+    assert EventType.STREAM_STATE in _CONTROL_EVENT_TYPES
+    assert EventType.CONNECTOR_FATAL in _CONTROL_EVENT_TYPES
+    assert EventType.CONFIG_UPDATE in _CONTROL_EVENT_TYPES
+
+
+def test_control_types_include_strategy_command():
+    assert EventType.STRATEGY_COMMAND in _CONTROL_EVENT_TYPES
+
+
+def test_control_types_tier_to_control():
+    assert _tier(EventType.STREAM_STATE) == EventTier.CONTROL
+    assert _tier(EventType.CONNECTOR_FATAL) == EventTier.CONTROL
+    assert _tier(EventType.CONFIG_UPDATE) == EventTier.CONTROL
+    assert _tier(EventType.STRATEGY_COMMAND) == EventTier.CONTROL
+
+
+def test_control_types_business_is_default():
+    assert _tier(EventType.BAR) == EventTier.BUSINESS
+    assert EventType.BAR not in _CONTROL_EVENT_TYPES

--- a/tests/unit/order/test_order_handler_storage.py
+++ b/tests/unit/order/test_order_handler_storage.py
@@ -1,0 +1,41 @@
+"""Handler-owned storage retrofit for ``OrderHandler`` (CTX-02 / D-02, plan 02-02).
+
+Proves the purely-additive ctor seam: with ``environment='backtest', sql_engine=None``
+the handler owns its storage init and yields the SAME ``InMemoryOrderStorage`` concrete
+the backtest path constructed before (byte-exact oracle preserved). The explicit
+``order_storage=`` override still wins, and the instance exposed on ``.storage`` is the
+exact object forwarded to ``OrderManager`` — the wiring seam ``compose_engine`` reads
+back for ``portfolio_handler.set_order_storage(...)`` in plan 02-03 (D-18 preserved:
+the manager still owns storage for all read paths; ``.storage`` is a wiring read, not a
+second read path).
+"""
+
+import queue
+from unittest.mock import MagicMock
+
+from itrader.order_handler.order_handler import OrderHandler
+from itrader.order_handler.storage.in_memory_storage import InMemoryOrderStorage
+
+
+def test_backtest_slice_yields_in_memory_storage():
+    handler = OrderHandler(
+        queue.Queue(), MagicMock(), environment="backtest", sql_engine=None
+    )
+    assert isinstance(handler.storage, InMemoryOrderStorage)
+
+
+def test_explicit_order_storage_override_wins():
+    explicit = InMemoryOrderStorage()
+    handler = OrderHandler(queue.Queue(), MagicMock(), order_storage=explicit)
+    assert handler.storage is explicit
+
+
+def test_storage_is_the_instance_forwarded_to_order_manager():
+    # Wiring-seam identity: `.storage` MUST be the exact object the manager owns,
+    # because compose_engine (plan 02-03) reads `.storage` back to wire
+    # portfolio_handler.set_order_storage(...). Prove it with an explicit sentinel
+    # so the assertion holds regardless of the factory's construction path.
+    explicit = InMemoryOrderStorage()
+    handler = OrderHandler(queue.Queue(), MagicMock(), order_storage=explicit)
+    assert handler.storage is handler.order_manager.order_storage
+    assert handler.order_manager.order_storage is explicit

--- a/tests/unit/strategy/test_strategies_handler_storage.py
+++ b/tests/unit/strategy/test_strategies_handler_storage.py
@@ -1,0 +1,28 @@
+"""Handler-owned signal-store retrofit for ``StrategiesHandler`` (CTX-02 / D-02, plan 02-02).
+
+Proves the purely-additive ctor seam: with ``environment='backtest', sql_engine=None``
+(and no ``signal_store`` passed) the handler owns its signal-store init and yields the
+SAME ``InMemorySignalStore`` concrete the backtest path built before (byte-exact oracle
+preserved). An explicit ``signal_store=`` override still wins — the concrete exposed on
+``.signal_store`` is the object ``compose_engine`` reads back onto the Engine holder in
+plan 02-03.
+"""
+
+import queue
+from unittest.mock import MagicMock
+
+from itrader.strategy_handler.storage.in_memory_storage import InMemorySignalStore
+from itrader.strategy_handler.strategies_handler import StrategiesHandler
+
+
+def test_backtest_slice_yields_in_memory_signal_store():
+    handler = StrategiesHandler(
+        queue.Queue(), MagicMock(), environment="backtest", sql_engine=None
+    )
+    assert isinstance(handler.signal_store, InMemorySignalStore)
+
+
+def test_explicit_signal_store_override_wins():
+    explicit = InMemorySignalStore()
+    handler = StrategiesHandler(queue.Queue(), MagicMock(), signal_store=explicit)
+    assert handler.signal_store is explicit


### PR DESCRIPTION
This pull request updates the project planning and tracking documentation to mark Phase 2 ("Event Bus") as complete and to reflect the advancement of several requirements and plans from Phase 3 into Phase 2. The documentation now shows that the two-tier EventBus infrastructure, handler-owned storage, and the new EngineContext signature have all shipped, and the project is moving into Phase 3, which now only contains the `SqlBackend→SqlEngine` rename. All relevant status tables, checklists, and summaries have been updated to reflect these changes.

**Phase 2 completion and documentation updates:**

- Marked all Phase 2 Event Bus requirements (BUS-01 to BUS-04) and the EngineContext/handler-owned storage requirements (CTX-01 to CTX-03) as complete in `.planning/REQUIREMENTS.md` and `.planning/ROADMAP.md` [[1]](diffhunk://#diff-67371e9d153097459f183a0e7ea40fa2bbfb96749f61cf91d0ffbb145a7b88d9L62-R96) [[2]](diffhunk://#diff-67371e9d153097459f183a0e7ea40fa2bbfb96749f61cf91d0ffbb145a7b88d9L357-R369) [[3]](diffhunk://#diff-50b07cc2a4b37b50419fd3b063aea1f5d1fe2a2b90a47254943677108d0008bbL103-R103) [[4]](diffhunk://#diff-50b07cc2a4b37b50419fd3b063aea1f5d1fe2a2b90a47254943677108d0008bbL143-R174).
- Updated `.planning/PROJECT.md` to summarize the delivery of the EventBus protocol (with both FIFO and Priority implementations), new CONTROL EventTypes, the frozen EngineContext, and the end-state `compose_engine(ctx, spec)` signature, with verification and advisory notes.

**Project state and progress tracking:**

- Updated `.planning/STATE.md` to advance the current phase to Phase 3, update the completed phases and plans count, and provide detailed log entries for all three Phase 2 plans and their outcomes [[1]](diffhunk://#diff-10c47d0e33270cc4a979d56198376cf3a9df6cc3a3c397ef7d5131afda869b40L5-R17) [[2]](diffhunk://#diff-10c47d0e33270cc4a979d56198376cf3a9df6cc3a3c397ef7d5131afda869b40L29-R39) [[3]](diffhunk://#diff-10c47d0e33270cc4a979d56198376cf3a9df6cc3a3c397ef7d5131afda869b40R131-R136) [[4]](diffhunk://#diff-10c47d0e33270cc4a979d56198376cf3a9df6cc3a3c397ef7d5131afda869b40R195-R197) [[5]](diffhunk://#diff-10c47d0e33270cc4a979d56198376cf3a9df6cc3a3c397ef7d5131afda869b40L200-R213).
- Updated the roadmap and requirements tables to show Phase 2 as complete, including the number of completed plans and the percent progress.

**Phase and requirement restructuring:**

- Clarified in `.planning/ROADMAP.md` and `.planning/REQUIREMENTS.md` that CTX-01/02/03 were pulled forward into Phase 2, leaving only CTX-04 (the `SqlBackend→SqlEngine` rename) in Phase 3 [[1]](diffhunk://#diff-50b07cc2a4b37b50419fd3b063aea1f5d1fe2a2b90a47254943677108d0008bbL143-R174) [[2]](diffhunk://#diff-67371e9d153097459f183a0e7ea40fa2bbfb96749f61cf91d0ffbb145a7b88d9L62-R96).
- Updated phase goals, requirements, and success criteria to reflect the new structure and the fact that handler-owned storage and the new EngineContext signature are already delivered.

These updates ensure the project documentation accurately reflects the current state, recent accomplishments, and the next steps for the v1.8 milestone.