### PR TITLE
V1.8/phase 6.1 seam cleanup

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -105,7 +105,7 @@ below, not strict numeric order (P4 waits on P3; P5 on P2+P3; P6 on P4+P5; etc.)
 - [x] **Phase 4: Storage Schema: Migrations Relocation + New Durable Stores** - `migrations/` → project root FIRST, then `SystemStore`/`VenueStore`/`StrategyRegistryStore` chained on the `HaltRecordStore` template; single-head + parity Alembic gate over the FULL chain + rehydrate (SQL-01..02, STORE-01..05) (completed 2026-07-09)
 - [x] **Phase 5: Venue Registry + Bundle** - Two registries, `VenuePlugin`/`VenueBundle`, precision/validate on the exchange, connector memoization, shared `StreamSupervisor` — kills every `if exchange==` (VENUE-01..07) (completed 2026-07-12)
 - [x] **Phase 6: LiveRunner + Factory + Facade Shrink** - `build_live_system`, `LiveRunner`, shared `UniverseWiring` *(oracle-sensitive)*, `LiveRouteRegistrar`, ~200-line facade, replay-harness→`tests/` (`TestRunner`/`TestLiveDataProvider`; paper→OKX live feed) (RUN-01..07, TEST-01) (completed 2026-07-13)
-- [ ] **Phase 6.1 (INSERTED): Seam Cleanup** - `build_live_system` consumes `compose_engine` (store/feed-agnostic seam, oracle byte-exact), collapse `LiveSystemComponents`, de-dup the `for_exchange` spec-builder, de-lazy the `trading_system` barrel — behavior-preserving, lands before P7 (SEAM-01..04)
+- [x] **Phase 6.1 (INSERTED): Seam Cleanup** - `build_live_system` consumes `compose_engine` (store/feed-agnostic seam, oracle byte-exact), collapse `LiveSystemComponents`, de-dup the `for_exchange` spec-builder, de-lazy the `trading_system` barrel — behavior-preserving, lands before P7 (SEAM-01..04) (completed 2026-07-14)
 - [ ] **Phase 7: Safety + Reconciliation + Stream Recovery** - `SafetyController`, `ReconciliationCoordinator`, `StreamRecoveryHandler`, CONTROL routes, pre-trade throttle — flag machinery deleted (SAFE-01..06)
 - [ ] **Phase 8: Error Subsystem** - Injected `ErrorPolicy`, formalized `ErrorHandler`, two-guard terminal safety, CF-1 aggregate circuit breaker (ERR-01..04)
 - [ ] **Phase 9 ★: Runtime-Config Platform** - `RuntimeConfig` overlay, scoped `ConfigUpdateEvent` + allowlist, restart layering, stats/state UI read-model (RTCFG-01..06)
@@ -406,7 +406,7 @@ P1 and P2 have no dependencies and can start in parallel.
 | 4. Storage Schema: Migrations Relocation + New Durable Stores | v1.8 | 4/4 | Complete    | 2026-07-10 |
 | 5. Venue Registry + Bundle | v1.8 | 6/6 | Complete    | 2026-07-12 |
 | 6. LiveRunner + Factory + Facade Shrink | v1.8 | 7/7 | Complete    | 2026-07-13 |
-| 6.1 (INSERTED). Seam Cleanup | v1.8 | 4/4 | Complete   | 2026-07-14 |
+| 6.1 (INSERTED). Seam Cleanup | v1.8 | 4/4 | Complete    | 2026-07-14 |
 | 7. Safety + Reconciliation + Stream Recovery | v1.8 | 0/TBD | Not started | - |
 | 8. Error Subsystem | v1.8 | 0/TBD | Not started | - |
 | 9 ★. Runtime-Config Platform | v1.8 | 0/TBD | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -298,7 +298,7 @@ Plans:
 
 **Plans**: 4 plans
 
-- [ ] 06.1-01-PLAN.md — SEAM-01: spec-free `compose_engine` + `EngineContext` store/feed seam + backtest pass-through (oracle-gated, isolated) (wave 1)
+- [x] 06.1-01-PLAN.md — SEAM-01: spec-free `compose_engine` + `EngineContext` store/feed seam + backtest pass-through (oracle-gated, isolated) (wave 1)
 - [ ] 06.1-02-PLAN.md — SEAM-01/02: `build_live_system` consumes `compose_engine`; collapse `LiveSystemComponents`; `VenueLifecycle` as the single venue holder; remove interim `Engine` (wave 2)
 - [ ] 06.1-03-PLAN.md — SEAM-03: shared `VenueSpec` builder (one home for the `{'okx':'okx','paper':'okx'}` map); `for_exchange` + `build_live_system` share it (wave 3)
 - [ ] 06.1-04-PLAN.md — SEAM-04: de-lazy the `trading_system` barrel (backtest-only) + hoist the pure imports; inertness backstop (wave 4)
@@ -406,7 +406,7 @@ P1 and P2 have no dependencies and can start in parallel.
 | 4. Storage Schema: Migrations Relocation + New Durable Stores | v1.8 | 4/4 | Complete    | 2026-07-10 |
 | 5. Venue Registry + Bundle | v1.8 | 6/6 | Complete    | 2026-07-12 |
 | 6. LiveRunner + Factory + Facade Shrink | v1.8 | 7/7 | Complete    | 2026-07-13 |
-| 6.1 (INSERTED). Seam Cleanup | v1.8 | 0/TBD | Not started | - |
+| 6.1 (INSERTED). Seam Cleanup | v1.8 | 1/4 | In Progress|  |
 | 7. Safety + Reconciliation + Stream Recovery | v1.8 | 0/TBD | Not started | - |
 | 8. Error Subsystem | v1.8 | 0/TBD | Not started | - |
 | 9 ★. Runtime-Config Platform | v1.8 | 0/TBD | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -300,7 +300,7 @@ Plans:
 
 - [x] 06.1-01-PLAN.md — SEAM-01: spec-free `compose_engine` + `EngineContext` store/feed seam + backtest pass-through (oracle-gated, isolated) (wave 1)
 - [x] 06.1-02-PLAN.md — SEAM-01/02: `build_live_system` consumes `compose_engine`; collapse `LiveSystemComponents`; `VenueLifecycle` as the single venue holder; remove interim `Engine` (wave 2)
-- [ ] 06.1-03-PLAN.md — SEAM-03: shared `VenueSpec` builder (one home for the `{'okx':'okx','paper':'okx'}` map); `for_exchange` + `build_live_system` share it (wave 3)
+- [x] 06.1-03-PLAN.md — SEAM-03: shared `VenueSpec` builder (one home for the `{'okx':'okx','paper':'okx'}` map); `for_exchange` + `build_live_system` share it (wave 3)
 - [ ] 06.1-04-PLAN.md — SEAM-04: de-lazy the `trading_system` barrel (backtest-only) + hoist the pure imports; inertness backstop (wave 4)
 
 ### Phase 7: Safety + Reconciliation + Stream Recovery
@@ -406,7 +406,7 @@ P1 and P2 have no dependencies and can start in parallel.
 | 4. Storage Schema: Migrations Relocation + New Durable Stores | v1.8 | 4/4 | Complete    | 2026-07-10 |
 | 5. Venue Registry + Bundle | v1.8 | 6/6 | Complete    | 2026-07-12 |
 | 6. LiveRunner + Factory + Facade Shrink | v1.8 | 7/7 | Complete    | 2026-07-13 |
-| 6.1 (INSERTED). Seam Cleanup | v1.8 | 2/4 | In Progress|  |
+| 6.1 (INSERTED). Seam Cleanup | v1.8 | 3/4 | In Progress|  |
 | 7. Safety + Reconciliation + Stream Recovery | v1.8 | 0/TBD | Not started | - |
 | 8. Error Subsystem | v1.8 | 0/TBD | Not started | - |
 | 9 ★. Runtime-Config Platform | v1.8 | 0/TBD | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -299,7 +299,7 @@ Plans:
 **Plans**: 4 plans
 
 - [x] 06.1-01-PLAN.md — SEAM-01: spec-free `compose_engine` + `EngineContext` store/feed seam + backtest pass-through (oracle-gated, isolated) (wave 1)
-- [ ] 06.1-02-PLAN.md — SEAM-01/02: `build_live_system` consumes `compose_engine`; collapse `LiveSystemComponents`; `VenueLifecycle` as the single venue holder; remove interim `Engine` (wave 2)
+- [x] 06.1-02-PLAN.md — SEAM-01/02: `build_live_system` consumes `compose_engine`; collapse `LiveSystemComponents`; `VenueLifecycle` as the single venue holder; remove interim `Engine` (wave 2)
 - [ ] 06.1-03-PLAN.md — SEAM-03: shared `VenueSpec` builder (one home for the `{'okx':'okx','paper':'okx'}` map); `for_exchange` + `build_live_system` share it (wave 3)
 - [ ] 06.1-04-PLAN.md — SEAM-04: de-lazy the `trading_system` barrel (backtest-only) + hoist the pure imports; inertness backstop (wave 4)
 
@@ -406,7 +406,7 @@ P1 and P2 have no dependencies and can start in parallel.
 | 4. Storage Schema: Migrations Relocation + New Durable Stores | v1.8 | 4/4 | Complete    | 2026-07-10 |
 | 5. Venue Registry + Bundle | v1.8 | 6/6 | Complete    | 2026-07-12 |
 | 6. LiveRunner + Factory + Facade Shrink | v1.8 | 7/7 | Complete    | 2026-07-13 |
-| 6.1 (INSERTED). Seam Cleanup | v1.8 | 1/4 | In Progress|  |
+| 6.1 (INSERTED). Seam Cleanup | v1.8 | 2/4 | In Progress|  |
 | 7. Safety + Reconciliation + Stream Recovery | v1.8 | 0/TBD | Not started | - |
 | 8. Error Subsystem | v1.8 | 0/TBD | Not started | - |
 | 9 ★. Runtime-Config Platform | v1.8 | 0/TBD | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -301,7 +301,7 @@ Plans:
 - [x] 06.1-01-PLAN.md — SEAM-01: spec-free `compose_engine` + `EngineContext` store/feed seam + backtest pass-through (oracle-gated, isolated) (wave 1)
 - [x] 06.1-02-PLAN.md — SEAM-01/02: `build_live_system` consumes `compose_engine`; collapse `LiveSystemComponents`; `VenueLifecycle` as the single venue holder; remove interim `Engine` (wave 2)
 - [x] 06.1-03-PLAN.md — SEAM-03: shared `VenueSpec` builder (one home for the `{'okx':'okx','paper':'okx'}` map); `for_exchange` + `build_live_system` share it (wave 3)
-- [ ] 06.1-04-PLAN.md — SEAM-04: de-lazy the `trading_system` barrel (backtest-only) + hoist the pure imports; inertness backstop (wave 4)
+- [x] 06.1-04-PLAN.md — SEAM-04: de-lazy the `trading_system` barrel (backtest-only) + hoist the pure imports; inertness backstop (wave 4)
 
 ### Phase 7: Safety + Reconciliation + Stream Recovery
 
@@ -406,7 +406,7 @@ P1 and P2 have no dependencies and can start in parallel.
 | 4. Storage Schema: Migrations Relocation + New Durable Stores | v1.8 | 4/4 | Complete    | 2026-07-10 |
 | 5. Venue Registry + Bundle | v1.8 | 6/6 | Complete    | 2026-07-12 |
 | 6. LiveRunner + Factory + Facade Shrink | v1.8 | 7/7 | Complete    | 2026-07-13 |
-| 6.1 (INSERTED). Seam Cleanup | v1.8 | 3/4 | In Progress|  |
+| 6.1 (INSERTED). Seam Cleanup | v1.8 | 4/4 | Complete   | 2026-07-14 |
 | 7. Safety + Reconciliation + Stream Recovery | v1.8 | 0/TBD | Not started | - |
 | 8. Error Subsystem | v1.8 | 0/TBD | Not started | - |
 | 9 ★. Runtime-Config Platform | v1.8 | 0/TBD | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -296,7 +296,12 @@ Plans:
 
 **Out of scope** (owned elsewhere): loop-lifecycle callback web (`_on_loop_start`/`_on_loop_error`) → P7/P8/P9; session-init→construction flip → blocked by test contract, enabled by P10; `UniverseHandler` setter-fold → P7; `wire_universe`/membership relocation → working-as-intended (shared by both runners; `UniverseHandler` is live-only).
 
-**Plans**: TBD (run /gsd-plan-phase 06.1 to break down)
+**Plans**: 4 plans
+
+- [ ] 06.1-01-PLAN.md — SEAM-01: spec-free `compose_engine` + `EngineContext` store/feed seam + backtest pass-through (oracle-gated, isolated) (wave 1)
+- [ ] 06.1-02-PLAN.md — SEAM-01/02: `build_live_system` consumes `compose_engine`; collapse `LiveSystemComponents`; `VenueLifecycle` as the single venue holder; remove interim `Engine` (wave 2)
+- [ ] 06.1-03-PLAN.md — SEAM-03: shared `VenueSpec` builder (one home for the `{'okx':'okx','paper':'okx'}` map); `for_exchange` + `build_live_system` share it (wave 3)
+- [ ] 06.1-04-PLAN.md — SEAM-04: de-lazy the `trading_system` barrel (backtest-only) + hoist the pure imports; inertness backstop (wave 4)
 
 ### Phase 7: Safety + Reconciliation + Stream Recovery
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -6,7 +6,7 @@ current_phase: 06.1
 current_phase_name: seam-cleanup-make-build-live-system-consume-the-shared-compo
 status: executing
 stopped_at: Phase 06.1 context gathered
-last_updated: "2026-07-14T11:05:35.269Z"
+last_updated: "2026-07-14T11:15:39.556Z"
 last_activity: 2026-07-14
 last_activity_desc: Phase 06.1 execution started
 progress:
@@ -34,7 +34,7 @@ disturbing the byte-exact oracle or the OKX import-inertness gate**. FastAPI its
 ## Current Position
 
 Phase: 06.1 (seam-cleanup-make-build-live-system-consume-the-shared-compo) — EXECUTING
-Plan: 3 of 4
+Plan: 4 of 4
 Status: Ready to execute
 Last activity: 2026-07-14 — Phase 06.1 execution started
 
@@ -165,6 +165,7 @@ P1/P5/P6/P7/P8 (all live-only / backtest-dark).
 - [Phase ?]: 06-07/D-16: TestRunner is behavior-preserving (calls _initialize_live_session before its per-bar drive); the D-12 construction-time flip stays DEFERRED per 06-06
 - [Phase ?]: 06.1-01 (SEAM-01/D-04): compose_engine spec-free; store/feed on EngineContext (D-01/D-02, LR-14 amended); bind+generate_bar_event lifted to base BarFeed ABC; precompute narrowed at backtest-only runner; oracle byte-exact 134/46189.87730727451 + inertness green
 - [Phase ?]: 06.1-02 (SEAM-01/SEAM-02/D-05/D-10): build_live_system consumes compose_engine (hand-rolled 4-handler graph + commission closure deleted, FeeModelCommissionEstimator reused); credential-probe arm selects only environment('live'/'backtest')+shared SqlEngine so compose's handler-owned storage lands the identical durable path on both arms; LiveSystemComponents deleted, facade __init__ = pure injection over Engine+VenueLifecycle+separate SQL/halt handles (D-07/D-09); interim Engine reconstruction removed (reads self._engine); oracle byte-exact + inertness green, mypy clean, bodies untouched (D-08)
+- [Phase 06.1]: 06.1-03 (SEAM-03/D-11): typed frozen VenueSpec (execution_venue/data_provider/account_id) + shared build_venue_spec builder replace the twice-written SimpleNamespace fake-spec; build_venue_spec is the SOLE home of the {okx,paper}->okx default-provider map, called by BOTH for_exchange and build_live_system (inline specs+maps at :274-283/:1605-1613 deleted, SimpleNamespace import dropped); feeds assemble_venue only, never compose_engine (spec-free since D-04); spec-equality unit test proves the two entry points cannot drift; oracle byte-exact 134/46189.87730727451 + inertness green, mypy clean
 
 ### Pending Todos
 
@@ -220,6 +221,7 @@ the one with teeth), CF-2/7→P7, CF-3/4/9→P5, CF-5→P8, CF-6/8→P1 (CF-8 al
 | Phase 06 P07 | 70min | 3 tasks | 21 files |
 | Phase 06.1 P01 | 22min | 3 tasks | 7 files |
 | Phase 06.1 P02 | 18 | 3 tasks | 1 files |
+| Phase 06.1 P03 | 4 | 3 tasks | 4 files |
 
 ## Deferred Items
 
@@ -268,7 +270,7 @@ substantive owner-gated item is `margin-equity-double-counts-notional-wr01`.
 
 ## Session Continuity
 
-Last session: 2026-07-14T11:04:53.306Z
+Last session: 2026-07-14T11:14:32.329Z
 Stopped at: Phase 06.1 context gathered
 success criteria + dependencies + 64/64 coverage); STATE.md refreshed for 12 phases; REQUIREMENTS.md
 traceability + category tags + gates renumbered.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,9 +4,9 @@ milestone: v1.8
 milestone_name: — Live System Refactor & Live-Readiness Hardening
 current_phase: 06.1
 current_phase_name: seam-cleanup-make-build-live-system-consume-the-shared-compo
-status: executing
-stopped_at: Phase 06.1 context gathered
-last_updated: "2026-07-14T11:15:39.556Z"
+status: verifying
+stopped_at: Completed 06.1-04-PLAN.md (final plan of phase 06.1)
+last_updated: "2026-07-14T11:24:28.761Z"
 last_activity: 2026-07-14
 last_activity_desc: Phase 06.1 execution started
 progress:
@@ -35,7 +35,7 @@ disturbing the byte-exact oracle or the OKX import-inertness gate**. FastAPI its
 
 Phase: 06.1 (seam-cleanup-make-build-live-system-consume-the-shared-compo) — EXECUTING
 Plan: 4 of 4
-Status: Ready to execute
+Status: Phase complete — ready for verification
 Last activity: 2026-07-14 — Phase 06.1 execution started
 
 Progress: [████░░░░░░] 44%
@@ -166,6 +166,8 @@ P1/P5/P6/P7/P8 (all live-only / backtest-dark).
 - [Phase ?]: 06.1-01 (SEAM-01/D-04): compose_engine spec-free; store/feed on EngineContext (D-01/D-02, LR-14 amended); bind+generate_bar_event lifted to base BarFeed ABC; precompute narrowed at backtest-only runner; oracle byte-exact 134/46189.87730727451 + inertness green
 - [Phase ?]: 06.1-02 (SEAM-01/SEAM-02/D-05/D-10): build_live_system consumes compose_engine (hand-rolled 4-handler graph + commission closure deleted, FeeModelCommissionEstimator reused); credential-probe arm selects only environment('live'/'backtest')+shared SqlEngine so compose's handler-owned storage lands the identical durable path on both arms; LiveSystemComponents deleted, facade __init__ = pure injection over Engine+VenueLifecycle+separate SQL/halt handles (D-07/D-09); interim Engine reconstruction removed (reads self._engine); oracle byte-exact + inertness green, mypy clean, bodies untouched (D-08)
 - [Phase 06.1]: 06.1-03 (SEAM-03/D-11): typed frozen VenueSpec (execution_venue/data_provider/account_id) + shared build_venue_spec builder replace the twice-written SimpleNamespace fake-spec; build_venue_spec is the SOLE home of the {okx,paper}->okx default-provider map, called by BOTH for_exchange and build_live_system (inline specs+maps at :274-283/:1605-1613 deleted, SimpleNamespace import dropped); feeds assemble_venue only, never compose_engine (spec-free since D-04); spec-equality unit test proves the two entry points cannot drift; oracle byte-exact 134/46189.87730727451 + inertness green, mypy clean
+- [Phase ?]: D-12: trading_system barrel drops the live surface entirely (backtest-only); live consumers import from the live submodule directly
+- [Phase ?]: D-13: pure imports (SessionInitializer/EngineContext/UniverseHandlerConfig) hoisted to live_trading_system module top; heavy ccxt.pro/SQL/venue imports stay lazy inside build_live_system
 
 ### Pending Todos
 
@@ -222,6 +224,7 @@ the one with teeth), CF-2/7→P7, CF-3/4/9→P5, CF-5→P8, CF-6/8→P1 (CF-8 al
 | Phase 06.1 P01 | 22min | 3 tasks | 7 files |
 | Phase 06.1 P02 | 18 | 3 tasks | 1 files |
 | Phase 06.1 P03 | 4 | 3 tasks | 4 files |
+| Phase 06.1 P04 | 6 | 3 tasks | 3 files |
 
 ## Deferred Items
 
@@ -270,8 +273,8 @@ substantive owner-gated item is `margin-equity-double-counts-notional-wr01`.
 
 ## Session Continuity
 
-Last session: 2026-07-14T11:14:32.329Z
-Stopped at: Phase 06.1 context gathered
+Last session: 2026-07-14T11:24:28.753Z
+Stopped at: Completed 06.1-04-PLAN.md (final plan of phase 06.1)
 success criteria + dependencies + 64/64 coverage); STATE.md refreshed for 12 phases; REQUIREMENTS.md
 traceability + category tags + gates renumbered.
 Resume file: .planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-CONTEXT.md

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,9 +4,9 @@ milestone: v1.8
 milestone_name: — Live System Refactor & Live-Readiness Hardening
 current_phase: 7
 current_phase_name: Safety + Reconciliation + Stream Recovery
-status: verifying
+status: executing
 stopped_at: Phase 06.1 context gathered
-last_updated: "2026-07-14T08:04:15.059Z"
+last_updated: "2026-07-14T10:16:41.174Z"
 last_activity: 2026-07-13
 last_activity_desc: "Completed quick task 260713-phm: fix Phase 06 review WR-02 + IN-02"
 progress:
@@ -35,7 +35,7 @@ disturbing the byte-exact oracle or the OKX import-inertness gate**. FastAPI its
 
 Phase: 7 — Safety + Reconciliation + Stream Recovery
 Plan: Not started
-Status: Phase complete — ready for verification
+Status: Ready to execute
 Last activity: 2026-07-13 — Completed quick task 260713-phm: fix Phase 06 review WR-02 + IN-02
 
 Progress: [████░░░░░░] 44%

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,13 +2,13 @@
 gsd_state_version: 1.0
 milestone: v1.8
 milestone_name: — Live System Refactor & Live-Readiness Hardening
-current_phase: 06.1
-current_phase_name: seam-cleanup-make-build-live-system-consume-the-shared-compo
+current_phase: 7
+current_phase_name: Safety + Reconciliation + Stream Recovery
 status: verifying
 stopped_at: Completed 06.1-04-PLAN.md (final plan of phase 06.1)
-last_updated: "2026-07-14T11:24:28.761Z"
+last_updated: "2026-07-14T11:52:36.465Z"
 last_activity: 2026-07-14
-last_activity_desc: Phase 06.1 execution started
+last_activity_desc: Phase 06.1 complete, transitioned to Phase 7
 progress:
   total_phases: 9
   completed_phases: 6
@@ -33,10 +33,10 @@ disturbing the byte-exact oracle or the OKX import-inertness gate**. FastAPI its
 
 ## Current Position
 
-Phase: 06.1 (seam-cleanup-make-build-live-system-consume-the-shared-compo) — EXECUTING
-Plan: 4 of 4
+Phase: 7 — Safety + Reconciliation + Stream Recovery
+Plan: Not started
 Status: Phase complete — ready for verification
-Last activity: 2026-07-14 — Phase 06.1 execution started
+Last activity: 2026-07-14 — Phase 06.1 complete, transitioned to Phase 7
 
 Progress: [████░░░░░░] 44%
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,10 +5,10 @@ milestone_name: — Live System Refactor & Live-Readiness Hardening
 current_phase: 7
 current_phase_name: Safety + Reconciliation + Stream Recovery
 status: verifying
-stopped_at: Phase 6 context gathered
-last_updated: "2026-07-13T14:05:14.188Z"
+stopped_at: Phase 06.1 context gathered
+last_updated: "2026-07-14T08:04:15.059Z"
 last_activity: 2026-07-13
-last_activity_desc: Phase 06 complete, transitioned to Phase 7
+last_activity_desc: "Completed quick task 260713-phm: fix Phase 06 review WR-02 + IN-02"
 progress:
   total_phases: 9
   completed_phases: 6
@@ -264,11 +264,11 @@ substantive owner-gated item is `margin-equity-double-counts-notional-wr01`.
 
 ## Session Continuity
 
-Last session: 2026-07-13T13:43:59.509Z
-Stopped at: Phase 6 context gathered
+Last session: 2026-07-14T08:04:15.048Z
+Stopped at: Phase 06.1 context gathered
 success criteria + dependencies + 64/64 coverage); STATE.md refreshed for 12 phases; REQUIREMENTS.md
 traceability + category tags + gates renumbered.
-Resume file: .planning/phases/06-liverunner-factory-facade-shrink/06-CONTEXT.md
+Resume file: .planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-CONTEXT.md
 Carried todo: 14 pending todos in `todos/pending/` (10 fold into v1.8 as CF-1..CF-10; `v17-residual-carryforward.md`
 is the index; the substantive open item is `margin-equity-double-counts-notional-wr01`, owner-gated).
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -6,7 +6,7 @@ current_phase: 06.1
 current_phase_name: seam-cleanup-make-build-live-system-consume-the-shared-compo
 status: executing
 stopped_at: Phase 06.1 context gathered
-last_updated: "2026-07-14T10:44:23.579Z"
+last_updated: "2026-07-14T11:05:35.269Z"
 last_activity: 2026-07-14
 last_activity_desc: Phase 06.1 execution started
 progress:
@@ -34,7 +34,7 @@ disturbing the byte-exact oracle or the OKX import-inertness gate**. FastAPI its
 ## Current Position
 
 Phase: 06.1 (seam-cleanup-make-build-live-system-consume-the-shared-compo) — EXECUTING
-Plan: 2 of 4
+Plan: 3 of 4
 Status: Ready to execute
 Last activity: 2026-07-14 — Phase 06.1 execution started
 
@@ -164,6 +164,7 @@ P1/P5/P6/P7/P8 (all live-only / backtest-dark).
 - [Phase ?]: 06-07/TEST-01/D-18: relocated the whole replay harness to tests/support/replay_harness.py; production is replay-free (paper->OKX feed, D-21); paper EXECUTION venue untouched (D-20)
 - [Phase ?]: 06-07/D-16: TestRunner is behavior-preserving (calls _initialize_live_session before its per-bar drive); the D-12 construction-time flip stays DEFERRED per 06-06
 - [Phase ?]: 06.1-01 (SEAM-01/D-04): compose_engine spec-free; store/feed on EngineContext (D-01/D-02, LR-14 amended); bind+generate_bar_event lifted to base BarFeed ABC; precompute narrowed at backtest-only runner; oracle byte-exact 134/46189.87730727451 + inertness green
+- [Phase ?]: 06.1-02 (SEAM-01/SEAM-02/D-05/D-10): build_live_system consumes compose_engine (hand-rolled 4-handler graph + commission closure deleted, FeeModelCommissionEstimator reused); credential-probe arm selects only environment('live'/'backtest')+shared SqlEngine so compose's handler-owned storage lands the identical durable path on both arms; LiveSystemComponents deleted, facade __init__ = pure injection over Engine+VenueLifecycle+separate SQL/halt handles (D-07/D-09); interim Engine reconstruction removed (reads self._engine); oracle byte-exact + inertness green, mypy clean, bodies untouched (D-08)
 
 ### Pending Todos
 
@@ -218,6 +219,7 @@ the one with teeth), CF-2/7→P7, CF-3/4/9→P5, CF-5→P8, CF-6/8→P1 (CF-8 al
 | Phase 06 P06 | 50min | 3 tasks | 26 files |
 | Phase 06 P07 | 70min | 3 tasks | 21 files |
 | Phase 06.1 P01 | 22min | 3 tasks | 7 files |
+| Phase 06.1 P02 | 18 | 3 tasks | 1 files |
 
 ## Deferred Items
 
@@ -266,7 +268,7 @@ substantive owner-gated item is `margin-equity-double-counts-notional-wr01`.
 
 ## Session Continuity
 
-Last session: 2026-07-14T10:44:04.991Z
+Last session: 2026-07-14T11:04:53.306Z
 Stopped at: Phase 06.1 context gathered
 success criteria + dependencies + 64/64 coverage); STATE.md refreshed for 12 phases; REQUIREMENTS.md
 traceability + category tags + gates renumbered.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,13 +2,13 @@
 gsd_state_version: 1.0
 milestone: v1.8
 milestone_name: — Live System Refactor & Live-Readiness Hardening
-current_phase: 7
-current_phase_name: Safety + Reconciliation + Stream Recovery
+current_phase: 06.1
+current_phase_name: seam-cleanup-make-build-live-system-consume-the-shared-compo
 status: executing
 stopped_at: Phase 06.1 context gathered
-last_updated: "2026-07-14T10:16:41.174Z"
-last_activity: 2026-07-13
-last_activity_desc: "Completed quick task 260713-phm: fix Phase 06 review WR-02 + IN-02"
+last_updated: "2026-07-14T10:44:23.579Z"
+last_activity: 2026-07-14
+last_activity_desc: Phase 06.1 execution started
 progress:
   total_phases: 9
   completed_phases: 6
@@ -26,17 +26,17 @@ See: .planning/PROJECT.md (Current Milestone: v1.8 — Live System Refactor & Li
 **Core value:** A single backtest run of `SMA_MACD` on the golden BTCUSD CSV produces correct,
 deterministic, cross-validated numbers (oracle **134 / `46189.87730727451`**; v1.5 W1 baseline 15.7 s /
 152.8 MB). v1.7 shipped a live operating mode (paper-first on OKX) without disturbing that oracle.
-**Current focus:** Phase 06 — liverunner-factory-facade-shrink
+**Current focus:** Phase 06.1 — seam-cleanup-make-build-live-system-consume-the-shared-compo
 thin ~200-line facade over focused, venue-parametrized, FastAPI-ready collaborators — **without
 disturbing the byte-exact oracle or the OKX import-inertness gate**. FastAPI itself is out of scope
 (LR-01). Full scope: core refactor (P1–P8 + P12) + the three ★ feature-adds (P9–P11).
 
 ## Current Position
 
-Phase: 7 — Safety + Reconciliation + Stream Recovery
-Plan: Not started
+Phase: 06.1 (seam-cleanup-make-build-live-system-consume-the-shared-compo) — EXECUTING
+Plan: 2 of 4
 Status: Ready to execute
-Last activity: 2026-07-13 — Completed quick task 260713-phm: fix Phase 06 review WR-02 + IN-02
+Last activity: 2026-07-14 — Phase 06.1 execution started
 
 Progress: [████░░░░░░] 44%
 
@@ -163,6 +163,7 @@ P1/P5/P6/P7/P8 (all live-only / backtest-dark).
 - [Phase ?]: 06-06: build_live_system(spec) is the live composition root (RUN-01/D-09); facade __init__ is pure injection; live wires PriorityEventBus (D-23); LiveRunner owns the drain loop; D-12 construction-time session-init flip deferred to 06-07 — RUN-03 lands structurally
 - [Phase ?]: 06-07/TEST-01/D-18: relocated the whole replay harness to tests/support/replay_harness.py; production is replay-free (paper->OKX feed, D-21); paper EXECUTION venue untouched (D-20)
 - [Phase ?]: 06-07/D-16: TestRunner is behavior-preserving (calls _initialize_live_session before its per-bar drive); the D-12 construction-time flip stays DEFERRED per 06-06
+- [Phase ?]: 06.1-01 (SEAM-01/D-04): compose_engine spec-free; store/feed on EngineContext (D-01/D-02, LR-14 amended); bind+generate_bar_event lifted to base BarFeed ABC; precompute narrowed at backtest-only runner; oracle byte-exact 134/46189.87730727451 + inertness green
 
 ### Pending Todos
 
@@ -216,6 +217,7 @@ the one with teeth), CF-2/7→P7, CF-3/4/9→P5, CF-5→P8, CF-6/8→P1 (CF-8 al
 | Phase 06 P05 | 9min | 3 tasks | 3 files |
 | Phase 06 P06 | 50min | 3 tasks | 26 files |
 | Phase 06 P07 | 70min | 3 tasks | 21 files |
+| Phase 06.1 P01 | 22min | 3 tasks | 7 files |
 
 ## Deferred Items
 
@@ -264,7 +266,7 @@ substantive owner-gated item is `margin-equity-double-counts-notional-wr01`.
 
 ## Session Continuity
 
-Last session: 2026-07-14T08:04:15.048Z
+Last session: 2026-07-14T10:44:04.991Z
 Stopped at: Phase 06.1 context gathered
 success criteria + dependencies + 64/64 coverage); STATE.md refreshed for 12 phases; REQUIREMENTS.md
 traceability + category tags + gates renumbered.

--- a/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-01-PLAN.md
+++ b/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-01-PLAN.md
@@ -1,0 +1,219 @@
+---
+phase: 06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - itrader/trading_system/engine_context.py
+  - itrader/trading_system/compose.py
+  - itrader/trading_system/backtest_trading_system.py
+  - itrader/trading_system/live_trading_system.py
+  - tests/integration/test_okx_inertness.py
+autonomous: true
+requirements: [SEAM-01]
+
+must_haves:
+  truths:
+    - "EngineContext gains feed (required) + store (Optional=None), typed via TYPE_CHECKING forward-refs to the BASE BarFeed/PriceStore types (mirrors sql_engine); the LR-14 'exactly four fields / the shape is frozen here' invariant is consciously amended and its docstring updated (D-01, D-03)"
+    - "EngineContext field order is reworked so required fields (bus/config/environment/feed) precede the defaulted ones (store=None, sql_engine=None) — avoids the dataclass 'non-default argument follows default argument' error (D-01, D-03)"
+    - "compose_engine is SPEC-FREE: signature compose_engine(ctx, *, exchange_config=None, results_store=None) with NO spec param; the body reads store/feed off ctx and never reads spec.data/start/end/timeframe/exchange/results_store (D-04)"
+    - "store/feed CONSTRUCTION moves out of compose_engine into the backtest factory; compose reads ctx.feed (required) + ctx.store (Optional); FeeModelCommissionEstimator stays in compose (D-04)"
+    - "backtest (build_backtest_system + the legacy BacktestTradingSystem.__init__ arm + the e2e ScenarioSpec=SystemSpec path) builds CsvPriceStore+BacktestBarFeed → ctx and passes exchange_config/results_store to compose explicitly; the SMA_MACD oracle stays byte-exact 134 / 46189.87730727451 (check_exact=True) with the determinism double-run identical — the shared-path-regression edge (SEAM-01) is pinned by this gate (D-04)"
+    - "the live build_live_system EngineContext construction passes store=None (LiveBarFeed reads no store) + feed=the live feed — a minimal construction-site fix only, NO handler-graph rewire in this plan (D-02)"
+    - "every EngineContext(...) construction site is updated for the new required feed field: build_backtest_system, the legacy __init__, live build_live_system, and the test_okx_inertness.py register-vs-build probe (which builds a pure BacktestBarFeed over a CsvPriceStore — both already on the backtest graph, so the probe stays inert) (D-01)"
+  artifacts:
+    - "itrader/trading_system/engine_context.py — EngineContext with new feed + store fields"
+    - "itrader/trading_system/compose.py — spec-free compose_engine(ctx, *, exchange_config=None, results_store=None)"
+  key_links:
+    - "compose_engine reads ctx.feed / ctx.store — the mode-injection seam; backtest injects real store+feed, live injects LiveBarFeed+store=None"
+    - "build_backtest_system → EngineContext(feed=…, store=…) → compose_engine(ctx, exchange_config=…, results_store=…) → oracle byte-exact"
+  prohibitions:
+    - statement: "MUST NOT change backtest output bytes (behavior-preserving, not a re-baseline)"
+      status: enforced
+      verification: "poetry run pytest tests/integration/test_backtest_oracle.py — oracle 134 / 46189.87730727451 (check_exact=True) + determinism double-run identical"
+    - statement: "MUST NOT pull ccxt.pro/SQL onto the backtest import path (the new required feed on the probe ctx is a pure BacktestBarFeed/CsvPriceStore)"
+      status: enforced
+      verification: "poetry run pytest tests/integration/test_okx_inertness.py green"
+    - statement: "MUST NOT alter live runtime behavior — this plan touches live_trading_system.py ONLY at the EngineContext construction site (add feed/store), no handler-graph / order-flow / safety / reconcile / stream change"
+      status: enforced
+      verification: "live construction/lifecycle suite green with no behavioral test changes: poetry run pytest tests/integration/test_live_paper_lifecycle.py tests/unit/trading_system"
+---
+
+<objective>
+Make the shared `compose_engine` seam **spec-free** and **store/feed-agnostic** by moving the
+store/feed onto the shared `EngineContext` (the mode-injection seam), and adapt every backtest
+call site to the new signature — proving the SMA_MACD oracle stays byte-exact BEFORE any live
+rewire. This is the oracle-gated centerpiece of Phase 06.1 (SEAM-01), isolated in its own Wave-1
+plan so the byte-exact gate is proven before the mechanical live work in later plans.
+
+Purpose: `compose_engine` currently hardcodes `CsvPriceStore`+`BacktestBarFeed` (compose.py:161-165)
+and reads a backtest-shaped `spec`, so live cannot consume it. After D-01 moves store/feed to `ctx`
+and D-04 makes compose spec-free, live can call `compose_engine(ctx)` with neither a store nor a spec.
+Output: an amended `EngineContext` (feed required, store Optional), a spec-free `compose_engine`, and
+all backtest call sites passing store/feed via `ctx` and `exchange_config`/`results_store` explicitly.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-CONTEXT.md
+@.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-SPEC.md
+</context>
+
+<artifacts_produced>
+Symbols this phase (this plan) creates/changes — excluded from the source-grounding drift pass:
+- `EngineContext.feed: "BarFeed"` (NEW, required field; TYPE_CHECKING forward-ref to `itrader.price_handler.feed.base.BarFeed`)
+- `EngineContext.store: Optional["PriceStore"] = None` (NEW, Optional field; TYPE_CHECKING forward-ref to `itrader.price_handler.store.base.PriceStore`)
+- `compose_engine(ctx, *, exchange_config=None, results_store=None)` (CHANGED signature — the `spec` param is REMOVED; SPEC-FREE)
+- `Engine.store` / `Engine.feed` type widening (to `Optional[PriceStore]` / `BarFeed`) so live's `store=None` / `LiveBarFeed` satisfy `mypy --strict`
+- The amended LR-14 invariant docstring in `engine_context.py` ("exactly four fields … the shape is frozen here" → consciously amended, D-01)
+</artifacts_produced>
+
+<!-- These identifiers must be named in <action> for the executor (the store/feed construction MOVES to the backtest factory) while an acceptance criterion negative-greps them in compose.py — the write target and the grep target are different files, so the appearance is legitimate. -->
+<!-- planner-discipline-allow: CsvPriceStore( -->
+<!-- planner-discipline-allow: BacktestBarFeed( -->
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Extend EngineContext with feed (required) + store (Optional) and amend the LR-14 invariant (D-01/D-03)</name>
+  <files>itrader/trading_system/engine_context.py</files>
+  <read_first>
+    - itrader/trading_system/engine_context.py — the CURRENT 4-field frozen EngineContext (bus/config/environment/sql_engine); the `sql_engine: Optional["SqlEngine"] = None` + TYPE_CHECKING forward-ref pattern to MIRROR exactly; the LR-14 "Design invariants" docstring block ("Exactly four fields … The shape is frozen here.") this task amends. Indentation: **TABS**.
+    - itrader/price_handler/feed/base.py — the base `BarFeed(ABC)` (line 75) the new `feed` field forward-refs.
+    - itrader/price_handler/store/base.py — the base `PriceStore(ABC)` (line 21) the new `store` field forward-refs.
+  </read_first>
+  <action>
+    File is **TABS** (measure bytes; do not normalize). Add two fields to the frozen `EngineContext`
+    dataclass: `feed` (REQUIRED, annotated `"BarFeed"`) and `store` (Optional, annotated
+    `Optional["PriceStore"]`, default `None`). Add the base-type imports under the existing
+    `TYPE_CHECKING` guard — `from itrader.price_handler.feed.base import BarFeed` and
+    `from itrader.price_handler.store.base import PriceStore` — mirroring exactly how `SqlEngine`
+    is guarded so importing `engine_context` pulls no concretion (keeps the module import-inert).
+    Rework the FIELD ORDER so all required fields precede the defaulted ones: `bus`, `config`,
+    `environment`, `feed` (required), then `store = None`, `sql_engine = None` (defaulted) — this
+    avoids the "non-default argument follows default argument" dataclass error. Update the module +
+    class docstring: the LR-14 "Exactly four fields … The shape is frozen here." invariant is
+    CONSCIOUSLY AMENDED per D-01 — reframe `ctx` as "everything the mode factory selects: transport +
+    knobs + backends (`sql_engine`, `store`, `feed`)"; document `store` as real-in-backtest /
+    None-in-live (the identical idiom to `sql_engine` real-in-live / None-in-backtest, D-02) and
+    `feed` as the required per-mode read-model. Add per-field docstring entries for `feed`/`store`.
+  </action>
+  <verify>
+    <automated>poetry run python -c "from itrader.trading_system.engine_context import EngineContext; import dataclasses; f=[x.name for x in dataclasses.fields(EngineContext)]; assert f[:4]==['bus','config','environment','feed'], f; assert 'store' in f and 'sql_engine' in f; print('FIELDS_OK', f)"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c "feed:" itrader/trading_system/engine_context.py` >= 1 and `grep -c "store:" itrader/trading_system/engine_context.py` >= 1
+    - `grep -c "from itrader.price_handler.feed.base import BarFeed" itrader/trading_system/engine_context.py` == 1 and it is under the `if TYPE_CHECKING:` block
+    - The dataclass fields, in order, are `bus, config, environment, feed, store, sql_engine` (asserted by the Task-1 verify command printing `FIELDS_OK`)
+    - The docstring no longer claims "the shape is frozen here" as an absolute; it references D-01 amending LR-14 (grep for `D-01` in the file)
+    - `poetry run pytest tests/integration/test_okx_inertness.py` still green (module stays import-inert — the forward-refs are TYPE_CHECKING-only)
+  </acceptance_criteria>
+  <done>EngineContext carries feed (required) + store (Optional=None) via TYPE_CHECKING forward-refs; field order is required-before-defaulted; the LR-14 invariant docstring is amended per D-01.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Make compose_engine spec-free; read store/feed off ctx; widen Engine store/feed types (D-04)</name>
+  <files>itrader/trading_system/compose.py</files>
+  <read_first>
+    - itrader/trading_system/compose.py — the current `compose_engine(ctx, spec)` (:114-258): the A1 spec-read block (:143-152) that becomes deletions, the store/feed CONSTRUCTION (:161-165) that moves to the factory, the `Engine` holder (:81-111) whose `store: CsvPriceStore` / `feed: BacktestBarFeed` fields need widening, and `FeeModelCommissionEstimator` (:54-78) which STAYS. Note the module top imports of `SystemSpec`, `CsvPriceStore`, `BacktestBarFeed`, `to_timedelta` that become unused once construction moves out. Indentation: **TABS**.
+    - itrader/trading_system/engine_context.py — the new `ctx.feed` / `ctx.store` fields Task 1 added (what compose now reads).
+    - itrader/price_handler/feed/base.py + itrader/price_handler/store/base.py — the base `BarFeed` / `PriceStore` types for the widened `Engine.feed` / `Engine.store` annotations.
+  </read_first>
+  <action>
+    File is **TABS**. Change the signature to `compose_engine(ctx: "EngineContext", *, exchange_config: Optional[Any] = None, results_store: Optional["ResultsStore"] = None) -> Engine` — REMOVE the `spec` parameter entirely (SPEC-FREE, D-04). Delete the A1 kwargs->spec fold block (the `csv_paths`/`start_date`/`end_date`/`timeframe`/`exchange_config`/`results_store` reads off `spec`) and the store/feed CONSTRUCTION (`CsvPriceStore(...)` + `BacktestBarFeed(...)`): compose now reads `store = ctx.store` and `feed = ctx.feed`. Use the `exchange_config` PARAM in the `ExecutionHandler(ctx.bus, exchange_config=exchange_config)` construction and the `results_store` PARAM in the returned `Engine(..., results_store=results_store)`. `FeeModelCommissionEstimator(simulated_exchange)` and all handler wiring stay byte-identical. Widen the `Engine` holder types so live's `store=None` / `LiveBarFeed` are accepted under `mypy --strict`: `store: Optional[PriceStore] = None` and `feed: BarFeed`. Add `from itrader.price_handler.feed.base import BarFeed` and `from itrader.price_handler.store.base import PriceStore` (both pure, already on the backtest graph). Drop the now-unused `SystemSpec` import (and `CsvPriceStore`/`BacktestBarFeed`/`to_timedelta` if no longer referenced). Update the module + compose docstring to describe the spec-free seam (compose reads infra `ctx` + the two how/where params; the WHAT-to-run spec is factory-local, D-04). Do NOT place fenced code in comments.
+  </action>
+  <verify>
+    <automated>poetry run python -c "import inspect; from itrader.trading_system.compose import compose_engine; s=inspect.signature(compose_engine); assert 'spec' not in s.parameters, s; assert list(s.parameters)==['ctx','exchange_config','results_store'], list(s.parameters); print('SIG_OK', s)"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `poetry run python -c "import inspect;from itrader.trading_system.compose import compose_engine;print(list(inspect.signature(compose_engine).parameters))"` prints `['ctx', 'exchange_config', 'results_store']`
+    - `grep -c "spec\." itrader/trading_system/compose.py` == 0 (no spec-field read survives in compose)
+    - `grep -c "CsvPriceStore(" itrader/trading_system/compose.py` == 0 and `grep -c "BacktestBarFeed(" itrader/trading_system/compose.py` == 0 (store/feed construction moved to the factory)
+    - `grep -c "FeeModelCommissionEstimator" itrader/trading_system/compose.py` >= 1 (adapter retained)
+    - `poetry run mypy itrader/trading_system/compose.py itrader/trading_system/engine_context.py` clean (Engine store/feed widening accepted)
+  </acceptance_criteria>
+  <done>compose_engine has no spec param, reads store/feed off ctx, uses the two explicit how/where params, and the Engine holder store/feed types are widened; mypy --strict clean on compose + engine_context.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Adapt every EngineContext + compose_engine call site to the spec-free seam; prove oracle byte-exact (D-04/D-02)</name>
+  <files>itrader/trading_system/backtest_trading_system.py, itrader/trading_system/live_trading_system.py, tests/integration/test_okx_inertness.py</files>
+  <read_first>
+    - itrader/trading_system/backtest_trading_system.py — the factory `build_backtest_system` (:423-491, the `EngineContext(...)` at :456 + `compose_engine(ctx, spec)` at :462, reads `spec.exchange` at :443, `spec.data` at :444) and the legacy `BacktestTradingSystem.__init__` arm (the `EngineContext(...)` at :151 + `compose_engine(ctx, spec)` at :157). Both must build `CsvPriceStore`+`BacktestBarFeed` → ctx and pass `exchange_config`/`results_store` to compose. Indentation: **TABS**.
+    - itrader/trading_system/compose.py — the store/feed construction just deleted (the exact `CsvPriceStore(csv_paths=…, start_date=…, end_date=… or None)` + `BacktestBarFeed(store, to_timedelta(timeframe))` recipe the factory must now build verbatim, byte-preserving).
+    - itrader/trading_system/live_trading_system.py — the live `EngineContext(...)` construction at :1619 (the ctx passed to `assemble_venue`, NOT to compose) + the live `feed = LiveBarFeed(...)` at :1481. Indentation: **4-SPACE**. This plan adds `feed=feed, store=None` to that ctx ONLY (D-02) — no handler-graph rewire (that is plan 06.1-02).
+    - tests/integration/test_okx_inertness.py — the register-vs-build probe `EngineContext(bus=_bus, config=_cfg, environment="backtest", sql_engine=None)` at :121 that now needs a pure `feed` (a `BacktestBarFeed` over a `CsvPriceStore`, both already on the backtest graph). Indentation: **4-SPACE**.
+  </read_first>
+  <action>
+    In `build_backtest_system` (TABS) and the legacy `BacktestTradingSystem.__init__` legacy arm (TABS):
+    build the store + feed BEFORE the ctx — `store = CsvPriceStore(csv_paths=…, start_date=…, end_date=… or None)`
+    and `feed = BacktestBarFeed(store, to_timedelta(timeframe))` using the SAME argument values compose used
+    (from the spec's data/start/end/timeframe) so the run stays byte-identical; add the `CsvPriceStore` /
+    `BacktestBarFeed` / `to_timedelta` imports to backtest_trading_system.py. Pass them onto the ctx
+    (`EngineContext(bus=…, config=…, environment='backtest', feed=feed, store=store, sql_engine=None)`) and
+    change the compose call to `compose_engine(ctx, exchange_config=exchange_config, results_store=results_store)`
+    where `exchange_config = spec.exchange` and `results_store = getattr(spec, 'results_store', None)` (the e2e
+    ScenarioSpec is now the `SystemSpec` alias and carries `results_store`; the legacy arm passes
+    `results_store=None`). In `live_trading_system.py` (4-SPACE): add `feed=feed, store=None` to the
+    `EngineContext(...)` at :1619 (D-02 — LiveBarFeed reads no store) — a construction-site fix ONLY, leave the
+    hand-rolled handler graph untouched this plan. In `test_okx_inertness.py` (4-SPACE): update the probe ctx to
+    build a pure `feed` (`BacktestBarFeed(CsvPriceStore(), to_timedelta('1d'))`) and pass `feed=…, store=…`; the
+    inertness ASSERTIONS themselves stay unchanged (this is a mechanical construction-site adaptation, not a
+    weakening). Then run the oracle + inertness gates.
+  </action>
+  <verify>
+    <automated>poetry run pytest tests/integration/test_backtest_oracle.py tests/integration/test_okx_inertness.py -q</automated>
+  </verify>
+  <acceptance_criteria>
+    - `poetry run pytest tests/integration/test_backtest_oracle.py` passes — the SMA_MACD run is byte-exact `134 / 46189.87730727451` (`check_exact=True`); running it a second consecutive time is identical (determinism double-run)
+    - `poetry run pytest tests/integration/test_okx_inertness.py` green (the new required `feed` on the probe ctx is a pure BacktestBarFeed/CsvPriceStore — no ccxt.pro/SQL pulled; the `sql` cached_property stays unresolved)
+    - `grep -rn "compose_engine(ctx, spec)" itrader/` == 0 (no old two-arg call remains); `grep -rn "compose_engine(ctx," itrader/trading_system/backtest_trading_system.py` shows the new keyword form
+    - `grep -c "feed=feed, store=None" itrader/trading_system/live_trading_system.py` >= 1 (live ctx updated, D-02)
+    - `poetry run mypy itrader` clean (backtest_trading_system.py strict-checked; live_trading_system.py is ignore_errors by config)
+  </acceptance_criteria>
+  <done>All EngineContext + compose_engine call sites use the spec-free seam; the backtest factory builds store/feed → ctx and passes exchange_config/results_store explicitly; oracle byte-exact 134 / 46189.87730727451 and inertness green.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| shared compose seam ↔ backtest oracle path | This plan edits `compose_engine`, which the golden SMA_MACD run composes through — the only boundary with regression teeth this phase. No new external input, auth, secret, or network surface is added. |
+| backtest import graph ↔ heavy backends | The new required `feed` field must not let a SQL/ccxt concretion leak onto the backtest import path via the probe ctx. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-06.1.01-ORACLE | Tampering | compose_engine store/feed/spec change | high | mitigate | oracle byte-exact gate `134 / 46189.87730727451` (`check_exact=True`) + determinism double-run in Task 3 — a bit-drift reddens loudly |
+| T-06.1.01-INERT | Tampering | EngineContext new required feed field | high | mitigate | inertness gate: the probe ctx builds a pure BacktestBarFeed/CsvPriceStore; TYPE_CHECKING-only forward-refs; `test_okx_inertness.py` asserts no ccxt.pro/SQL pulled |
+| T-06.1.01-TYPE | Information Disclosure | Engine store/feed type widening | low | accept | `mypy --strict` clean over `itrader` is the gate; widening to base types is a safe superset |
+</threat_model>
+
+<verification>
+- `poetry run pytest tests/integration/test_backtest_oracle.py` — byte-exact `134 / 46189.87730727451` (`check_exact=True`), determinism double-run identical (MANDATORY per-PLAN oracle gate: this plan touches compose.py + engine_context.py + backtest_trading_system.py).
+- `poetry run pytest tests/integration/test_okx_inertness.py` — green (backtest import path pulls no ccxt.pro/SQL; the new probe ctx feed is pure).
+- `poetry run mypy itrader` — clean (compose.py / engine_context.py / backtest_trading_system.py are strict-checked).
+- `poetry run pytest tests/unit/trading_system tests/integration/test_live_paper_lifecycle.py` — live construction/lifecycle unchanged (this plan touches live only at the ctx construction site).
+</verification>
+
+<success_criteria>
+- `compose_engine(ctx, *, exchange_config=None, results_store=None)` — no `spec` param (asserted by inspect).
+- `EngineContext` carries `feed` (required) + `store` (Optional=None) via TYPE_CHECKING forward-refs; field order required-before-defaulted; LR-14 invariant docstring amended (D-01).
+- Backtest oracle byte-exact `134 / 46189.87730727451`; inertness green; `mypy --strict` clean.
+</success_criteria>
+
+<output>
+Create `.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-01-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-01-SUMMARY.md
+++ b/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-01-SUMMARY.md
@@ -1,0 +1,146 @@
+---
+phase: 06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo
+plan: 01
+subsystem: trading_system / compose seam
+tags: [SEAM-01, compose-engine, engine-context, mode-injection, oracle-gated]
+status: complete
+requires:
+  - "EngineContext (bus/config/environment/sql_engine) from Phase 02"
+  - "compose_engine(ctx, spec) two-arg seam from Phase 02-03"
+provides:
+  - "compose_engine(ctx, *, exchange_config=None, results_store=None) — spec-free shared seam"
+  - "EngineContext.feed (required) + EngineContext.store (Optional=None) — the mode-injection seam"
+  - "BarFeed.bind + BarFeed.generate_bar_event declared on the base ABC (shared feed contract)"
+affects:
+  - "itrader/trading_system/compose.py"
+  - "itrader/trading_system/engine_context.py"
+  - "itrader/price_handler/feed/base.py"
+  - "itrader/trading_system/backtest_runner.py"
+  - "itrader/trading_system/backtest_trading_system.py"
+  - "itrader/trading_system/live_trading_system.py (construction-site only)"
+tech_stack:
+  added: []
+  patterns:
+    - "ctx as the single mode-injection seam (per-mode backends real-in-one/None-in-other)"
+    - "TYPE_CHECKING forward-refs to BASE feed/store types (import-inert)"
+    - "backtest-only narrowing (cast) at the backtest-only consumer, shared capabilities on the base ABC"
+key_files:
+  created: []
+  modified:
+    - "itrader/trading_system/engine_context.py"
+    - "itrader/trading_system/compose.py"
+    - "itrader/price_handler/feed/base.py"
+    - "itrader/trading_system/backtest_runner.py"
+    - "itrader/trading_system/backtest_trading_system.py"
+    - "itrader/trading_system/live_trading_system.py"
+    - "tests/integration/test_okx_inertness.py"
+decisions:
+  - "D-01: store+feed ride on EngineContext (not compose params); LR-14 'exactly four fields' invariant consciously amended"
+  - "D-02: live carries store=None (LiveBarFeed reads no store) — construction-site fix only, no handler-graph rewire"
+  - "D-03: both new ctx fields typed via TYPE_CHECKING forward-refs to the BASE feed/store types (import-inert)"
+  - "D-04: compose_engine is SPEC-FREE — exchange_config/results_store become explicit kwargs, spec never crosses the seam"
+metrics:
+  duration_minutes: 22
+  tasks: 3
+  files_modified: 7
+  completed: 2026-07-14
+---
+
+# Phase 06.1 Plan 01: Spec-Free compose_engine + EngineContext Store/Feed Seam Summary
+
+Made the shared `compose_engine` seam **spec-free** and **store/feed-agnostic** by moving the
+per-mode `store`/`feed` read-models onto the shared `EngineContext` (the mode-injection seam),
+proving the SMA_MACD backtest stays byte-exact `134 / 46189.87730727451` (`check_exact=True`,
+determinism double-run identical) before any live rewire.
+
+## What was built
+
+- **`EngineContext` extended (Task 1):** added `feed` (required, base `BarFeed` forward-ref) and
+  `store` (`Optional[PriceStore] = None`) under the existing `TYPE_CHECKING` guard. Field order
+  reworked required-before-defaulted (`bus`/`config`/`environment`/`feed`, then `store`/`sql_engine`)
+  to avoid the "non-default argument follows default argument" dataclass error. The locked LR-14
+  "exactly four fields … the shape is frozen here" invariant was **consciously amended** per D-01
+  (docstring reframes `ctx` as the mode-injection seam: `store` is real-in-backtest / None-in-live,
+  the identical idiom as `sql_engine`).
+- **`compose_engine` made spec-free (Task 2):** signature is now
+  `compose_engine(ctx, *, exchange_config=None, results_store=None)` — the `spec` parameter is gone.
+  The A1 spec-read fold and the `CsvPriceStore`/`BacktestBarFeed` construction were deleted; compose
+  now reads `store = ctx.store` and `feed = ctx.feed`. `FeeModelCommissionEstimator` and all handler
+  wiring stay byte-identical. The `Engine` holder `store`/`feed` types were widened to the base
+  `Optional[PriceStore]` / `BarFeed`.
+- **All call sites adapted (Task 3):** `build_backtest_system`, the legacy
+  `BacktestTradingSystem.__init__` arm, and the e2e `SystemSpec` path build `CsvPriceStore`+
+  `BacktestBarFeed` → `ctx` and call `compose_engine(ctx, exchange_config=…, results_store=…)`
+  explicitly. Live's `build_live_system` `EngineContext` gained `feed=feed, store=None` (D-02,
+  construction-site only — no handler-graph rewire). The `test_okx_inertness.py` register-vs-build
+  probe now builds a pure `BacktestBarFeed`/`CsvPriceStore` feed on the probe ctx.
+
+## Verification evidence
+
+- `poetry run pytest tests/integration/test_backtest_oracle.py` — PASS (byte-exact
+  `134 / 46189.87730727451`, `check_exact=True`); run twice consecutively — identical (determinism).
+- `poetry run pytest tests/integration/test_okx_inertness.py` — PASS (no ccxt.pro/SQL pulled; the new
+  required probe `feed` is a pure BacktestBarFeed/CsvPriceStore; `sql` cached_property stays unresolved).
+- `poetry run mypy itrader` — clean (249 source files).
+- `poetry run pytest tests/unit/trading_system tests/integration/test_live_paper_lifecycle.py` — 22 passed
+  (live construction/lifecycle unchanged).
+- Grep gates: `compose_engine(ctx, spec)` == 0; `spec.` in compose.py == 0; `CsvPriceStore(`/
+  `BacktestBarFeed(` in compose.py == 0; `feed=feed, store=None` in live == 1.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Declared `bind` + `generate_bar_event` on the base `BarFeed` ABC**
+- **Found during:** Task 2 (mypy `--strict` gate).
+- **Issue:** Widening the `Engine` holder `feed` to the base `BarFeed` (a plan artifact) surfaced
+  `"BarFeed" has no attribute "generate_bar_event"` (compose EventHandler wiring) and
+  `"BarFeed" has no attribute "bind"` (shared `universe_wiring.py:112`). Both methods already exist on
+  BOTH concrete feeds (`BacktestBarFeed` + `LiveBarFeed`) — the base ABC just never declared them.
+  The design intent (per `LiveBarFeed.generate_bar_event`'s own docstring) is explicitly "so the
+  handler can pass `feed.generate_bar_event` unconditionally", i.e. a uniform feed capability.
+- **Fix:** Declared both as abstract methods on `BarFeed` (base). `generate_bar_event` uses the
+  identical `(TimeEvent) -> BarEvent | None` signature both concretes carry; `bind` uses a loose
+  `global_queue: Any` so the two concrete overrides (EventBus vs `queue.Queue`) stay compatible.
+  TYPE_CHECKING string forward-refs keep the base module import-inert. Runtime behavior unchanged.
+- **Files modified:** `itrader/price_handler/feed/base.py`
+- **Commit:** 89480000
+
+**2. [Rule 3 - Blocking] Narrowed `store`/`feed` to concrete backends at the backtest-only runner**
+- **Found during:** Task 2 (mypy `--strict` gate).
+- **Issue:** The widened base `Engine.store`/`Engine.feed` rippled into `backtest_runner.py`:
+  `store.symbols()`/`store.index()` hit the `Optional` None-union, and `feed.precompute(...)` is a
+  `BacktestBarFeed`-only capability the base `BarFeed` (and the live feed) does not carry.
+- **Fix:** `BacktestRunner` is definitionally backtest-only, so it narrows `engine.store` →
+  `PriceStore` and `engine.feed` → `BacktestBarFeed` via `cast` at the single call site before the
+  backtest-specific reads. No live path touches this code. Runtime behavior unchanged (oracle
+  byte-exact confirms).
+- **Files modified:** `itrader/trading_system/backtest_runner.py`
+- **Commit:** 89480000
+
+**Note on the Engine-widening trade-off:** the plan's stated rationale for widening
+(`Engine.store`/`feed` to base "so live's store=None/LiveBarFeed satisfy mypy") is architecturally
+correct; the concrete-narrowing was placed at the backtest-only consumer (`BacktestRunner`) rather
+than reintroducing concrete construction into the shared seam. Shared feed capabilities (`bind`,
+`generate_bar_event`) were lifted to the base ABC honestly (both concretes implement them); the one
+genuinely backtest-only capability (`precompute`) is narrowed at its single backtest-only caller.
+
+## Known Stubs
+
+None — no stubs introduced. `LiveBarFeed.generate_bar_event` remains a DORMANT no-op by design
+(live emits BarEvents directly via `update()`); this pre-existed and is now formalized by the base
+ABC declaration.
+
+## Threat Flags
+
+None — no new network endpoints, auth paths, file access, or trust-boundary schema changes. The
+threat register's `mitigate` dispositions (T-06.1.01-ORACLE, T-06.1.01-INERT) are satisfied by the
+byte-exact oracle + determinism double-run gate and the pure-feed inertness gate, both green.
+
+## Self-Check: PASSED
+
+- Files verified present: engine_context.py, compose.py, base.py, backtest_runner.py,
+  backtest_trading_system.py, live_trading_system.py, test_okx_inertness.py — all modified on disk.
+- Commits verified in `git log`: c9c0bd1c (Task 1), 89480000 (Task 2), 654fa600 (Task 3).
+</content>
+</invoke>

--- a/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-02-PLAN.md
+++ b/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-02-PLAN.md
@@ -1,0 +1,247 @@
+---
+phase: 06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo
+plan: 02
+type: execute
+wave: 2
+depends_on: [06.1-01]
+files_modified:
+  - itrader/trading_system/live_trading_system.py
+autonomous: true
+requirements: [SEAM-01, SEAM-02]
+
+must_haves:
+  truths:
+    - "build_live_system obtains its handler graph from compose_engine (built off the live PriorityEventBus, environment reflecting the credential probe, feed=LiveBarFeed, store=None) and reuses FeeModelCommissionEstimator; the hand-rolled ExecutionHandler/OrderHandler/StrategiesHandler/EventHandler construction AND the re-inlined _estimate_commission closure are DELETED — no parallel handler-wiring copy remains in live_trading_system.py (D-05)"
+    - "the compose Engine stays the shared, mode-agnostic, OKX-free graph — the venue/connector handles are NOT bolted onto it as dead OKX None-fields (D-06)"
+    - "the factory's VenueLifecycle (returned by assemble_venue) is the SINGLE venue/connector holder — build_live_system stops field-by-field unpacking it; one cohesive object flows through (D-07)"
+    - "the lifecycle is unpacked in the facade __init__: self._okx_* are sourced off lifecycle.bundle.*/lifecycle.provider WITH the bundle.connector-is-not-None streaming-venue guard preserved so paper stays None; the safety/reconcile/stream method bodies P7 will extract stay UNCHURNED (D-08)"
+    - "the SQL spine (system_db_backend / halt_record_store) stays SEPARATE facade/infra fields — NOT folded into the venue holder (folding would recreate the grab-bag) (D-09)"
+    - "LiveSystemComponents (the 20-field Any bag) is DELETED; the facade __init__ is direct pure injection taking the compose Engine + the VenueLifecycle + the SQL/halt handles as keyword-only params, sourcing store/order_storage/signal_store FROM the engine (engine.store=None on live / engine.order_handler.storage / engine.strategies_handler.signal_store) — no duplicate fields; the interim Engine reconstruction in _initialize_live_session is REMOVED (reads the real engine off injected self._engine) (D-10)"
+    - "the no-Postgres-creds in-memory fallback arm (build_live_system, the probe.password/probe.url branch) STILL routes through compose_engine with environment reflecting the probe result — the fallback-branch edge (SEAM-01) is verified by a live-build on BOTH the in-memory and Postgres arms (D-05)"
+    - "nothing on the live path reads self.store expecting a real store — engine.store is None on live and only held, never read as a real store (D-02 verify item confirmed)"
+  artifacts:
+    - "itrader/trading_system/live_trading_system.py — build_live_system consuming compose_engine; LiveSystemComponents deleted; pure-injection facade __init__"
+  key_links:
+    - "build_live_system -> EngineContext(feed=LiveBarFeed, store=None, environment=probe-result) -> compose_engine(ctx) -> the live handler graph"
+    - "facade __init__ <- compose Engine (handlers/storages) + VenueLifecycle (venue/connector) + SQL/halt handles"
+  prohibitions:
+    - statement: "MUST NOT change backtest output bytes (behavior-preserving; this plan is live-only, backtest-dark)"
+      status: enforced
+      verification: "poetry run pytest tests/integration/test_backtest_oracle.py — oracle 134 / 46189.87730727451 (check_exact=True) unchanged"
+    - statement: "MUST NOT pull ccxt.pro/SQL onto the backtest import path"
+      status: enforced
+      verification: "poetry run pytest tests/integration/test_okx_inertness.py green (heavy imports stay lazy inside build_live_system)"
+    - statement: "MUST NOT alter live runtime behavior (order flow, safety, reconcile, stream) — construction/wiring only; the safety/reconcile/stream method bodies stay untouched (P6 D-04 / D-08)"
+      status: enforced
+      verification: "poetry run pytest tests/integration/test_live_paper_lifecycle.py tests/integration/test_live_system_okx_wiring.py tests/unit/trading_system tests/unit/execution — green with no behavioral test changes"
+---
+
+<objective>
+Rewire `build_live_system` to obtain its handler graph from the now-spec-free `compose_engine`
+(plan 06.1-01), deleting the hand-rolled parallel handler construction and the re-inlined
+`_estimate_commission` closure; then collapse the `LiveSystemComponents` bag and the interim
+`Engine` reconstruction — the facade becomes direct pure injection over the compose `Engine` + the
+factory's `VenueLifecycle` + the separate SQL/halt handles (SEAM-01 live consumption + SEAM-02).
+
+Purpose: Phase 6 left `build_live_system` re-implementing `compose_engine` by hand (a
+single-producer/single-consumer 20-field `Any` bag + a duplicated commission closure) as a
+deliberately shallow interim. This plan lands the real seam so Phase 7's SafetyController /
+ReconciliationCoordinator / StreamRecoveryHandler extraction builds on the clean graph. Output: a
+`build_live_system` that calls `compose_engine`, a deleted `LiveSystemComponents`, and a
+pure-injection facade. Behavior-preserving; live is backtest-dark.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-CONTEXT.md
+@.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-SPEC.md
+@.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-01-SUMMARY.md
+@itrader/trading_system/compose.py
+@itrader/venues/lifecycle.py
+@itrader/venues/bundle.py
+</context>
+
+<artifacts_produced>
+Symbols this phase (this plan) creates/changes — excluded from the source-grounding drift pass:
+- `LiveSystemComponents` (DELETED — the 20-field Any bag, live_trading_system.py:103-134)
+- `_estimate_commission` closure (DELETED — live_trading_system.py:1541-1545; replaced by compose's `FeeModelCommissionEstimator`)
+- The interim `Engine(...)` reconstruction in `_initialize_live_session` (DELETED — live_trading_system.py:926-937)
+- The hand-rolled `ExecutionHandler`/`OrderHandler`/`StrategiesHandler`/`EventHandler` construction inside `build_live_system` (DELETED — the graph now comes from `compose_engine`)
+- `LiveTradingSystem.__init__` (CHANGED signature — pure injection: compose `Engine` + `VenueLifecycle` + SQL/halt handles as keyword-only params; no `components` bag)
+- `self._engine` (NEW facade field — the injected compose `Engine`, source of truth for `_initialize_live_session`)
+</artifacts_produced>
+
+<!-- These identifiers name the exact symbols this plan DELETES; the action must name them so the executor removes them, and the acceptance criteria negative-grep them to prove removal. Legitimate appearance (deletion targets). -->
+<!-- planner-discipline-allow: _estimate_commission -->
+<!-- planner-discipline-allow: class LiveSystemComponents -->
+<!-- planner-discipline-allow: Engine( -->
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: build_live_system consumes compose_engine; delete the hand-rolled graph + _estimate_commission (D-05/D-02)</name>
+  <files>itrader/trading_system/live_trading_system.py</files>
+  <read_first>
+    - itrader/trading_system/live_trading_system.py — build_live_system (:1438-1734): the PriorityEventBus/store/LiveBarFeed setup (:1476-1481), the Postgres-vs-in-memory fallback arm (:1492-1535, the probe.password/probe.url branch that selects order_storage/signal_store/system_db_backend), the hand-rolled ExecutionHandler+_estimate_commission+StrategiesHandler+OrderHandler+EventHandler block (:1537-1572) this task DELETES, the EngineContext(...) at :1619 (now carrying feed/store from plan 06.1-01), and the venue-assembly block (:1574-1657). Indentation: 4-SPACE.
+    - itrader/trading_system/compose.py — the spec-free compose_engine(ctx, *, exchange_config=None, results_store=None) (from plan 06.1-01) + FeeModelCommissionEstimator (:54-78) that replaces the closure; the Engine holder fields (engine.order_handler.storage / engine.strategies_handler.signal_store / engine.execution_handler) build_live_system now sources from.
+    - .planning/phases/06.1-.../06.1-01-SUMMARY.md — the exact new compose signature + ctx field shape + how compose wires handler-owned storage (so live reconciles its durable-store path with compose).
+  </read_first>
+  <action>
+    File is 4-SPACE (measure bytes; do not normalize). Build the live EngineContext (feed=the
+    LiveBarFeed, store=None per D-02, environment reflecting the credential probe — the same
+    environment string live uses today on each arm, so the fallback still routes through compose) and
+    call engine = compose_engine(ctx, exchange_config=None, results_store=None). Live's ExecutionHandler
+    keeps exchange_config=None (its default today, byte-preserving). DELETE the hand-rolled
+    ExecutionHandler(global_queue) / StrategiesHandler(...) / OrderHandler(...) / EventHandler(...)
+    construction (:1537-1572) AND the _estimate_commission closure (:1541-1545): the graph + commission
+    adapter now come from compose. Source the handles the downstream venue wiring needs off the engine —
+    execution_handler = engine.execution_handler (for execution_handler.exchanges[...] venue wiring and
+    the PaperVenuePlugin(...simulated...) registration), portfolio_handler = engine.portfolio_handler,
+    etc. — do NOT rebuild them. Preserve the Postgres/in-memory fallback ARM that selects
+    order_storage/signal_store/system_db_backend byte-for-byte (CachedSqlOrderStorage/SqlOrderStorage on
+    the Postgres arm, in-memory on the fallback arm): compose builds handlers with handler-owned storage
+    from ctx.environment, so reconcile the live durable-store behavior with compose per 06.1-01-SUMMARY
+    (thread the probe-selected sql_engine onto ctx.sql_engine + environment so the handler-owned storage
+    matches today's live behavior; where live previously injected order_storage/signal_store into the
+    handlers, verify the compose-owned storage yields the identical durable path). Keep the
+    feed/provider/venue wiring (feed.set_provider / provider.set_bar_sink /
+    execution_handler.exchanges[exchange] = ...) intact. Heavy imports (LiveBarFeed, SqlSettings,
+    ccxt/venue substrate) STAY lazy inside the function body (inertness). No fenced code in comments.
+  </action>
+  <verify>
+    <automated>poetry run pytest tests/integration/test_okx_inertness.py -q</automated>
+  </verify>
+  <acceptance_criteria>
+    - `poetry run python -c "import inspect;from itrader.trading_system import live_trading_system as m;print('compose_engine(' in inspect.getsource(m.build_live_system))"` prints True
+    - `grep -c "_estimate_commission" itrader/trading_system/live_trading_system.py` == 0 (closure deleted, D-05)
+    - No second construction of the four handlers inside build_live_system — `poetry run python -c "import inspect;from itrader.trading_system import live_trading_system as m;s=inspect.getsource(m.build_live_system);assert s.count('EventHandler(')==0 and s.count('ExecutionHandler(')==0 and s.count('OrderHandler(')==0 and s.count('StrategiesHandler(')==0;print('NO_HANDROLL')"` prints NO_HANDROLL
+    - `poetry run pytest tests/integration/test_okx_inertness.py` green (heavy imports stay lazy; production still registers 'okx' data provider + maps paper->'okx', per the existing register-vs-build assertions)
+    - `poetry run pytest tests/integration/test_live_system_okx_wiring.py tests/integration/test_store_live_drive.py` green (live wiring preserved on both okx + binance/in-memory arms — the fallback-branch edge)
+  </acceptance_criteria>
+  <done>build_live_system calls compose_engine for its graph, reuses FeeModelCommissionEstimator, and no hand-rolled handler construction or _estimate_commission closure remains; both the Postgres and in-memory arms route through compose.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Delete LiveSystemComponents; facade __init__ = pure injection over Engine + VenueLifecycle + SQL handles (D-06/D-07/D-08/D-09/D-10)</name>
+  <files>itrader/trading_system/live_trading_system.py</files>
+  <read_first>
+    - itrader/trading_system/live_trading_system.py — the LiveSystemComponents dataclass (:103-134, DELETE), the facade __init__ (:145-252, especially the injected-component-graph block :177-197 that stores 20 fields), the for_exchange classmethod (:254-283, still calls build_live_system — keep its contract), and the facade construction after wiring (the components = LiveSystemComponents(...) + facade = LiveTradingSystem(components, ...) at :1660-1682). Indentation: 4-SPACE.
+    - itrader/venues/lifecycle.py — VenueLifecycle: .bundle + .provider read-only properties; the single cohesive venue/connector holder (D-07).
+    - itrader/venues/bundle.py — VenueBundle: exchange / account_factory / connector(None for paper) — reached via lifecycle.bundle.*; the connector-None discriminator (D-08).
+    - itrader/trading_system/compose.py — the Engine holder fields the facade sources from (engine.store [None on live], engine.order_handler.storage, engine.strategies_handler.signal_store, engine.event_handler, engine.portfolio_handler, engine.execution_handler, engine.screeners_handler, engine.global_queue, engine.feed).
+  </read_first>
+  <action>
+    File is 4-SPACE. DELETE the @dataclass class LiveSystemComponents (:103-134). Rewrite the facade
+    __init__ to PURE INJECTION taking keyword-only params: the compose engine: Engine, the lifecycle:
+    VenueLifecycle | None, and the SEPARATE SQL/halt handles system_db_backend + halt_record_store
+    (D-09 — the SQL spine is NOT part of the venue holder), plus exchange: str and status_callback.
+    Store self._engine = engine. Source the handler/feed/store fields OFF the engine (no duplicate
+    fields): self.event_handler = engine.event_handler, self.portfolio_handler =
+    engine.portfolio_handler, self.strategies_handler = engine.strategies_handler, self.order_handler =
+    engine.order_handler, self.execution_handler = engine.execution_handler, self.screeners_handler =
+    engine.screeners_handler, self.global_queue = engine.global_queue, self.feed = engine.feed,
+    self.store = engine.store (None on live — held, never read as a real store, D-02), self._order_storage
+    = engine.order_handler.storage, self._signal_store = engine.strategies_handler.signal_store. Source
+    the venue handles OFF the lifecycle WITH the streaming-venue guard preserved (D-08): self._venue_lifecycle
+    = lifecycle; self._venue_bundle = lifecycle.bundle if lifecycle is not None else None; self._okx_connector
+    = lifecycle.bundle.connector if lifecycle is not None else None; and the streaming handles
+    (self._okx_exchange, self._venue_account, self._okx_data_provider) set from the lifecycle ONLY when
+    lifecycle is not None and lifecycle.bundle.connector is not None (paper keeps them None — byte-identical
+    to today's :1648-1652 guard; venue_account via lifecycle.bundle.account_factory()). Keep
+    self._system_db_backend / self._halt_record_store as the separate injected fields (D-09). Leave ALL the
+    fresh per-instance runtime state (status/locks/flags/stats) and the safety/reconcile/stream method BODIES
+    exactly as-is (D-08/P6 D-04). In build_live_system: DELETE the components = LiveSystemComponents(...)
+    construction (:1660-1681) and construct the facade directly with the engine + lifecycle + SQL handles
+    (facade = LiveTradingSystem(engine=engine, lifecycle=venue_lifecycle, system_db_backend=system_db_backend,
+    halt_record_store=halt_record_store, exchange=exchange, status_callback=status_callback)). The
+    facade-dependent post-construction wiring (:1684-1731 — provider/exchange/connector halt signals,
+    LiveRunner/ErrorPolicy) stays.
+  </action>
+  <verify>
+    <automated>poetry run python -c "from itrader.trading_system import live_trading_system as m; assert not hasattr(m,'LiveSystemComponents'); import inspect; p=inspect.signature(m.LiveTradingSystem.__init__).parameters; assert 'engine' in p and 'lifecycle' in p; print('INJECT_OK')"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c "class LiveSystemComponents" itrader/trading_system/live_trading_system.py` == 0 (D-10)
+    - `LiveTradingSystem.__init__` takes keyword-only `engine` + `lifecycle` + `system_db_backend` + `halt_record_store` (asserted by the Task-2 verify printing INJECT_OK); no `components` param remains
+    - `poetry run python -c "import inspect;from itrader.trading_system import live_trading_system as m;print('components.' not in inspect.getsource(m.LiveTradingSystem.__init__))"` prints True (no bag-field reads)
+    - `poetry run pytest tests/integration/test_live_paper_lifecycle.py tests/integration/test_early_durable_halt_refusal.py` green (facade construction + halt lifecycle preserved)
+  </acceptance_criteria>
+  <done>LiveSystemComponents is deleted; the facade __init__ is pure injection sourcing handlers/storage off the engine and venue handles off the lifecycle (paper None-guard preserved), with the SQL spine kept separate.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Remove the interim Engine reconstruction in _initialize_live_session; read the injected engine (D-10)</name>
+  <files>itrader/trading_system/live_trading_system.py</files>
+  <read_first>
+    - itrader/trading_system/live_trading_system.py — _initialize_live_session (:892-980): the lazy imports (:913-918), the INTERIM Engine(...) reconstruction (:926-937, DELETE) with its placeholder clock/time_generator, the SessionInitializer construction (:959-966) that consumes the engine, and the engine.universe mirror (:969). Indentation: 4-SPACE.
+    - .planning/phases/06.1-.../06.1-02 (this plan) Task 2 — self._engine is now the injected compose Engine.
+  </read_first>
+  <action>
+    File is 4-SPACE. DELETE the interim Engine(...) reconstruction block (:926-937) and its
+    now-unnecessary lazy imports of Engine / BacktestClock / TimeGenerator (:914,:915,:917). Replace
+    `engine = Engine(...)` with `engine = self._engine` (the real compose Engine injected in Task 2).
+    Everything downstream (venue_exchange resolution, UniverseHandlerConfig, the SessionInitializer
+    construction over `engine`, the `self.universe = engine.universe` mirror, the idempotency latch,
+    the try/except -> SystemStatus.ERROR mapping) stays byte-identical. Keep the remaining lazy imports
+    that are still needed here (SessionInitializer, UniverseHandlerConfig — hoisting them is plan 06.1-04,
+    not this plan). Per D-04/D-08 do NOT touch the safety/reconcile/stream method bodies.
+  </action>
+  <verify>
+    <automated>poetry run python -c "import inspect;from itrader.trading_system import live_trading_system as m;s=inspect.getsource(m.LiveTradingSystem._initialize_live_session);assert 'Engine(' not in s, 'interim Engine still constructed';assert 'self._engine' in s;print('NO_INTERIM_ENGINE')"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `poetry run python -c "import inspect;from itrader.trading_system import live_trading_system as m;print('Engine(' not in inspect.getsource(m.LiveTradingSystem._initialize_live_session))"` prints True (no interim Engine)
+    - `grep -c "Engine(" itrader/trading_system/live_trading_system.py` == 0 (no Engine construction anywhere in the file — the compose Engine is injected, D-10)
+    - `poetry run pytest tests/integration/test_backtest_oracle.py` — oracle byte-exact `134 / 46189.87730727451` (regression check; live is backtest-dark)
+    - `poetry run pytest tests/integration/test_okx_inertness.py tests/integration/test_live_paper_lifecycle.py tests/unit/trading_system tests/unit/execution` green
+    - `poetry run mypy itrader` clean (live_trading_system.py is ignore_errors by config; compose.py/engine_context.py still strict-clean)
+  </acceptance_criteria>
+  <done>_initialize_live_session reads the injected compose Engine off self._engine; no Engine(...) is constructed anywhere in live_trading_system.py; oracle byte-exact and inertness green.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| live composition root ↔ live runtime behavior | This plan restructures how the live graph is CONSTRUCTED; it must not change order flow / safety / reconcile / stream behavior (P6 D-04 bodies untouched). No new external input, auth, secret, or network surface. |
+| in-memory fallback arm ↔ compose_engine | The no-Postgres-creds arm must still route through compose_engine (not silently bypass it) — the fallback-branch edge. |
+| backtest import graph ↔ live heavy imports | The rewire must keep ccxt.pro/SQL/venue substrate lazy inside build_live_system's body. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-06.1.02-FALLBACK | Tampering | in-memory fallback arm bypassing compose | high | mitigate | live-build test on BOTH the in-memory (binance) and Postgres (okx) arms — test_live_system_okx_wiring + test_store_live_drive green; the fallback arm constructs through compose_engine |
+| T-06.1.02-BEHAV | Tampering | facade __init__ / venue-handle sourcing | high | mitigate | safety/reconcile/stream method bodies untouched (grep/diff scoped to __init__ + build_live_system); paper connector-None guard preserved so paper _okx_* stay None; live lifecycle suite green with no behavioral test changes |
+| T-06.1.02-INERT | Tampering | build_live_system heavy imports | high | mitigate | test_okx_inertness green — LiveBarFeed/SqlSettings/ccxt/venue substrate stay lazy inside the function body |
+| T-06.1.02-ORACLE | Tampering | shared compose Engine reuse | medium | mitigate | oracle byte-exact regression check (Task 3) — live is backtest-dark, so a drift would signal accidental shared-graph coupling |
+</threat_model>
+
+<verification>
+- `poetry run pytest tests/integration/test_backtest_oracle.py` — byte-exact `134 / 46189.87730727451` (`check_exact=True`) unchanged (regression; live is backtest-dark).
+- `poetry run pytest tests/integration/test_okx_inertness.py` — green (heavy live imports stay lazy).
+- `poetry run pytest tests/integration/test_live_system_okx_wiring.py tests/integration/test_store_live_drive.py tests/integration/test_live_paper_lifecycle.py` — live-build on both the Postgres (okx) and in-memory (binance) arms; the fallback-branch edge verified.
+- `poetry run pytest tests/unit/trading_system tests/unit/execution` — live construction/lifecycle unit suite green, no behavioral test changes.
+- `poetry run mypy itrader` — clean.
+</verification>
+
+<success_criteria>
+- `build_live_system` calls `compose_engine` for its graph; the hand-rolled handler construction + `_estimate_commission` closure are gone (grep-clean); FeeModelCommissionEstimator reused.
+- `LiveSystemComponents` no longer exists; no `Engine(...)` is constructed in `live_trading_system.py`; the facade __init__ is pure injection (D-10).
+- The VenueLifecycle is the single venue holder; SQL spine kept separate (D-07/D-09); paper `_okx_*` stay None (D-08).
+- Oracle byte-exact; inertness green; live construction/lifecycle suite green.
+</success_criteria>
+
+<output>
+Create `.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-02-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-02-SUMMARY.md
+++ b/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-02-SUMMARY.md
@@ -1,0 +1,138 @@
+---
+phase: 06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo
+plan: 02
+subsystem: trading_system / live composition root
+tags: [SEAM-01, SEAM-02, compose-engine, pure-injection, venue-lifecycle, live-only]
+status: complete
+requires:
+  - "compose_engine(ctx, *, exchange_config=None, results_store=None) — spec-free shared seam (06.1-01)"
+  - "EngineContext.feed (required) + EngineContext.store (Optional=None) mode-injection seam (06.1-01)"
+  - "VenueLifecycle (.bundle/.provider) as the cohesive venue/connector holder (Phase 05-06)"
+provides:
+  - "build_live_system consuming compose_engine for its handler graph (no parallel hand-rolled copy)"
+  - "pure-injection LiveTradingSystem.__init__ (engine + lifecycle + SQL/halt handles, no components bag)"
+  - "LiveSystemComponents DELETED; interim Engine reconstruction in _initialize_live_session DELETED"
+affects:
+  - "itrader/trading_system/live_trading_system.py"
+tech_stack:
+  added: []
+  patterns:
+    - "ctx.environment/sql_engine per-credential-probe-arm drive compose's handler-OWNED storage init"
+    - "single VenueLifecycle holder unpacked in __init__ (D-08) — bodies unchurned for P7"
+    - "SQL spine + halt store stay SEPARATE facade infra (D-09), not folded into the venue holder"
+key_files:
+  created: []
+  modified:
+    - "itrader/trading_system/live_trading_system.py"
+decisions:
+  - "D-05: build_live_system calls compose_engine; hand-rolled ExecutionHandler/OrderHandler/StrategiesHandler/EventHandler + _estimate_commission closure deleted; FeeModelCommissionEstimator reused"
+  - "D-02: live carries store=None (engine.store) — held, never read as a real store (verify item confirmed)"
+  - "D-07/D-08: VenueLifecycle is the single venue/connector holder; unpacked in __init__ with the paper connector-None guard preserved; safety/reconcile/stream bodies untouched"
+  - "D-09: system_db_backend + halt_record_store kept SEPARATE infra fields (not in the venue holder)"
+  - "D-10: LiveSystemComponents deleted; __init__ = direct pure injection sourcing handlers/storages off the engine; interim Engine reconstruction removed (reads self._engine)"
+  - "SEAM-01 fallback edge: the in-memory (no-Postgres-creds) arm routes through compose_engine with environment='backtest'/sql_engine=None; the Postgres arm with environment='live'/sql_engine=backend"
+metrics:
+  duration_minutes: 18
+  tasks: 3
+  files_modified: 1
+  completed: 2026-07-14
+---
+
+# Phase 06.1 Plan 02: build_live_system Consumes compose_engine + Pure-Injection Facade Summary
+
+Rewired the live composition root so `build_live_system` obtains its handler graph from the
+now spec-free `compose_engine` (06.1-01) instead of hand-rolling a parallel copy, then collapsed
+the `LiveSystemComponents` 20-field `Any` bag and the interim `Engine` reconstruction into a direct
+pure-injection facade over the compose `Engine` + the factory's `VenueLifecycle` + the separate
+SQL/halt handles — behavior-preserving (backtest oracle byte-exact `134 / 46189.87730727451`,
+inertness green), live-only.
+
+## What was built
+
+- **Task 1 — compose consumption (D-05/D-02):** `build_live_system` now builds the shared
+  mode-injection `EngineContext` (`feed=LiveBarFeed`, `store=None` per D-02, and
+  `environment`+`sql_engine` reflecting the credential-probe arm) and calls
+  `engine = compose_engine(ctx, exchange_config=None, results_store=None)`. The hand-rolled
+  `ExecutionHandler`/`StrategiesHandler`/`OrderHandler`/`EventHandler` block AND the re-inlined
+  `_estimate_commission` closure are DELETED — compose supplies the graph and reuses
+  `FeeModelCommissionEstimator`. The credential-probe arm now selects only `environment`
+  (`'live'` / `'backtest'`) + the shared `SqlEngine`; compose's handler-OWNED storage init derives
+  the identical durable path on both arms (Postgres → `CachedSqlOrderStorage(SqlOrderStorage(backend))`
+  + the live signal store; in-memory → `InMemoryOrderStorage` + `InMemorySignalStore`). The single
+  early `ctx` is reused for venue assembly (plugins read only `ctx.bus` / `ctx.config.stream`).
+- **Task 2 — pure-injection facade (D-06..D-10):** the `@dataclass LiveSystemComponents` is DELETED;
+  `LiveTradingSystem.__init__` is direct keyword-only injection (`engine`, `lifecycle`,
+  `system_db_backend`, `halt_record_store`, `exchange`, `status_callback`). Handlers/feed/storages are
+  sourced OFF `engine` (`store=engine.store` held-not-read; `_order_storage=engine.order_handler.storage`;
+  `_signal_store=engine.strategies_handler.signal_store`). Venue/connector handles are sourced off the
+  single `VenueLifecycle` with the `bundle.connector`-None streaming-venue guard preserved (paper keeps
+  every `_okx_*` None); the SQL spine + halt store stay SEPARATE infra fields (D-09). `build_live_system`
+  constructs the facade directly and no longer field-by-field unpacks the lifecycle (only the
+  streaming-venue `execution_handler` registration + the two halt-signal handles stay in the factory).
+- **Task 3 — read the injected engine (D-10):** the interim `Engine(...)` reconstruction (with its
+  placeholder clock / time_generator) in `_initialize_live_session` is DELETED along with its now-unneeded
+  lazy imports (`Engine`/`BacktestClock`/`TimeGenerator`); `engine = self._engine` reads the real compose
+  Engine injected in Task 2. `SessionInitializer` / `wire_universe` / the `self.universe` mirror /
+  the idempotency latch / the `try/except → SystemStatus.ERROR` mapping stay byte-identical.
+
+## Verification evidence
+
+- `poetry run pytest tests/integration/test_backtest_oracle.py` — PASS, byte-exact
+  `134 / 46189.87730727451` (`check_exact=True`); run twice consecutively — identical (determinism).
+- `poetry run pytest tests/integration/test_okx_inertness.py` — PASS (heavy live imports stay lazy inside
+  `build_live_system`; `compose_engine`/`EngineContext` taken lazily in-body).
+- `poetry run pytest tests/integration/test_live_system_okx_wiring.py tests/integration/test_store_live_drive.py`
+  — PASS (the fallback-branch edge: live-build verified on BOTH the Postgres/okx and in-memory/binance arms).
+- `poetry run pytest tests/integration/test_live_paper_lifecycle.py tests/integration/test_early_durable_halt_refusal.py`
+  — PASS (facade construction + halt lifecycle preserved).
+- Broader live-touching sweep (17 files: durable-halt, halt-latch, live-bar-metrics, portfolio-durable-wiring,
+  paper-restart-restore, resume-gated/missed-fill, drift/off-loop/reconnect, venue-account-drop) — 88 passed.
+- `poetry run pytest tests/unit/trading_system tests/unit/execution` — PASS (289 passed).
+- `poetry run mypy itrader` — clean (249 source files).
+- Grep gates: `compose_engine(` in `build_live_system` == True; `_estimate_commission` == 0;
+  `EventHandler(`/`ExecutionHandler(`/`OrderHandler(`/`StrategiesHandler(` in `build_live_system` == 0;
+  `class LiveSystemComponents` == 0; `__init__` params include `engine`+`lifecycle` (INJECT_OK);
+  `components.` in `__init__` == 0; no interim `Engine(` in `_initialize_live_session` (NO_INTERIM_ENGINE);
+  `self._engine` present.
+
+## Deviations from Plan
+
+### Acceptance-criterion clarification (not a code deviation)
+
+**1. Task 3 grep `grep -c "Engine(" == 0` — one residual match is `SqlEngine(`, retained by design (D-09)**
+- **Found during:** Task 3 acceptance verification.
+- **Issue:** The literal grep `Engine(` matches `SqlEngine(` at the Postgres credential arm
+  (`backend = SqlEngine(SqlSettings(driver=SqlDriver.POSTGRESQL_PSYCOPG2))`) — a pre-existing,
+  legitimate construction of the SQL SPINE that D-09 EXPLICITLY keeps as separate infra.
+- **Resolution:** The criterion's stated intent is "no compose `Engine` construction anywhere in the
+  file". That intent is satisfied — the interim compose-`Engine(...)` reconstruction is gone; a precise
+  pattern (`grep -nE "(^|[^A-Za-z])Engine\(" | grep -v SqlEngine`) returns 0. The `SqlEngine(` match is
+  the SQL backend, not the compose Engine, and removing it would violate D-09. No code change made; the
+  compose Engine is injected (`self._engine`), never constructed in `live_trading_system.py`.
+
+No auto-fixed bugs (Rules 1-3) were needed — the plan executed as written. The behavior-preserving
+reconciliation of live's durable-store path with compose's handler-owned storage was verified against
+the storage factories (`OrderStorageFactory.create('live', sql_engine=backend)` yields the identical
+`CachedSqlOrderStorage(SqlOrderStorage(backend))`; `'backtest'` yields `InMemoryOrderStorage` — matching
+the former explicit construction byte-for-byte on both arms).
+
+## Known Stubs
+
+None — this is a deletion/rewire refactor. No stubs, mock data sources, or placeholder values were
+introduced. (Residual dead module-top imports — `CsvPriceStore`, the four handler classes,
+`SimulatedExchange`, the storage factories, `dataclass` — are now unused but LEFT IN PLACE: pure-import
+hoist/cleanup in `live_trading_system.py` is explicitly plan 06.1-04 scope, D-13.)
+
+## Threat Flags
+
+None — no new network endpoints, auth paths, file access, or trust-boundary schema changes. This plan
+restructures HOW the live graph is CONSTRUCTED only. The threat register's `mitigate` dispositions are
+satisfied: T-06.1.02-FALLBACK (both arms route through `compose_engine`, verified by the okx-wiring +
+store-live-drive suites); T-06.1.02-BEHAV (safety/reconcile/stream bodies untouched; paper `_okx_*` stay
+None via the preserved connector-None guard); T-06.1.02-INERT (heavy imports stay lazy — inertness green);
+T-06.1.02-ORACLE (oracle byte-exact regression check green — no accidental shared-graph coupling).
+
+## Self-Check: PASSED
+
+- File verified present: `itrader/trading_system/live_trading_system.py` (modified on disk).
+- Commits verified in `git log`: 19b0fa68 (Task 1), a8a77104 (Task 2), 6eb29959 (Task 3).

--- a/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-03-PLAN.md
+++ b/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-03-PLAN.md
@@ -1,0 +1,212 @@
+---
+phase: 06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo
+plan: 03
+type: execute
+wave: 3
+depends_on: [06.1-02]
+files_modified:
+  - itrader/trading_system/venue_spec.py
+  - itrader/trading_system/live_trading_system.py
+  - tests/unit/trading_system/test_venue_spec.py
+autonomous: true
+requirements: [SEAM-03]
+
+must_haves:
+  truths:
+    - "a small live-only VenueSpec (a frozen dataclass carrying exactly execution_venue / data_provider / account_id — genuinely venue-scoped, not backtest-shaped) feeds assemble_venue ONLY, never compose_engine (compose is spec-free since D-04); it is a typed dataclass, not a duck-typed SimpleNamespace (D-11)"
+    - "ONE shared builder (build_venue_spec) produces the VenueSpec and centralizes the {'okx':'okx','paper':'okx'} default-provider map in exactly ONE location; BOTH for_exchange and build_live_system call it — the twice-written SimpleNamespace + default-map (live_trading_system.py:274-283 and :1625-1633) are deleted (D-11)"
+    - "for_exchange('okx'|'paper'|other) and a direct build_live_system(spec) produce IDENTICAL VenueSpecs across the venue set (a unit test asserts equality via the dataclass __eq__) (D-11)"
+  artifacts:
+    - "itrader/trading_system/venue_spec.py — the frozen VenueSpec dataclass + build_venue_spec(...) shared builder"
+    - "tests/unit/trading_system/test_venue_spec.py — the for_exchange vs build_live_system spec-equality unit test"
+  key_links:
+    - "build_venue_spec is the single home of the {'okx':'okx','paper':'okx'} default-provider map -> VenueSpec -> assemble_venue"
+    - "for_exchange -> build_venue_spec -> build_live_system(spec); build_live_system -> build_venue_spec (or consumes the incoming VenueSpec) -> assemble_venue"
+  prohibitions:
+    - statement: "MUST NOT change backtest output bytes (behavior-preserving; live-only, backtest-dark)"
+      status: enforced
+      verification: "poetry run pytest tests/integration/test_backtest_oracle.py — oracle 134 / 46189.87730727451 (check_exact=True) unchanged"
+    - statement: "MUST NOT pull ccxt.pro/SQL onto the backtest import path (venue_spec.py is pure — strings + a dataclass, no venue substrate import)"
+      status: enforced
+      verification: "poetry run pytest tests/integration/test_okx_inertness.py green"
+    - statement: "MUST NOT alter live runtime behavior — the VenueSpec feeds assemble_venue with the same execution_venue/data_provider/account_id values as today (construction/wiring only)"
+      status: enforced
+      verification: "poetry run pytest tests/integration/test_live_system_okx_wiring.py tests/unit/trading_system — green with no behavioral test changes"
+---
+
+<objective>
+Centralize the live venue-selection spec: introduce a small typed `VenueSpec` dataclass + a single
+shared `build_venue_spec` builder that owns the `{'okx':'okx','paper':'okx'}` default-provider map,
+and repoint BOTH `for_exchange` and `build_live_system` to it — killing the twice-written
+`SimpleNamespace` fake-spec and duplicated default-map (SEAM-03).
+
+Purpose: after D-04 made `compose_engine` spec-free, the ONLY "spec" live still needs is the
+venue-selection trio `assemble_venue` reads (`execution_venue` / `data_provider` / `account_id`).
+Today it is duck-typed via `SimpleNamespace` and the default-map is written in two places
+(live_trading_system.py:274-283 and :1625-1633). Output: one typed builder, one home for the map,
+and a unit test proving `for_exchange` and `build_live_system` produce identical specs.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-CONTEXT.md
+@.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-SPEC.md
+@itrader/trading_system/system_spec.py
+@itrader/venues/assemble.py
+</context>
+
+<artifacts_produced>
+Symbols this phase (this plan) creates/changes — excluded from the source-grounding drift pass:
+- `itrader/trading_system/venue_spec.py::VenueSpec` (NEW frozen dataclass — `execution_venue` / `data_provider` / `account_id`)
+- `itrader/trading_system/venue_spec.py::build_venue_spec(execution_venue, *, data_provider=None, account_id=None) -> VenueSpec` (NEW shared builder; sole home of the `{'okx':'okx','paper':'okx'}` default-provider map)
+- The two inline `SimpleNamespace` venue-spec constructions + duplicated default maps in `live_trading_system.py` (:274-283 for_exchange, :1625-1633 build_live_system) — DELETED / repointed to `build_venue_spec`
+- `tests/unit/trading_system/test_venue_spec.py` (NEW — spec-equality unit test)
+</artifacts_produced>
+
+<!-- The default-provider map literal must be named in <action>: Task 1 WRITES it into the new venue_spec.py (its sole home), while Task 2's acceptance negative-greps it in live_trading_system.py to prove the two inline copies are removed. Different files — legitimate appearance. -->
+<!-- planner-discipline-allow: 'okx': 'okx', 'paper': 'okx' -->
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create the typed VenueSpec dataclass + the shared build_venue_spec builder (D-11)</name>
+  <files>itrader/trading_system/venue_spec.py</files>
+  <read_first>
+    - itrader/trading_system/system_spec.py — the sibling declarative spec value object (the frozen-dataclass style + docstring conventions to mirror); its execution_venue/data_provider/account_id fields (:124-126) are the venue-selection trio VenueSpec promotes. Indentation: TABS (match this sibling).
+    - itrader/venues/assemble.py — assemble_venue reads spec.execution_venue / spec.data_provider / spec.account_id (:71-76); the VenueSpec must structurally satisfy exactly those three reads.
+    - itrader/trading_system/live_trading_system.py — the two current inline SimpleNamespace specs (:277-281 for_exchange, :1625-1633 build_live_system) + the {'okx':'okx','paper':'okx'}.get(exchange,'okx') default-map (:274-275 and :1630-1631) whose logic build_venue_spec centralizes.
+  </read_first>
+  <action>
+    NEW file itrader/trading_system/venue_spec.py, indentation TABS (match the sibling
+    system_spec.py). Define a frozen dataclass VenueSpec with exactly three fields: execution_venue: str,
+    data_provider: str, account_id: Optional[str] = None (frozen=True gives a free __eq__ for the
+    equality test). Define the shared builder build_venue_spec(execution_venue: str, *, data_provider:
+    Optional[str] = None, account_id: Optional[str] = None) -> VenueSpec that applies the default-provider
+    map when data_provider is None: data_provider or {'okx': 'okx', 'paper': 'okx'}.get(execution_venue,
+    'okx') — this literal is now the SOLE home of the map. The module is pure (strings + a dataclass) —
+    import NO venue substrate / ccxt / SQL, so it stays import-inert and is mypy --strict clean. Module
+    docstring: cite D-11 and note it feeds assemble_venue ONLY, never compose_engine (compose is spec-free
+    since D-04). No fenced code in comments.
+  </action>
+  <verify>
+    <automated>poetry run python -c "from itrader.trading_system.venue_spec import VenueSpec, build_venue_spec; import dataclasses; assert [f.name for f in dataclasses.fields(VenueSpec)]==['execution_venue','data_provider','account_id']; assert build_venue_spec('paper').data_provider=='okx'; assert build_venue_spec('okx').data_provider=='okx'; assert build_venue_spec('binance').data_provider=='okx'; assert build_venue_spec('okx', data_provider='replay').data_provider=='replay'; assert build_venue_spec('okx')==build_venue_spec('okx'); print('VENUESPEC_OK')"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `poetry run mypy itrader/trading_system/venue_spec.py` clean (new strict-checked module)
+    - `VenueSpec` has exactly the fields `execution_venue, data_provider, account_id` and is frozen (equality works) — asserted by the Task-1 verify printing VENUESPEC_OK
+    - `build_venue_spec` applies `{'okx':'okx','paper':'okx'}` default when `data_provider` is None and honors an explicit `data_provider` override
+    - `grep -c "'okx': 'okx', 'paper': 'okx'" itrader/trading_system/venue_spec.py` == 1 (the map lives here)
+    - `poetry run pytest tests/integration/test_okx_inertness.py` green (module is pure/import-inert)
+  </acceptance_criteria>
+  <done>A frozen typed VenueSpec + the shared build_venue_spec builder exist, owning the sole copy of the default-provider map; mypy-clean and import-inert.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Repoint for_exchange + build_live_system to build_venue_spec; delete both inline SimpleNamespace specs (D-11)</name>
+  <files>itrader/trading_system/live_trading_system.py</files>
+  <read_first>
+    - itrader/trading_system/live_trading_system.py — for_exchange (:254-283): builds a SimpleNamespace spec (:277-281) via the inline default-map (:274-275) and passes it to build_live_system; build_live_system (:1438-1734): the venue_spec = SimpleNamespace(...) at :1625-1633 (its inline default-map at :1630-1631) that feeds assemble_venue at :1638-1639. Indentation: 4-SPACE.
+    - itrader/trading_system/venue_spec.py — the build_venue_spec builder from Task 1.
+    - itrader/venues/assemble.py — confirms assemble_venue consumes spec.execution_venue/data_provider/account_id, so a VenueSpec drops in for the SimpleNamespace unchanged.
+  </read_first>
+  <action>
+    File is 4-SPACE. Import build_venue_spec (and VenueSpec if needed for annotation) at module top
+    (pure — safe to hoist now; plan 06.1-04 formalizes the barrel/import hoist but this pure import is
+    fine here). In for_exchange: replace the inline SimpleNamespace + default-map (:274-281) with spec =
+    build_venue_spec(exchange, data_provider=overrides.pop('data_provider', None),
+    account_id=overrides.pop('account_id', None)); still pop data_plugins and pass through unchanged.
+    In build_live_system: replace the venue_spec = SimpleNamespace(...) block (:1625-1633) with a call to
+    build_venue_spec using the incoming spec's fields (venue_spec = build_venue_spec(exchange,
+    data_provider=getattr(spec, 'data_provider', None), account_id=getattr(spec, 'account_id', None))) so
+    the {'okx':'okx','paper':'okx'} map exists in exactly ONE location (venue_spec.py). Feed venue_spec to
+    assemble_venue exactly as today. Remove the now-unused SimpleNamespace import if no other use remains.
+    The values assemble_venue receives are byte-identical to today (same default-map logic, same explicit
+    overrides). No fenced code in comments.
+  </action>
+  <verify>
+    <automated>poetry run python -c "import inspect; from itrader.trading_system import live_trading_system as m; src=inspect.getsource(m); assert src.count(\"'okx': 'okx', 'paper': 'okx'\")==0, 'map still inline in live module'; assert 'build_venue_spec' in src; print('REPOINT_OK')"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c "'okx': 'okx', 'paper': 'okx'" itrader/trading_system/live_trading_system.py` == 0 (both inline maps removed)
+    - The repo-wide count of the default-map literal is exactly 1 — `grep -rc "'okx': 'okx', 'paper': 'okx'" itrader/ | grep -v ':0' ` shows only `itrader/trading_system/venue_spec.py:1`
+    - `poetry run python -c "import inspect;from itrader.trading_system import live_trading_system as m;print('build_venue_spec' in inspect.getsource(m.LiveTradingSystem.for_exchange) and 'build_venue_spec' in inspect.getsource(m.build_live_system))"` prints True
+    - `poetry run pytest tests/integration/test_live_system_okx_wiring.py` green (assemble_venue receives identical specs; live wiring unchanged)
+    - `poetry run pytest tests/integration/test_okx_inertness.py` green
+  </acceptance_criteria>
+  <done>for_exchange and build_live_system both build the live spec via build_venue_spec; the default-provider map + spec construction exist in exactly ONE location (venue_spec.py).</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Unit test — for_exchange and build_live_system produce identical VenueSpecs across the venue set (SEAM-03 acceptance)</name>
+  <files>tests/unit/trading_system/test_venue_spec.py</files>
+  <read_first>
+    - tests/unit/trading_system/ — existing unit tests in this dir for the fixture/marker conventions (folder-derived `unit` marker auto-applied; no package __init__ in tests/unit dirs per the test-dir collision note). Indentation: 4-SPACE (test files).
+    - itrader/trading_system/venue_spec.py — VenueSpec + build_venue_spec (the unit under test).
+    - itrader/trading_system/live_trading_system.py — for_exchange builds its spec via build_venue_spec; the equivalence to assert is that for_exchange('X') and build_venue_spec('X') (the spec build_live_system would consume) are equal VenueSpecs.
+  </read_first>
+  <action>
+    NEW file tests/unit/trading_system/test_venue_spec.py, 4-SPACE. Add parametrized tests over the
+    venue set {'okx', 'paper', 'binance'} asserting: (1) build_venue_spec(venue) yields the expected
+    (execution_venue, data_provider, account_id) trio with the default-map applied ('okx'->'okx',
+    'paper'->'okx', other->'okx'); (2) an explicit data_provider / account_id override is honored;
+    (3) the SEAM-03 identity: the VenueSpec for_exchange constructs equals the VenueSpec a direct
+    build_live_system(spec) would construct for the same venue — assert via VenueSpec.__eq__ (build both
+    the for_exchange-path spec and the build_live_system-path spec through build_venue_spec with matching
+    inputs and assert equality across the venue set). Do NOT stand up a full facade / connect to a venue
+    (CI-safe, no OKX creds) — the assertion is on the SPEC the two entry points build, which is the
+    load-bearing SEAM-03 invariant. Mark nothing by hand (folder-derived unit marker).
+  </action>
+  <verify>
+    <automated>poetry run pytest tests/unit/trading_system/test_venue_spec.py -q</automated>
+  </verify>
+  <acceptance_criteria>
+    - `poetry run pytest tests/unit/trading_system/test_venue_spec.py` passes — asserts default-map behavior for okx/paper/other, override honoring, and for_exchange-vs-build_live_system VenueSpec equality across the venue set
+    - The test runs CI-safe (no OKX credentials, no venue connect) — it asserts on the built VenueSpec, not a live facade
+    - `poetry run pytest tests/integration/test_backtest_oracle.py` — oracle byte-exact `134 / 46189.87730727451` (regression; live-only change)
+  </acceptance_criteria>
+  <done>A CI-safe unit test proves for_exchange and build_live_system produce identical VenueSpecs across okx/paper/other and validates the default-map + override behavior.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| venue-selection spec ↔ assemble_venue | The VenueSpec must feed assemble_venue the same execution_venue/data_provider/account_id as today; it never crosses into compose_engine (spec-free). No new external input, auth, secret, or network surface. |
+| venue_spec.py ↔ backtest import graph | The new module must stay pure (strings + a dataclass) so it pulls no venue substrate/ccxt/SQL. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-06.1.03-DRIFT | Tampering | duplicated default-map divergence | medium | mitigate | the {'okx':'okx','paper':'okx'} map lives in exactly ONE location (grep == 1); the spec-equality unit test proves for_exchange and build_live_system cannot drift |
+| T-06.1.03-INERT | Tampering | venue_spec.py import surface | low | mitigate | module is pure (no venue/ccxt/SQL import); test_okx_inertness green |
+| T-06.1.03-BEHAV | Tampering | live venue selection | medium | mitigate | test_live_system_okx_wiring green — assemble_venue receives identical specs; no behavioral test changes |
+</threat_model>
+
+<verification>
+- `poetry run pytest tests/unit/trading_system/test_venue_spec.py` — spec-equality + default-map behavior.
+- `poetry run pytest tests/integration/test_live_system_okx_wiring.py` — live venue selection unchanged.
+- `poetry run pytest tests/integration/test_okx_inertness.py` — green (venue_spec.py pure).
+- `poetry run pytest tests/integration/test_backtest_oracle.py` — byte-exact `134 / 46189.87730727451` (regression).
+- `poetry run mypy itrader` — clean (venue_spec.py strict-checked).
+</verification>
+
+<success_criteria>
+- A typed frozen `VenueSpec` + shared `build_venue_spec` builder exist; the `{'okx':'okx','paper':'okx'}` map + live-spec construction exist in exactly ONE location (D-11).
+- `for_exchange` and `build_live_system` both call the builder; a unit test proves they produce identical specs across the venue set.
+- Oracle byte-exact; inertness green; mypy clean.
+</success_criteria>
+
+<output>
+Create `.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-03-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-03-SUMMARY.md
+++ b/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-03-SUMMARY.md
@@ -1,0 +1,134 @@
+---
+phase: 06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo
+plan: 03
+subsystem: trading_system / live venue-selection spec
+tags: [SEAM-03, venue-spec, default-provider-map, live-only, behavior-preserving]
+status: complete
+requires:
+  - "compose_engine spec-free (06.1-01/D-04) — the venue-selection trio is the only live 'spec' left"
+  - "build_live_system consuming compose_engine + pure-injection facade (06.1-02)"
+  - "assemble_venue reads spec.execution_venue / data_provider / account_id (05-06, VENUE-06)"
+provides:
+  - "typed frozen VenueSpec (execution_venue/data_provider/account_id) replacing the duck-typed SimpleNamespace"
+  - "build_venue_spec — the ONE shared builder + SOLE home of the {okx,paper}->okx default-provider map"
+  - "for_exchange + build_live_system both call build_venue_spec (twice-written spec+map deleted)"
+affects:
+  - "itrader/trading_system/live_trading_system.py"
+  - "tests/integration/test_okx_inertness.py"
+tech_stack:
+  added: []
+  patterns:
+    - "typed frozen value object (free __eq__) over duck-typed SimpleNamespace for a small spec (D-11)"
+    - "single-home default map + idempotent builder so two entry points cannot drift"
+key_files:
+  created:
+    - "itrader/trading_system/venue_spec.py"
+    - "tests/unit/trading_system/test_venue_spec.py"
+  modified:
+    - "itrader/trading_system/live_trading_system.py"
+    - "tests/integration/test_okx_inertness.py"
+decisions:
+  - "D-11: a small live-only typed VenueSpec (3 venue-scoped fields) feeds assemble_venue ONLY, never compose_engine (spec-free since D-04); a frozen dataclass, not a SimpleNamespace"
+  - "D-11: build_venue_spec is the SOLE home of the {'okx':'okx','paper':'okx'} default-provider map; BOTH for_exchange and build_live_system call it — the two inline SimpleNamespace specs + duplicated maps (:274-283, :1605-1613) are deleted"
+  - "SimpleNamespace import dropped from live_trading_system.py (no remaining use)"
+  - "Rule 3 blocking fix: test_okx_inertness paper-map assertion repointed to build_venue_spec's source (the map relocated there by design); D-21 invariant intent preserved"
+metrics:
+  duration_minutes: 4
+  tasks: 3
+  files_modified: 4
+  completed: 2026-07-14
+---
+
+# Phase 06.1 Plan 03: Shared VenueSpec Builder (SEAM-03) Summary
+
+Centralized the live venue-selection spec into ONE typed frozen `VenueSpec` + ONE shared
+`build_venue_spec` builder that owns the sole copy of the `{'okx':'okx','paper':'okx'}`
+default-provider map, and repointed BOTH `for_exchange` and `build_live_system` to it — deleting
+the twice-written `SimpleNamespace` fake-spec + duplicated default-map (D-11). Behavior-preserving
+and live-only: the backtest oracle stays byte-exact (`134 / 46189.87730727451`), inertness green.
+
+## What was built
+
+- **Task 1 — typed VenueSpec + shared builder (D-11):** NEW `itrader/trading_system/venue_spec.py`
+  (TABS, mirroring the sibling `system_spec.py`). A `@dataclass(frozen=True) VenueSpec` with exactly
+  the three fields `assemble_venue` reads (`execution_venue: str`, `data_provider: str`,
+  `account_id: Optional[str] = None`) — frozen gives the free `__eq__` the SEAM-03 identity test needs.
+  `build_venue_spec(execution_venue, *, data_provider=None, account_id=None) -> VenueSpec` applies the
+  default-provider map (`data_provider or {'okx':'okx','paper':'okx'}.get(execution_venue, 'okx')`) —
+  this literal is now the SOLE home of the map. The module is pure (strings + a dataclass, zero venue /
+  ccxt / SQL imports) so it never touches the backtest import graph and is `mypy --strict` clean. The
+  docstring cites D-11 and notes it feeds `assemble_venue` ONLY, never `compose_engine` (spec-free since
+  D-04).
+- **Task 2 — repoint both callers, delete both inline specs (D-11):** `live_trading_system.py` (4-SPACE)
+  now imports `build_venue_spec` at module top (pure — safe to hoist; the broader barrel/import hoist is
+  06.1-04 scope). `for_exchange` builds its spec via `build_venue_spec(exchange, data_provider=...,
+  account_id=...)` (`data_plugins` still popped + passed through unchanged); `build_live_system` builds
+  `venue_spec = build_venue_spec(exchange, data_provider=getattr(spec,'data_provider',None),
+  account_id=getattr(spec,'account_id',None))` and feeds it to `assemble_venue` exactly as before. Both
+  inline `SimpleNamespace(...)` blocks + their duplicated default-maps are DELETED; the now-unused
+  `from types import SimpleNamespace` import is removed. The values `assemble_venue` receives are
+  byte-identical (same default-map logic, same explicit overrides).
+- **Task 3 — SEAM-03 spec-equality unit test:** NEW `tests/unit/trading_system/test_venue_spec.py`
+  (4-SPACE, package-less dir, folder-derived `unit` marker). Parametrized over `{'okx','paper','binance'}`:
+  (1) `build_venue_spec(venue)` yields the expected trio with the default-map applied; (2) explicit
+  `data_provider`/`account_id` overrides are honored; (3) the SEAM-03 identity — the `for_exchange`-path
+  spec equals the `build_live_system`-path spec (both re-built through the shared builder with matching
+  inputs, asserted via `VenueSpec.__eq__`); (4) the identity also holds under an explicit provider
+  override (round-trip stable). CI-safe — asserts on the built spec, no OKX creds, no venue connect.
+
+## Verification evidence
+
+- `poetry run pytest tests/unit/trading_system/test_venue_spec.py` — PASS (12 passed): default-map
+  behavior for okx/paper/other, override honoring, and `for_exchange`-vs-`build_live_system` VenueSpec
+  equality across the venue set.
+- `poetry run pytest tests/integration/test_backtest_oracle.py` — PASS (3 passed), oracle byte-exact
+  `134 / 46189.87730727451` (`check_exact=True`; live-only change, backtest-dark).
+- `poetry run pytest tests/integration/test_live_system_okx_wiring.py tests/integration/test_okx_inertness.py`
+  — PASS (15 passed): `assemble_venue` receives identical specs (live wiring unchanged); `venue_spec.py`
+  is pure/import-inert.
+- `poetry run pytest tests/unit/trading_system` — PASS (31 passed).
+- `poetry run mypy itrader` — clean (250 source files; +1 for the new `venue_spec.py`).
+- Grep gates: `grep -c "'okx': 'okx', 'paper': 'okx'" itrader/trading_system/venue_spec.py` == 1 (map's
+  sole home); == 0 in `live_trading_system.py`; repo-wide the literal appears in exactly ONE location
+  (`itrader/trading_system/venue_spec.py:1`); both `for_exchange` and `build_live_system` sources contain
+  `build_venue_spec`; `SimpleNamespace` count in the live module == 0.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Repointed test_okx_inertness paper-map assertion to build_venue_spec's source**
+- **Found during:** Task 2 verification (`test_live_system_okx_wiring.py tests/integration/test_okx_inertness.py`).
+- **Issue:** `test_production_build_live_system_registers_no_replay_data_provider` asserted the
+  `'paper': 'okx'` map literal appears inline in `build_live_system`'s source (`inspect.getsource`). The
+  plan DELIBERATELY relocates that literal into `build_venue_spec` (grep-count 0 in the live module is a
+  required Task-2 acceptance criterion), so the assertion broke — it encoded the pre-refactor source
+  location, not the D-21 invariant itself.
+- **Fix:** Repointed the two paper-map assertions to inspect `build_venue_spec`'s source (the map's new
+  sole home) while preserving the D-21 invariant intent (paper→`'okx'`, never `'replay'`). The
+  registration assertions (`data_registry.register('okx'`, no `'replay'` registration) stay pointed at
+  `build_live_system` where `data_registry.register` still lives, unaffected. Added a docstring note
+  explaining the SEAM-03/D-11 relocation.
+- **Files modified:** `tests/integration/test_okx_inertness.py`
+- **Commit:** f68d1c8f (committed atomically with the Task-2 rewire it is co-dependent with)
+
+## Known Stubs
+
+None — this is a centralize/delete/rewire refactor. No stubs, mock data sources, or placeholder values
+were introduced. (Any residual dead module-top imports in `live_trading_system.py` remain 06.1-04 scope,
+D-13 — untouched here.)
+
+## Threat Flags
+
+None — no new network endpoints, auth paths, file access, or trust-boundary schema changes. The plan's
+`mitigate` dispositions are satisfied: T-06.1.03-DRIFT (the `{'okx':'okx','paper':'okx'}` map lives in
+exactly ONE location, grep == 1; the spec-equality unit test proves `for_exchange` and `build_live_system`
+cannot drift); T-06.1.03-INERT (`venue_spec.py` is pure — no venue/ccxt/SQL import; `test_okx_inertness`
+green); T-06.1.03-BEHAV (`test_live_system_okx_wiring` green — `assemble_venue` receives identical specs;
+no behavioral test changes beyond the co-dependent source-location repoint).
+
+## Self-Check: PASSED
+
+- Files verified present: `itrader/trading_system/venue_spec.py`,
+  `tests/unit/trading_system/test_venue_spec.py` (both created on disk).
+- Commits verified in `git log`: 5164eedb (Task 1), f68d1c8f (Task 2), 41b4ed3d (Task 3).

--- a/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-04-PLAN.md
+++ b/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-04-PLAN.md
@@ -1,0 +1,210 @@
+---
+phase: 06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo
+plan: 04
+type: execute
+wave: 4
+depends_on: [06.1-03]
+files_modified:
+  - itrader/trading_system/__init__.py
+  - itrader/trading_system/live_trading_system.py
+  - tests/integration/test_okx_inertness.py
+autonomous: true
+requirements: [SEAM-04]
+
+must_haves:
+  truths:
+    - "trading_system/__init__.py exports BACKTEST ONLY — the live surface (LiveTradingSystem / build_live_system) is DROPPED from the barrel entirely (no __getattr__ magic; maximally inert), so importing the barrel does not pull the live module onto the backtest import graph (D-12) [import-graph leak edge]"
+    - "importing build_backtest_system from the trading_system barrel does NOT import itrader.trading_system.live_trading_system (asserted in the inertness probe, right after the backtest-root import, before the explicit P6 import block); test_okx_inertness.py stays green (D-12) [import-graph leak edge]"
+    - "the ~45 for_exchange/build_live_system/LiveTradingSystem call sites still resolve — they already import from the submodule itrader.trading_system.live_trading_system (already repointed), so the barrel drop breaks none; the mypy --strict + full-suite backstop confirms it (D-12) [call-site fan-out backstop]"
+    - "the genuinely-pure imports (SessionInitializer, UniverseHandlerConfig, EngineContext, and any remaining pure names in _initialize_live_session / build_live_system) hoist to module top in live_trading_system.py; the genuinely-heavy imports (ccxt.pro / SQL / venue substrate / LiveBarFeed) STAY lazy inside build_live_system (D-13)"
+  artifacts:
+    - "itrader/trading_system/__init__.py — backtest-only barrel (live export dropped)"
+    - "itrader/trading_system/live_trading_system.py — pure imports hoisted to module top; heavy imports still lazy"
+    - "tests/integration/test_okx_inertness.py — the no-live-module-import assertion added"
+  key_links:
+    - "trading_system barrel -> backtest surface only; live surface reached via the submodule import path"
+    - "live_trading_system.py module-top pure imports (post barrel-drop, off the backtest graph) <- SessionInitializer / UniverseHandlerConfig / EngineContext"
+  prohibitions:
+    - statement: "MUST NOT change backtest output bytes (behavior-preserving)"
+      status: enforced
+      verification: "poetry run pytest tests/integration/test_backtest_oracle.py — oracle 134 / 46189.87730727451 (check_exact=True) unchanged"
+    - statement: "MUST NOT pull ccxt.pro/SQL onto the backtest import path via the barrel change"
+      status: enforced
+      verification: "poetry run pytest tests/integration/test_okx_inertness.py green + the no-live-module-import assertion (build_backtest_system import does not pull live_trading_system)"
+    - statement: "MUST NOT alter live runtime behavior — barrel + import location changes only (no order flow / safety / reconcile / stream body change)"
+      status: enforced
+      verification: "poetry run pytest tests/unit tests/integration — full suite green with no behavioral test changes; mypy --strict clean"
+---
+
+<objective>
+De-lazy the `trading_system` barrel and hoist the pure imports: drop the live surface from
+`trading_system/__init__.py` entirely (backtest-only barrel, D-12) so the live module leaves the
+backtest import graph, then move the genuinely-pure imports in `live_trading_system.py` to module top
+while keeping ccxt.pro/SQL/venue substrate lazy (D-13) — the mechanical SEAM-04 fan-out, sliced last.
+
+Purpose: the barrel eagerly importing the live module (`__init__.py:5`) is the root cause of the
+pervasive lazy-imports-inside-methods needed to keep `test_okx_inertness.py` green. Once the barrel
+no longer pulls the live module onto the backtest path, the pure imports need not be lazy. Output: a
+backtest-only barrel, hoisted pure imports, a new no-live-module-import assertion, and a green
+inertness gate + full suite backstop.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-CONTEXT.md
+@.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-SPEC.md
+@itrader/trading_system/__init__.py
+@tests/integration/test_okx_inertness.py
+</context>
+
+<artifacts_produced>
+Symbols this phase (this plan) creates/changes — excluded from the source-grounding drift pass:
+- `itrader/trading_system/__init__.py` (CHANGED — the `from .live_trading_system import LiveTradingSystem, build_live_system` line + the two `__all__` live entries are DROPPED; barrel exports backtest only, D-12)
+- The hoisted module-top imports in `live_trading_system.py` (`SessionInitializer`, `UniverseHandlerConfig`, `EngineContext`, and any remaining pure names) — MOVED from inside `_initialize_live_session` / `build_live_system` to module top (D-13)
+- `tests/integration/test_okx_inertness.py` — a NEW assertion that importing the backtest root does not put `itrader.trading_system.live_trading_system` in `sys.modules`
+</artifacts_produced>
+
+<!-- The module name must be named in <action> (the live surface lives in this module; call sites import it from the submodule) while Task 1's acceptance negative-greps it in the barrel __init__.py to prove the eager live import is dropped. Different files — legitimate appearance. -->
+<!-- planner-discipline-allow: live_trading_system -->
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Drop the live surface from the barrel; add the no-live-module-import assertion (D-12)</name>
+  <files>itrader/trading_system/__init__.py, tests/integration/test_okx_inertness.py</files>
+  <read_first>
+    - itrader/trading_system/__init__.py — the current barrel (:1-12): line 5 `from .live_trading_system import LiveTradingSystem, build_live_system` + the two `__all__` live entries (:10-11) to DROP; keep the backtest exports (:1-4, :8-9). Indentation: SPACE.
+    - tests/integration/test_okx_inertness.py — the probe _PROBE string (:31-217): the backtest-root import (:36 `import itrader.trading_system.backtest_trading_system`), the _FORBIDDEN check (:38-99), and the LATER explicit P6 import block (:184-215) that legitimately imports build_live_system AFTER the check. The new assertion goes right after the _FORBIDDEN leaked check (near :96-99), BEFORE any explicit live import. Indentation: 4-SPACE.
+    - Call-site survey: the ~45 for_exchange/build_live_system/LiveTradingSystem sites already import from `itrader.trading_system.live_trading_system` (the submodule), NOT the barrel — dropping the barrel export breaks none. tests/support/replay_harness.py + scripts/run_live_paper.py also use the submodule import.
+  </read_first>
+  <action>
+    In itrader/trading_system/__init__.py (SPACE): DELETE line 5 (the `from .live_trading_system import
+    LiveTradingSystem, build_live_system`) and the two live entries from `__all__` — the barrel exports
+    `BacktestTradingSystem` + `build_backtest_system` ONLY (D-12; owner chose the explicit drop over a
+    PEP 562 `__getattr__` re-export). In tests/integration/test_okx_inertness.py (4-SPACE): add, inside
+    the _PROBE string immediately after the `_FORBIDDEN` leaked assertion (before the CFG-02 block at
+    :106), a new assertion that `"itrader.trading_system.live_trading_system" not in sys.modules` with a
+    clear message ("barrel must not pull the live module onto the backtest import graph, D-12/SEAM-04") —
+    since the probe imported ONLY the backtest root and the barrel no longer imports the live module, the
+    live module must be absent from sys.modules at this point. The later explicit `from
+    itrader.trading_system.live_trading_system import build_live_system` (:195) is unaffected (it runs
+    after this assertion and legitimately pulls the module for the register-vs-build check). Do NOT weaken
+    any existing assertion.
+  </action>
+  <verify>
+    <automated>poetry run pytest tests/integration/test_okx_inertness.py -q</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c "live_trading_system" itrader/trading_system/__init__.py` == 0 (barrel drops the live import + __all__ entries, D-12)
+    - `poetry run python -c "import sys, itrader.trading_system.backtest_trading_system; assert 'itrader.trading_system.live_trading_system' not in sys.modules, 'barrel leaked live module'; print('NO_LIVE_LEAK')"` prints `NO_LIVE_LEAK` (run in a context where the live module was not already imported — the probe runs it in a fresh interpreter)
+    - `poetry run pytest tests/integration/test_okx_inertness.py` green (the new no-live-module-import assertion + all existing assertions pass)
+    - `poetry run python -c "from itrader.trading_system import build_backtest_system, BacktestTradingSystem; print('BARREL_OK')"` prints BARREL_OK (backtest surface still exported)
+  </acceptance_criteria>
+  <done>The barrel exports backtest only; importing the backtest root pulls no live module (asserted); the inertness gate is green.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Hoist the pure imports to module top in live_trading_system.py; keep heavy imports lazy (D-13)</name>
+  <files>itrader/trading_system/live_trading_system.py</files>
+  <read_first>
+    - itrader/trading_system/live_trading_system.py — the remaining lazy pure imports in _initialize_live_session (:916 SessionInitializer, :918 UniverseHandlerConfig — Engine/BacktestClock/TimeGenerator were removed in plan 06.1-02 Task 3) + build_live_system (:1587 EngineContext, plus the pure `from itrader import config`); the genuinely-heavy lazy imports that MUST stay inside build_live_system (LiveBarFeed :1480, SqlSettings :1492/:1507, SqlEngine/CachedSqlOrderStorage/SqlOrderStorage :1508-1512, HaltRecordStore :1532, ConnectorProvider :1586 [connectors barrel pulls ccxt], okx_plugin/paper_plugin :1589-1594, assemble_venue/registry, ErrorPolicy/LiveRunner/WorkerSupervisor :1708-1710). Indentation: 4-SPACE.
+    - tests/integration/test_okx_inertness.py — the P6 register-vs-build block (:184-215) asserts importing build_live_system/LiveRunner/SessionInitializer pulls no ccxt.pro/SQL and leaves the `sql` cached_property unresolved; UniverseHandlerConfig's module (universe_handler) is pure (no ccxt/SQL) so hoisting it is safe for THAT block, and it never runs on the backtest path now (barrel drop).
+  </read_first>
+  <action>
+    File is 4-SPACE. Move the genuinely-PURE imports to module top: `from
+    itrader.trading_system.session_initializer import SessionInitializer`, `from
+    itrader.universe.universe_handler import UniverseHandlerConfig`, `from
+    itrader.trading_system.engine_context import EngineContext` (and `from itrader import config` if it is
+    only used lazily today) — these are safe to hoist now because the barrel drop (Task 1) removed
+    live_trading_system.py from the backtest import graph, so their module-top execution never touches the
+    backtest path. Remove the corresponding lazy `from ... import` lines from inside
+    _initialize_live_session / build_live_system. KEEP lazy inside build_live_system's body every
+    genuinely-HEAVY import: LiveBarFeed, SqlSettings / SqlDriver, SqlEngine / CachedSqlOrderStorage /
+    SqlOrderStorage, HaltRecordStore, ConnectorProvider (its connectors barrel eagerly pulls ccxt.pro),
+    okx_plugin / paper_plugin, assemble_venue / the registries, ErrorPolicy / LiveRunner /
+    WorkerSupervisor — moving any of these to module top would redden the inertness gate. Do NOT touch any
+    method BODY beyond the import relocation (D-04). No fenced code in comments.
+  </action>
+  <verify>
+    <automated>poetry run pytest tests/integration/test_okx_inertness.py -q</automated>
+  </verify>
+  <acceptance_criteria>
+    - The pure imports are at module top — `poetry run python -c "import inspect;from itrader.trading_system import live_trading_system as m;body=inspect.getsource(m.LiveTradingSystem._initialize_live_session);assert 'import SessionInitializer' not in body and 'import UniverseHandlerConfig' not in body;print('HOISTED')"` prints HOISTED
+    - The heavy imports stay lazy — `poetry run python -c "import inspect;from itrader.trading_system import live_trading_system as m;src=inspect.getsource(m.build_live_system);assert 'LiveBarFeed' in src and 'SqlSettings' in src and 'ConnectorProvider' in src;print('HEAVY_LAZY')"` prints HEAVY_LAZY (the heavy names still appear inside the function body)
+    - `poetry run pytest tests/integration/test_okx_inertness.py` green — both the backtest-root _FORBIDDEN check AND the P6 register-vs-build block pass (importing build_live_system pulls no ccxt.pro/SQL; the `sql` cached_property stays unresolved)
+    - `poetry run pytest tests/integration/test_backtest_oracle.py` — oracle byte-exact `134 / 46189.87730727451`
+  </acceptance_criteria>
+  <done>The genuinely-pure imports are hoisted to module top; ccxt.pro/SQL/venue substrate/LiveBarFeed stay lazy inside build_live_system; the inertness gate is green.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Full-suite + mypy backstop — the call-site fan-out resolves after the barrel change (SEAM-04 backstop)</name>
+  <files>tests/integration/test_okx_inertness.py</files>
+  <read_first>
+    - The call-site survey from Task 1: the ~45 for_exchange/build_live_system/LiveTradingSystem sites already import from the submodule (`itrader.trading_system.live_trading_system`), so the barrel drop should break none — this task is the mypy --strict + full-suite backstop that confirms it (the call-site fan-out is a non-inferable check per SPEC Edge Coverage).
+    - pyproject.toml — the mypy target `files = ["itrader"]` (strict); the `filterwarnings=["error"]` + `--strict-markers` pytest config; note the `make test` .env gotcha — use `poetry run pytest` directly (the project-convention gate), not `make test`.
+  </read_first>
+  <action>
+    File touched only if a stray barrel-style live import surfaces (none expected). Run the two backstop
+    gates and confirm zero regressions: (1) `poetry run mypy itrader` (strict) — every remaining
+    for_exchange/build_live_system/LiveTradingSystem reference resolves; (2) `poetry run pytest tests`
+    (the full suite under filterwarnings=["error"]) — green. If any site still imported the live surface
+    from the barrel (grep the repo to confirm zero), repoint it to `from
+    itrader.trading_system.live_trading_system import ...`. No production behavior change — this is the
+    call-site-fan-out backstop the SPEC carried to plan-phase.
+  </action>
+  <verify>
+    <automated>poetry run mypy itrader && poetry run pytest tests -q</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -rn "from itrader.trading_system import" --include=*.py . | grep -E "LiveTradingSystem|build_live_system"` returns nothing (no barrel-style live import remains anywhere in the repo)
+    - `poetry run mypy itrader` clean (the ~45 call sites resolve; SEAM-04 call-site-fan-out backstop)
+    - `poetry run pytest tests` green under `filterwarnings=["error"]` / `--strict-markers` (full-suite backstop)
+    - `poetry run pytest tests/integration/test_okx_inertness.py tests/integration/test_backtest_oracle.py` green (inertness + oracle byte-exact `134 / 46189.87730727451`)
+  </acceptance_criteria>
+  <done>No barrel-style live import remains; mypy --strict is clean and the full suite is green — the call-site fan-out resolves after the barrel drop.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| trading_system barrel ↔ backtest import graph | Dropping the live export must remove the live module from the backtest import graph without breaking the ~45 submodule call sites. No new external input, auth, secret, or network surface. |
+| module-top pure imports ↔ inertness | Hoisting pure imports must not accidentally pull a heavy backend onto the (now live-only) module's import — the heavy imports stay lazy. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-06.1.04-LEAK | Tampering | barrel re-leaking a heavy import | high | mitigate | test_okx_inertness green + the NEW no-live-module-import assertion (build_backtest_system import does not pull live_trading_system); the barrel exports backtest only |
+| T-06.1.04-FANOUT | Denial of Service | ~45 call sites breaking on the barrel drop | high | mitigate | call sites already import from the submodule (grep-confirmed); mypy --strict + full-suite backstop (Task 3) proves resolution |
+| T-06.1.04-HOIST | Tampering | hoisting a heavy import by mistake | high | mitigate | the P6 register-vs-build block asserts importing build_live_system pulls no ccxt.pro/SQL; heavy names verified still inside build_live_system's body (HEAVY_LAZY check) |
+| T-06.1.04-ORACLE | Tampering | accidental backtest-path change | medium | mitigate | oracle byte-exact regression check + full suite green |
+</threat_model>
+
+<verification>
+- `poetry run pytest tests/integration/test_okx_inertness.py` — green, incl. the new no-live-module-import assertion (build_backtest_system import does not pull live_trading_system) — the import-graph-leak edge.
+- `poetry run mypy itrader` — clean (the ~45 call sites resolve; call-site-fan-out backstop).
+- `poetry run pytest tests` — full suite green under `filterwarnings=["error"]`.
+- `poetry run pytest tests/integration/test_backtest_oracle.py` — byte-exact `134 / 46189.87730727451` (regression).
+</verification>
+
+<success_criteria>
+- `trading_system/__init__.py` exports backtest only; importing `build_backtest_system` from the barrel does not import `live_trading_system` (asserted) (D-12).
+- The pure imports are hoisted to module top; ccxt.pro/SQL/venue substrate/LiveBarFeed stay lazy (D-13).
+- `test_okx_inertness.py` green; the ~45 call sites resolve (mypy --strict + full suite green); oracle byte-exact.
+</success_criteria>
+
+<output>
+Create `.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-04-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-04-SUMMARY.md
+++ b/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-04-SUMMARY.md
@@ -1,0 +1,144 @@
+---
+phase: 06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo
+plan: 04
+subsystem: trading_system / barrel-drop + pure-import hoist
+tags: [SEAM-04, barrel-drop, import-graph-inertness, live-only, behavior-preserving]
+status: complete
+requires:
+  - "compose_engine spec-free + shared VenueSpec builder (06.1-01/02/03) — the live surface now consumes the shared compose graph"
+  - "call sites already repointed to itrader.trading_system.live_trading_system (the submodule) in prior plans — barrel drop breaks none"
+provides:
+  - "backtest-only trading_system barrel — the live surface (LiveTradingSystem / build_live_system) DROPPED entirely (D-12)"
+  - "importing the backtest root pulls NO live module (new sys.modules assertion in the inertness probe)"
+  - "pure imports (SessionInitializer / EngineContext / UniverseHandlerConfig) hoisted to live_trading_system module top; heavy ccxt.pro/SQL/venue imports stay lazy (D-13)"
+affects:
+  - "itrader/trading_system/__init__.py"
+  - "itrader/trading_system/live_trading_system.py"
+  - "tests/integration/test_okx_inertness.py"
+tech_stack:
+  added: []
+  patterns:
+    - "explicit barrel narrowing (drop the export, no PEP 562 __getattr__ re-export) for maximal import-graph inertness (D-12)"
+    - "de-lazy pure imports once the module leaves the backtest import graph; keep genuinely-heavy backends lazy inside the factory body (D-13)"
+key_files:
+  created: []
+  modified:
+    - "itrader/trading_system/__init__.py"
+    - "itrader/trading_system/live_trading_system.py"
+    - "tests/integration/test_okx_inertness.py"
+decisions:
+  - "D-12: trading_system/__init__.py exports BacktestTradingSystem + build_backtest_system ONLY; the eager 'from .live_trading_system import ...' + its two __all__ entries are removed. No __getattr__ magic (owner chose the explicit drop). Live consumers import from the live submodule directly."
+  - "D-13: SessionInitializer / EngineContext / UniverseHandlerConfig hoisted to live_trading_system module top (safe once the barrel drop removed this module from the backtest import graph); LiveBarFeed / SqlSettings / SQL spine / ConnectorProvider / okx_plugin / assemble_venue / LiveRunner STAY lazy inside build_live_system's body."
+  - "from itrader import config left LAZY in method bodies (read only there) — not hoisted, to avoid touching method bodies beyond the import relocation (D-04)."
+metrics:
+  duration_minutes: 6
+  tasks: 3
+  files_modified: 3
+  completed: 2026-07-14
+---
+
+# Phase 06.1 Plan 04: Barrel-Drop + Pure-Import Hoist (SEAM-04) Summary
+
+Dropped the live surface (`LiveTradingSystem` / `build_live_system`) from the
+`trading_system` barrel entirely so importing the barrel no longer pulls the live module
+onto the backtest import graph (D-12), then hoisted the genuinely-pure imports in
+`live_trading_system.py` to module top while keeping ccxt.pro/SQL/venue substrate lazy
+inside `build_live_system` (D-13). Behavior-preserving: the backtest oracle stays
+byte-exact (`134 / 46189.87730727451`), the inertness gate is green (including a new
+no-live-module-import assertion), and the full suite (2143 passed) confirms the ~45
+call-site fan-out resolves — all sites already imported from the submodule, so the barrel
+drop broke none. This is the FINAL plan of phase 06.1.
+
+## What was built
+
+- **Task 1 — drop the live surface from the barrel + new no-live-module-import assertion (D-12):**
+  `itrader/trading_system/__init__.py` (SPACE) now exports `BacktestTradingSystem` +
+  `build_backtest_system` ONLY. The eager `from .live_trading_system import
+  LiveTradingSystem, build_live_system` line and its two `__all__` entries are removed —
+  no PEP 562 `__getattr__` re-export (the owner chose the explicit drop for maximal
+  inertness). A doc comment records D-12 and points live consumers at the submodule import
+  path. In `tests/integration/test_okx_inertness.py` (4-SPACE) the `_PROBE` gains a new
+  assertion, placed immediately after the `_FORBIDDEN` leaked check and BEFORE the CFG-02
+  block, that `"itrader.trading_system.live_trading_system" not in sys.modules` after the
+  backtest-root import — proving the barrel no longer drags the live module onto the
+  backtest graph. The later explicit `from itrader.trading_system.live_trading_system
+  import build_live_system` (in the P6 register-vs-build block) runs AFTER this assertion
+  and legitimately pulls the module, so it is unaffected; no existing assertion was
+  weakened.
+- **Task 2 — hoist the pure imports to module top; keep heavy imports lazy (D-13):**
+  `live_trading_system.py` (4-SPACE) now imports `SessionInitializer`, `EngineContext`,
+  and `UniverseHandlerConfig` at module top (grouped with the existing trading_system /
+  universe imports, with a D-13 comment). These are safe to hoist now because Task 1's
+  barrel drop removed this module from the backtest import graph, so their module-top
+  execution never touches the backtest path. The corresponding lazy `from ... import`
+  lines were removed from inside `_initialize_live_session` (SessionInitializer /
+  UniverseHandlerConfig) and `build_live_system` (EngineContext). Every genuinely-HEAVY
+  import STAYS lazy inside `build_live_system`'s body: `LiveBarFeed`, `SqlSettings` /
+  `SqlDriver`, `SqlEngine` / `CachedSqlOrderStorage` / `SqlOrderStorage`,
+  `HaltRecordStore`, `ConnectorProvider` (its connectors barrel eagerly pulls ccxt.pro),
+  `okx_plugin` / `paper_plugin`, `assemble_venue` + the registries, `ErrorPolicy` /
+  `LiveRunner` / `WorkerSupervisor`. `from itrader import config as _system_config` was
+  left lazy in the method bodies where it is read (not one of the three pure imports the
+  plan required hoisting; hoisting it would have meant touching method bodies beyond the
+  import relocation — D-04). No method BODY changed beyond the import relocation. No fenced
+  code in comments.
+- **Task 3 — mypy --strict + full-suite call-site-fan-out backstop (SEAM-04):** No file
+  change was required — a repo-wide grep confirmed zero barrel-style live imports remain
+  (every `for_exchange` / `build_live_system` / `LiveTradingSystem` call site — 19
+  submodule imports — already imports from `itrader.trading_system.live_trading_system`).
+  `poetry run mypy itrader` is clean (250 source files) and `poetry run pytest tests`
+  passes (2143 passed, 6 skipped — all OKX-cred-gated, expected) under
+  `filterwarnings=["error"]` / `--strict-markers`, proving the ~45 call-site fan-out
+  resolves after the barrel drop.
+
+## Verification evidence
+
+- `grep -c "live_trading_system" itrader/trading_system/__init__.py` == 0 (barrel drops
+  the live import + `__all__` entries).
+- `poetry run python -c "... assert 'itrader.trading_system.live_trading_system' not in sys.modules ..."`
+  prints `NO_LIVE_LEAK` (backtest-root import pulls no live module).
+- `poetry run python -c "from itrader.trading_system import build_backtest_system, BacktestTradingSystem; ..."`
+  prints `BARREL_OK` (backtest surface still exported).
+- HOISTED probe (`_initialize_live_session` source has no `import SessionInitializer` /
+  `import UniverseHandlerConfig`) prints `HOISTED`; HEAVY_LAZY probe (`build_live_system`
+  source still contains `LiveBarFeed` / `SqlSettings` / `ConnectorProvider`) prints
+  `HEAVY_LAZY`.
+- `poetry run pytest tests/integration/test_okx_inertness.py` — PASS (4 passed), incl. the
+  new no-live-module-import assertion + the P6 register-vs-build block (importing
+  build_live_system pulls no ccxt.pro/SQL; `sql` cached_property stays unresolved).
+- `poetry run pytest tests/integration/test_backtest_oracle.py` — PASS (3 passed), oracle
+  byte-exact `134 / 46189.87730727451` (`check_exact=True`).
+- `poetry run mypy itrader` — clean (250 source files).
+- `poetry run pytest tests` — 2143 passed, 6 skipped (OKX-cred-gated) under
+  `filterwarnings=["error"]` / `--strict-markers`.
+- Repo-wide grep: `grep -rn "from itrader.trading_system import" --include="*.py" . | grep -E "LiveTradingSystem|build_live_system"`
+  returns nothing (no barrel-style live import anywhere, incl. .ipynb and scripts/).
+
+## Deviations from Plan
+
+None — the plan executed exactly as written. Task 3 required no file edit (no stray
+barrel-style live import surfaced; the call-site fan-out was already submodule-imported by
+prior plans, so it was a pure verification backstop).
+
+## Known Stubs
+
+None — this is a barrel-drop + import-relocation refactor. No stubs, mock data sources, or
+placeholder values were introduced.
+
+## Threat Flags
+
+None — no new network endpoints, auth paths, file access, or trust-boundary schema
+changes. The plan's `mitigate` dispositions are satisfied: T-06.1.04-LEAK (barrel exports
+backtest only; the new no-live-module-import assertion + `test_okx_inertness` green prove
+no heavy import re-leaks); T-06.1.04-FANOUT (repo-wide grep == 0 barrel-style live imports;
+mypy --strict + full-suite green prove the ~45 call sites resolve); T-06.1.04-HOIST (the P6
+register-vs-build block + the HEAVY_LAZY check confirm the heavy imports stayed inside
+`build_live_system`'s body); T-06.1.04-ORACLE (oracle byte-exact + full suite green).
+
+## Self-Check: PASSED
+
+- Files verified present: `itrader/trading_system/__init__.py`,
+  `itrader/trading_system/live_trading_system.py`,
+  `tests/integration/test_okx_inertness.py` (all on disk).
+- Commits verified in `git log`: 7dc546fc (Task 1 — barrel drop), 747807be (Task 2 —
+  pure-import hoist). Task 3 was verification-only (no commit).

--- a/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-CONTEXT.md
+++ b/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-CONTEXT.md
@@ -76,8 +76,7 @@ where they differ; the SPEC's *acceptance criteria/gates* still hold verbatim.
   path reads `self.store` expecting a real store (expected vestigial; if something does, repoint
   it).
 
-- **D-03 (both new `ctx` fields typed via `TYPE_CHECKING` forward-refs to the BASE store/feed
-  types):** `engine_context.py` is documented import-inert; annotate the new fields against the
+- **D-03 (both new `ctx` fields typed via `TYPE_CHECKING` forward-refs to the BASE store/feed types):** `engine_context.py` is documented import-inert; annotate the new fields against the
   base `store`/`feed` types under `TYPE_CHECKING` — mirroring exactly how `sql_engine` avoids
   pulling SQLAlchemy — so adding them pulls no concretion onto the backtest graph. The concrete
   `LiveBarFeed` is imported only inside the live factory (lazy). Keeps `test_okx_inertness.py`
@@ -101,21 +100,18 @@ where they differ; the SPEC's *acceptance criteria/gates* still hold verbatim.
   values flow. Live's `ExecutionHandler` gets `exchange_config=None` (its default today, so no
   behavior change).
 
-- **D-05 (live reuses `FeeModelCommissionEstimator`; the hand-rolled `_estimate_commission`
-  closure is deleted):** once `build_live_system` calls `compose_engine`, the commission adapter
+- **D-05 (live reuses `FeeModelCommissionEstimator`; the hand-rolled `_estimate_commission` closure is deleted):** once `build_live_system` calls `compose_engine`, the commission adapter
   comes from compose (compose.py:54-78) — the re-inlined closure at live_trading_system.py:1541-1545
   is removed (SPEC SEAM-01 acceptance, unchanged).
 
 ### Area 2 — venue-extras collapse (SEAM-02)
 
-- **D-06 (`Engine` stays the shared, mode-agnostic, OKX-free graph — venue handles do NOT go on
-  it):** Rejected putting the venue/connector fields on the shared `Engine` dataclass: it is the
+- **D-06 (`Engine` stays the shared, mode-agnostic, OKX-free graph — venue handles do NOT go on it):** Rejected putting the venue/connector fields on the shared `Engine` dataclass: it is the
   BACKTEST holder too, so it would carry ~8 live-only OKX `None` fields as dead weight and drag
   venue/OKX vocabulary into the one seam kept venue-free — moving the loose-`Any` pile onto the
   shared class instead of deleting it. `Engine` is unchanged this phase.
 
-- **D-07 (reuse the factory's `VenueLifecycle` as the SINGLE venue/connector holder — no unpack,
-  no new class):** `assemble_venue` already returns a cohesive `VenueLifecycle` that groups the
+- **D-07 (reuse the factory's `VenueLifecycle` as the SINGLE venue/connector holder — no unpack, no new class):** `assemble_venue` already returns a cohesive `VenueLifecycle` that groups the
   whole venue/connector cluster: `lifecycle.bundle.exchange` (= `okx_exchange`/simulated),
   `lifecycle.bundle.connector` (= `okx_connector`, `None` for paper), `lifecycle.bundle.account_factory()`
   (= `venue_account`), `lifecycle.provider` (= `okx_data_provider`). `build_live_system`'s
@@ -174,8 +170,7 @@ where they differ; the SPEC's *acceptance criteria/gates* still hold verbatim.
   holds: `test_okx_inertness.py` green; importing `build_backtest_system` from the barrel does not
   import `live_trading_system`; the call-site fan-out is the `mypy --strict` + full-suite backstop.
 
-- **D-13 (hoist the pure imports to module top in `live_trading_system.py`; heavy imports stay
-  lazy):** with the module off the backtest import graph (D-12), the genuinely-pure imports
+- **D-13 (hoist the pure imports to module top in `live_trading_system.py`; heavy imports stay lazy):** with the module off the backtest import graph (D-12), the genuinely-pure imports
   (`Engine`, `BacktestClock`, `TimeGenerator`, `SessionInitializer`, `UniverseHandlerConfig`) move
   to module top; the genuinely-heavy imports (ccxt.pro / SQL / venue substrate) STAY lazy inside
   `build_live_system`.

--- a/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-CONTEXT.md
+++ b/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-CONTEXT.md
@@ -1,0 +1,326 @@
+# Phase 06.1: Seam Cleanup - Context
+
+**Gathered:** 2026-07-14
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+`build_live_system` wires its handler graph by consuming the shared `compose_engine`
+(made **spec-free** and store/feed-agnostic) instead of hand-rolling a parallel copy,
+and the interim scaffolding Phase 6 left behind — `LiveSystemComponents`, the unpacked
+venue handles, the duplicated `for_exchange` spec-builder, the backtest-graph-eager
+live barrel — is removed. **Behavior-preserving:** live runtime behavior unchanged;
+backtest oracle byte-exact `134 / 46189.87730727451` (`check_exact=True`);
+`test_okx_inertness.py` green. Lands **before Phase 7** so P7's
+`SafetyController`/`ReconciliationCoordinator`/`StreamRecoveryHandler` extraction
+builds on the clean seam, not the hand-rolled copy.
+
+</domain>
+
+<spec_lock>
+## Requirements (locked via SPEC.md)
+
+**4 requirements are locked.** See `06.1-SPEC.md` for full requirements, boundaries,
+and acceptance criteria. Downstream agents MUST read `06.1-SPEC.md` before planning
+or implementing. Requirements are not duplicated here.
+
+**In scope (from SPEC.md):**
+- Store/feed injection seam on `compose_engine` + backtest call-site pass-through (SEAM-01)
+- `build_live_system` rewired to consume `compose_engine` + `FeeModelCommissionEstimator` (SEAM-01)
+- Removal of `LiveSystemComponents` and the interim `Engine` reconstruction; venue-extras holder (SEAM-02)
+- Single shared live-spec builder for `for_exchange` + `build_live_system` (SEAM-03)
+- Barrel de-lazying + pure-import hoist in `live_trading_system.py` (SEAM-04)
+
+**Out of scope (from SPEC.md):**
+- Loop-lifecycle callback web / `_on_loop_start` / `_on_loop_error` / the 9 LiveRunner callbacks — **P7/P8/P9**
+- Moving `_initialize_live_session` to construction time — **blocked** by the test contract; enabled later by **P10**
+- Folding `UniverseHandler`'s 5 non-freeze setters into its ctor — **P7**
+- Relocating `wire_universe` / membership into `UniverseHandler` — **working as intended** (shared by both runners)
+- Any change to live runtime behavior (order flow, safety, reconcile, stream) — behavior-preserving refactor
+
+</spec_lock>
+
+<decisions>
+## Implementation Decisions
+
+The discussion refined SEAM-01/03 beyond the SPEC's original framing: the store/feed
+seam landed on `ctx` (not a `compose_engine` parameter), which then made `compose_engine`
+**spec-free** — eliminating the "live builds a fake backtest spec" problem the SPEC's
+SEAM-03 anticipated. These decisions supersede the SPEC's illustrative target snippets
+where they differ; the SPEC's *acceptance criteria/gates* still hold verbatim.
+
+### Area 1 — compose_engine store/feed seam (SEAM-01)
+
+- **D-01 (store + feed ride on the shared `EngineContext`, not as `compose_engine` params):**
+  Extend the ONE shared `EngineContext` (currently `bus`/`config`/`environment`/`sql_engine`)
+  with `feed` (required) + `store` (Optional, default `None`). This is the mode-injection
+  seam the owner wants: `ctx` is **where the mode-specific factory selects and injects
+  per-mode backends** — `sql_engine` already follows exactly this pattern (real in live,
+  `None` in backtest), so `store` (real in backtest, `None` in live) is the identical idiom
+  in the same file, NOT a new concession. Reframes `ctx`'s identity from "infra-only" to
+  "everything the mode factory selects: transport + knobs + backends (`sql_engine`, `store`,
+  `feed`)"; `spec` stays purely "what to run". **This consciously amends the locked LR-14
+  invariant** ("exactly four fields… NEVER add a field. The shape is frozen here") — the
+  planner updates that docstring/invariant text and every `EngineContext(...)` construction
+  site. Rejected: (a) inject store+feed as `compose_engine` kwargs (the owner's objection:
+  live would still build a vestigial `CsvPriceStore`, and it scatters the injection surface);
+  (b) `make_feed(store)` callable; (c) two `EngineContext` subclasses per mode — doesn't
+  remove the `store` field from compose's read contract (compose reads `ctx.store` uniformly,
+  so it's `Optional`/`None` on live anyway), adds frozen-dataclass-inheritance friction, and
+  still needs `TYPE_CHECKING` for the live feed type — surface without benefit.
+
+- **D-02 (live carries `store=None` — do NOT build an unused `CsvPriceStore`):** `LiveBarFeed`
+  never reads a store, so live passes `store=None` on `ctx` (the whole point of the Optional).
+  `store: Optional[...] = None`, `feed` required. **Verify item:** confirm nothing on the live
+  path reads `self.store` expecting a real store (expected vestigial; if something does, repoint
+  it).
+
+- **D-03 (both new `ctx` fields typed via `TYPE_CHECKING` forward-refs to the BASE store/feed
+  types):** `engine_context.py` is documented import-inert; annotate the new fields against the
+  base `store`/`feed` types under `TYPE_CHECKING` — mirroring exactly how `sql_engine` avoids
+  pulling SQLAlchemy — so adding them pulls no concretion onto the backtest graph. The concrete
+  `LiveBarFeed` is imported only inside the live factory (lazy). Keeps `test_okx_inertness.py`
+  green. Field order reworked so required fields precede defaulted ones (avoids the
+  "non-default after default" dataclass error).
+
+- **D-04 (`compose_engine` becomes SPEC-FREE — the centerpiece architectural decision):**
+  Signature becomes `compose_engine(ctx, *, exchange_config=None, results_store=None)` — **no
+  `spec`**. Rationale: after D-01 moves store/feed to `ctx`, compose no longer reads
+  `spec.data`/`start`/`end`/`timeframe` (those only built the store/feed). The only two fields
+  it still read (`spec.exchange`, `spec.results_store`) are *how/where to execute + persist*,
+  NOT "what to run" — so they become explicit params. `SystemSpec` is the **backtest factory's**
+  input (strategies/portfolios/dates/ticker) and now never crosses the shared seam. This is the
+  owner's explicit requirement: **"I don't want backtest specification in live mode."** The
+  backtest factory (`build_backtest_system`) pulls `exchange_config`/`results_store` out of its
+  `SystemSpec`, builds store/feed → `ctx`, calls `compose_engine(ctx, exchange_config=…,
+  results_store=…)`, then does its own `add_portfolio`/strategy registration. Live calls
+  `compose_engine(ctx)` with neither. **Consequence (oracle-gated):** changes `compose_engine`'s
+  signature — `build_backtest_system` and the e2e `ScenarioSpec` duck-typed call site adapt to
+  pass the two params explicitly; byte-exact as long as the same `exchange_config`/`results_store`
+  values flow. Live's `ExecutionHandler` gets `exchange_config=None` (its default today, so no
+  behavior change).
+
+- **D-05 (live reuses `FeeModelCommissionEstimator`; the hand-rolled `_estimate_commission`
+  closure is deleted):** once `build_live_system` calls `compose_engine`, the commission adapter
+  comes from compose (compose.py:54-78) — the re-inlined closure at live_trading_system.py:1541-1545
+  is removed (SPEC SEAM-01 acceptance, unchanged).
+
+### Area 2 — venue-extras collapse (SEAM-02)
+
+- **D-06 (`Engine` stays the shared, mode-agnostic, OKX-free graph — venue handles do NOT go on
+  it):** Rejected putting the venue/connector fields on the shared `Engine` dataclass: it is the
+  BACKTEST holder too, so it would carry ~8 live-only OKX `None` fields as dead weight and drag
+  venue/OKX vocabulary into the one seam kept venue-free — moving the loose-`Any` pile onto the
+  shared class instead of deleting it. `Engine` is unchanged this phase.
+
+- **D-07 (reuse the factory's `VenueLifecycle` as the SINGLE venue/connector holder — no unpack,
+  no new class):** `assemble_venue` already returns a cohesive `VenueLifecycle` that groups the
+  whole venue/connector cluster: `lifecycle.bundle.exchange` (= `okx_exchange`/simulated),
+  `lifecycle.bundle.connector` (= `okx_connector`, `None` for paper), `lifecycle.bundle.account_factory()`
+  (= `venue_account`), `lifecycle.provider` (= `okx_data_provider`). `build_live_system`'s
+  field-by-field unpacking is exactly the shredding to stop. Hold the `VenueLifecycle` as the one
+  reference; uniform across okx AND paper (paper gets a lifecycle+bundle with `connector=None`).
+  This is a principled domain grouping (owner: *"define all of them under one class called
+  connectors… I have a factory for that"*), NOT the arbitrary grab-bag `LiveSystemComponents` was.
+
+- **D-08 (unpack the lifecycle in `__init__` — P7-safe, bodies untouched):** `build_live_system`
+  passes the single `lifecycle`; the facade `__init__` sources its existing `self._okx_*` fields
+  off it (`self._okx_exchange = lifecycle.bundle.exchange`, …). The shredding disappears from the
+  factory and one cohesive object flows through, while the safety/reconcile/stream method bodies
+  P7 will extract stay **unchurned** (the milestone deliberately keeps them untouched — P6 D-04).
+  Rejected full read-through (`self._venue.bundle.exchange` in every method body) — churns exactly
+  the bodies P7 is about to pull out.
+
+- **D-09 (the SQL spine is NOT part of "connectors" — keep it separate):** `system_db_backend`
+  (which IS the same `SqlEngine` already threaded into `ctx.sql_engine` + the handlers) and
+  `halt_record_store` are storage/durable infra, not venue/connector — they stay separate
+  facade/infra fields, never folded into the venue holder (folding them back would recreate the
+  grab-bag). `exchange` (the venue-name string) is `spec.execution_venue`-derived, kept as-is.
+
+- **D-10 (delete `LiveSystemComponents`; facade `__init__` = direct pure injection):** No wrapper
+  class. The 20-field `Any` bag bought ZERO mypy safety (the live facade module is
+  `[[tool.mypy.overrides]]` `ignore_errors`, and the fields were `Any`) — it was single-producer/
+  single-consumer ceremony. Facade takes the compose `Engine` + the `VenueLifecycle` + the SQL
+  handles as direct keyword-only params; `store`/`order_storage`/`signal_store` are sourced FROM
+  the engine (`engine.store` (None on live) / `engine.order_handler.storage` /
+  `engine.strategies_handler.signal_store`) — no duplicate fields. Satisfies P6 D-09 pure-injection
+  (pre-built collaborators, no wiring logic in `__init__`). Also removes the interim `Engine`
+  reconstruction in `_initialize_live_session` (926-937) — it reads the real engine off injected
+  state.
+
+### Area 3 — shared live-spec builder (SEAM-03)
+
+- **D-11 (a small live-only `VenueSpec` for `assemble_venue` — NOT a compose spec):** Because
+  D-04 makes `compose_engine` spec-free, the ONLY "spec" live needs is the venue-selection trio
+  `assemble_venue` reads: `execution_venue` / `data_provider` / `account_id` (3 fields, genuinely
+  venue-scoped, not backtest-shaped). One shared typed builder produces it — centralizing the
+  `{'okx':'okx','paper':'okx'}` default-provider map — and BOTH `for_exchange` and
+  `build_live_system` call it, killing the twice-written `SimpleNamespace` + default-map
+  (live_trading_system.py:274-283 and 1625-1633). It feeds `assemble_venue` only, never
+  `compose_engine`. Prefer a small typed `VenueSpec` dataclass over the duck-typed
+  `SimpleNamespace` (mypy-friendly, self-documenting). SPEC SEAM-03 acceptance holds: the
+  `{'okx':'okx','paper':'okx'}` literal + spec construction exist in exactly ONE location;
+  `for_exchange('okx'|'paper'|other)` and direct `build_live_system` produce identical specs.
+
+### Area 4 — barrel de-lazy (SEAM-04)
+
+- **D-12 (DROP the live surface from the barrel entirely — owner choice over `__getattr__`):**
+  `trading_system/__init__.py` exports **backtest only** — no live reference at all (maximally
+  inert; even cleaner than a PEP 562 `__getattr__` lazy re-export, which was the recommended
+  alternative). The ~45 `from itrader.trading_system import build_live_system` / `LiveTradingSystem`
+  call sites are repointed to `itrader.trading_system.live_trading_system`. Owner preferred
+  explicit imports over import magic; accepts the larger mechanical diff. SPEC SEAM-04 acceptance
+  holds: `test_okx_inertness.py` green; importing `build_backtest_system` from the barrel does not
+  import `live_trading_system`; the call-site fan-out is the `mypy --strict` + full-suite backstop.
+
+- **D-13 (hoist the pure imports to module top in `live_trading_system.py`; heavy imports stay
+  lazy):** with the module off the backtest import graph (D-12), the genuinely-pure imports
+  (`Engine`, `BacktestClock`, `TimeGenerator`, `SessionInitializer`, `UniverseHandlerConfig`) move
+  to module top; the genuinely-heavy imports (ccxt.pro / SQL / venue substrate) STAY lazy inside
+  `build_live_system`.
+
+### Claude's Discretion
+- Exact names/signatures of the new/changed surfaces: the `VenueSpec` builder's name/home, the
+  `EngineContext` field order, the `compose_engine(ctx, *, exchange_config, results_store)` param
+  names, the facade `__init__` keyword-only param list.
+- Plan/wave slicing across SEAM-01..04, subject to the byte-exact + inertness gates. SEAM-01
+  (compose signature + `ctx` extension) is the oracle-gated change and should be isolated/verified
+  on its own; SEAM-04 (barrel drop + ~45 call-site repoint) is a mechanical fan-out best sliced
+  separately.
+- Whether `system_db_backend`/`halt_record_store` become two facade fields or a tiny separate
+  infra holder (D-09 only mandates they stay OUT of the venue holder).
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Phase framing & locked scope
+- `.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-SPEC.md`
+  — the 4 locked requirements (SEAM-01..04), boundaries, acceptance criteria, edge coverage,
+  prohibitions. **Read before planning.** NOTE: the discussion refined SEAM-01/03 (store/feed →
+  `ctx`; `compose_engine` spec-free) beyond the SPEC's illustrative snippets — the decisions above
+  supersede those snippets; the SPEC's acceptance criteria/gates hold verbatim.
+- `.planning/ROADMAP.md` § "Phase 06.1 (INSERTED): Seam Cleanup" — goal + success criteria.
+- `.planning/phases/06-liverunner-factory-facade-shrink/06-CONTEXT.md` — the P6 decisions this
+  builds on (D-09 pure-injection facade, D-04 untouched safety/reconcile/stream bodies, D-14a
+  mode-agnostic compose seam, the indentation split).
+
+### The shared compose seam (SEAM-01 — oracle-sensitive)
+- `itrader/trading_system/compose.py:81-111` `Engine` holder + `:114-258` `compose_engine(ctx, spec)`
+  — the seam that becomes spec-free; `:161-165` the store/feed construction that moves to the
+  factory/`ctx`; `:54-78` `FeeModelCommissionEstimator` (live reuses it, D-05).
+- `itrader/trading_system/engine_context.py` — the 4-field frozen `EngineContext` extended with
+  `feed`/`store` (D-01/D-03); the `sql_engine` `TYPE_CHECKING` forward-ref pattern to mirror; the
+  LR-14 "frozen shape" invariant this phase consciously amends.
+- `itrader/trading_system/system_spec.py:79-127` `SystemSpec` — the backtest factory's declarative
+  input that no longer crosses into compose (D-04); the `execution_venue`/`data_provider`/`account_id`
+  fields relevant to the live `VenueSpec` (D-11).
+- `itrader/trading_system/backtest_trading_system.py` (`build_backtest_system`) — adapts to build
+  store/feed → `ctx` and pass `exchange_config`/`results_store` explicitly (D-04). TABS.
+
+### The live composition root (SEAM-02/03/04)
+- `itrader/trading_system/live_trading_system.py:103-134` `LiveSystemComponents` (deleted, D-10);
+  `:145-252` `__init__` (pure-injection, sources from engine + lifecycle, D-08/D-10);
+  `:255-283` `for_exchange` + `:1625-1633` the duplicated venue-spec/default-map (one builder, D-11);
+  `:892-980` `_initialize_live_session` (interim `Engine` reconstruction removed, D-10);
+  `:1438-1734` `build_live_system` (hand-rolled graph → `compose_engine`; unpack removed, D-05/D-07/D-08).
+  4-SPACE.
+- `itrader/trading_system/__init__.py:5` — the eager live import to drop (D-12).
+
+### The venue factory + holder (SEAM-02)
+- `itrader/venues/assemble.py` `assemble_venue(...) -> (VenueBundle, VenueLifecycle)` — the factory
+  whose `VenueLifecycle` output becomes the single venue/connector holder (D-07). 4-SPACE.
+- `itrader/venues/lifecycle.py` `VenueLifecycle` — exposes `.bundle` + `.provider` (read-only);
+  the grouped object the facade holds.
+- `itrader/venues/bundle.py:47-73` `VenueBundle` (frozen/slots) — `exchange` / `account_factory` /
+  `connector`(None for paper) / `lifecycle`; reached via `lifecycle.bundle.*`.
+
+### Gate references
+- `tests/integration/test_backtest_oracle.py` — byte-exact oracle `134 / 46189.87730727451`
+  (`check_exact=True`) + determinism double-run; the per-PLAN gate on SEAM-01.
+- `tests/integration/test_okx_inertness.py` — backtest import path pulls no ccxt.pro/SQL; the gate
+  on SEAM-04 (and the `EngineContext` `TYPE_CHECKING` typing in D-03).
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `FeeModelCommissionEstimator` (compose.py:54-78) already promotes the `_estimate_commission`
+  closure live re-inlines — live just reuses it once it consumes `compose_engine` (D-05).
+- `VenueLifecycle` (venues/lifecycle.py) is ALREADY the cohesive venue/connector holder the owner
+  wants — `assemble_venue` returns it; stop unpacking it (D-07).
+- The `EngineContext.sql_engine: Optional["SqlEngine"] = None` + `TYPE_CHECKING` forward-ref is the
+  exact pattern the new `store`/`feed` fields follow (D-01/D-03) — real-in-one-mode / None-in-other,
+  import-inert.
+
+### Established Patterns
+- **`ctx` = the mode-injection seam** (transport + knobs + factory-selected backends). `sql_engine`
+  is the precedent for a per-mode backend that's real in one mode, `None` in the other — `store`
+  follows it (D-01).
+- **`spec` = "what to run", factory-local.** Post-D-04 it never enters the shared compose seam;
+  backtest keeps `SystemSpec`, live keeps a tiny `VenueSpec` (D-04/D-11).
+- **Interim-callback / untouched-body discipline (P6 D-04):** the facade's safety/reconcile/stream
+  method bodies stay unchurned so P7 extracts from a known baseline — hence unpack-in-`__init__`
+  (D-08), not read-through.
+- **Indentation split (bytes-per-file):** `compose.py`/`engine_context.py`/`backtest_trading_system.py`/
+  `system_spec.py`/`assemble.py`/`lifecycle.py`/`bundle.py`/`universe_wiring.py` are **TABS** (mostly);
+  `live_trading_system.py`/`session_initializer.py`/`live_runner.py` are **4-SPACE**;
+  `trading_system/__init__.py` is spaces. Measure per file; never normalize.
+
+### Integration Points
+- `build_backtest_system` is the ONLY caller that must adapt to the spec-free compose signature on
+  the oracle path (+ the e2e `ScenarioSpec` duck-typed call site) — D-04.
+- `build_live_system` + `for_exchange` are the two callers of the shared `VenueSpec` builder (D-11).
+- ~45 call sites import the live surface from the `trading_system` barrel — all repoint to the
+  submodule after D-12.
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- The owner drove the design toward **`ctx` as the single mode-injection seam** ("this is why we
+  have a context, right, to differentiate and inject components according to the different trading
+  system modes") and rejected every option that either built an unused object in live (vestigial
+  `CsvPriceStore`) or leaked backtest shape into live.
+- The decisive reframe: **`compose_engine` spec-free** — "I don't want backtest specification in
+  live mode." This is stronger than the SPEC's original SEAM-03 (which still built a shared live
+  compose-spec); the owner wanted the *architecturally correct* seam, not a centralized-but-still-
+  shared spec.
+- The owner rejected wrapper classes for their own sake (`LiveSystemComponents`, a bespoke
+  `LiveVenueExtras`) but ACCEPTED a principled grouping backed by an existing factory (reuse
+  `VenueLifecycle`) — the distinction is cohesion + a real producer, not "a bag to pass args".
+- On the barrel, the owner chose the more explicit **drop-the-export** over `__getattr__` magic,
+  accepting the larger call-site diff.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- **SafetyController / ReconciliationCoordinator / StreamRecoveryHandler + CONTROL routes (→ P7):**
+  the loop-lifecycle callback web (`_on_loop_start`/`_on_loop_error`/the 9 LiveRunner callbacks) and
+  the facade's safety/reconcile/stream bodies stay untouched here (that's why D-08 unpacks in
+  `__init__` rather than read-through). `set_freeze_gate`/dispatch-gate repoint to `SafetyController`
+  there.
+- **`_initialize_live_session` → construction-time flip (→ P10):** blocked by the
+  add-strategy-after-construction + monkeypatch test contract; this phase only removes the interim
+  `Engine` reconstruction, keeping session init deferred to `start()`.
+- **Fold `UniverseHandler`'s 5 non-freeze setters into its ctor (→ P7):** low-value churn now.
+- **Injected `ErrorPolicy` formalization / SystemStore stats read-model (→ P8/P9):** untouched here.
+
+None — discussion stayed within phase scope (the SEAM-01/03 refinement is a *deepening* of the
+SPEC's own seams toward the correct architecture, not new capability).
+
+</deferred>
+
+---
+
+*Phase: 06.1-Seam Cleanup*
+*Context gathered: 2026-07-14*

--- a/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-DISCUSSION-LOG.md
+++ b/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-DISCUSSION-LOG.md
@@ -1,0 +1,76 @@
+# Phase 06.1: Seam Cleanup - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-07-14
+**Phase:** 06.1-Seam Cleanup
+**Areas discussed:** Store/feed seam (SEAM-01), Venue-extras holder (SEAM-02), Shared spec-builder (SEAM-03), Barrel de-lazy (SEAM-04)
+
+---
+
+## Store/feed seam (SEAM-01)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Inject store+feed as compose kwargs | Each mode factory builds the pair, passes in | |
+| `make_feed(store)` callable | Compose keeps the store, caller supplies feed factory | |
+| Optional `feed` param, default builds BacktestBarFeed | One optional kwarg; store stays in compose | |
+| **Put store+feed on `EngineContext`** | The mode-injection seam carries them (like `sql_engine`) | ✓ |
+
+**User's choice:** Extend the shared `EngineContext` with `feed` (required) + `store` (Optional=None). Live passes `store=None`; the owner explicitly did not want to build a vestigial `CsvPriceStore` in live.
+**Notes:** Owner's framing — "this is why we have a context, to differentiate and inject components according to the different trading system modes." Rejected two-EngineContext-classes: doesn't remove the `store` field from compose's uniform read, adds frozen-inheritance friction, still needs `TYPE_CHECKING` for the live feed type. Consciously amends the locked LR-14 "4 fields frozen" invariant. Import-inertness preserved via `TYPE_CHECKING` base-type refs (mirrors `sql_engine`).
+
+### Follow-on: spec-free `compose_engine`
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Build a real `SystemSpec` for live | Reuse the frozen dataclass, fill dummy required fields | |
+| Centralize the `SimpleNamespace` | One duck-typed builder, written once | |
+| **Make `compose_engine` spec-free** | Drop `spec`; pass `exchange_config`/`results_store` explicitly | ✓ |
+
+**User's choice:** Spec-free `compose_engine(ctx, *, exchange_config=None, results_store=None)`.
+**Notes:** Owner rejected both spec-builder options ("they look ugly as fuck… I don't want backtest specification in live mode") and asked for the architecturally correct seam. Since moving store/feed to `ctx` left compose reading only `spec.exchange` + `spec.results_store`, those became explicit params and `SystemSpec` stays a backtest-factory-local concern that never crosses the shared seam. Oracle-gated (compose signature change; `build_backtest_system` + e2e `ScenarioSpec` call site adapt; byte-exact).
+
+---
+
+## Venue-extras holder (SEAM-02)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Frozen `LiveVenueExtras` + engine-sourced attrs | A new holder for the venue/SQL handles | |
+| Keep pass-through fields | Looser holder, minimal renames | |
+| Venue handles as direct `__init__` kwargs | No wrapper; ~10 keyword-only params | |
+| Venue handles on the shared `Engine` | One holder for everything | |
+| **Reuse the factory's `VenueLifecycle`** | The existing grouped object; unpack in `__init__` | ✓ |
+
+**User's choice:** `Engine` stays the shared graph; reuse `VenueLifecycle` (from `assemble_venue`) as the single venue/connector holder; unpack into the facade's existing `self._okx_*` fields in `__init__` (P7-safe); SQL spine kept separate; delete `LiveSystemComponents`.
+**Notes:** Owner: "I don't want to define the connectors one by one. I have a factory for that. I want to define all of them under one class called connectors." Established `LiveSystemComponents` bought zero mypy safety (live module is `ignore_errors`). Rejected venue fields on the shared `Engine` (backtest would carry dead OKX None-fields). Chose unpack-in-`__init__` over full read-through to keep the safety/reconcile/stream bodies P7 extracts unchurned.
+
+---
+
+## Barrel de-lazy (SEAM-04)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Module `__getattr__` lazy re-export | PEP 562 lazy import; ~45 call sites unchanged | |
+| **Drop live from barrel entirely** | Backtest-only barrel; repoint ~45 call sites | ✓ |
+
+**User's choice:** Drop the live surface from `trading_system/__init__.py` entirely; repoint the ~45 call sites to the submodule. Hoist pure imports to module top in `live_trading_system.py`; keep ccxt/SQL/venue lazy in `build_live_system`.
+**Notes:** Owner preferred explicit imports over `__getattr__` import magic, accepting the larger mechanical diff. Maximally inert (no live reference in the barrel at all).
+
+---
+
+## Claude's Discretion
+
+- Exact names/signatures: the `VenueSpec` builder, `EngineContext` field order, the
+  `compose_engine` param names, the facade `__init__` keyword-only list.
+- Plan/wave slicing across SEAM-01..04 (SEAM-01 oracle-gated + isolated; SEAM-04 mechanical fan-out).
+- Whether `system_db_backend`/`halt_record_store` become two facade fields or a tiny infra holder.
+
+## Deferred Ideas
+
+- SafetyController/Reconciliation/StreamRecovery + CONTROL routes → P7.
+- `_initialize_live_session` construction-time flip → P10 (blocked by the test contract here).
+- Fold `UniverseHandler`'s non-freeze setters into its ctor → P7.
+- `ErrorPolicy` formalization / SystemStore stats read-model → P8/P9.

--- a/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-REVIEW.md
+++ b/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-REVIEW.md
@@ -1,0 +1,135 @@
+---
+phase: 06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo
+reviewed: 2026-07-14T00:00:00Z
+depth: standard
+files_reviewed: 10
+files_reviewed_list:
+  - itrader/trading_system/engine_context.py
+  - itrader/trading_system/compose.py
+  - itrader/trading_system/backtest_trading_system.py
+  - itrader/trading_system/backtest_runner.py
+  - itrader/trading_system/live_trading_system.py
+  - itrader/trading_system/venue_spec.py
+  - itrader/trading_system/__init__.py
+  - itrader/price_handler/feed/base.py
+  - tests/integration/test_okx_inertness.py
+  - tests/unit/trading_system/test_venue_spec.py
+findings:
+  critical: 0
+  warning: 1
+  info: 2
+  total: 3
+status: issues_found
+---
+
+# Phase 06.1: Code Review Report
+
+**Reviewed:** 2026-07-14
+**Depth:** standard
+**Files Reviewed:** 10
+**Status:** issues_found
+
+## Summary
+
+Phase 06.1 is a behavior-preserving structural refactor of `itrader/trading_system/`:
+`compose_engine` was made spec-free (store/feed injected via `EngineContext`), the live
+`build_live_system` now consumes `compose_engine` instead of hand-rolling a parallel
+handler graph, the `{'okx':'okx','paper':'okx'}` default-provider map was centralized into
+a new pure `venue_spec.py`, and the live surface was dropped from the `trading_system`
+barrel.
+
+I traced every changed seam adversarially. The wiring is sound and byte-preserving:
+
+- **Storage equivalence verified.** The live in-memory arm (`environment='backtest'`,
+  `sql_engine=None`) resolves to `InMemoryOrderStorage` / `InMemorySignalStore` — identical
+  to the deleted explicit `OrderStorageFactory.create('backtest')` /
+  `SignalStorageFactory.create_in_memory()` calls. The Postgres arm resolves to
+  `CachedSqlOrderStorage(SqlOrderStorage(backend))` identically. `PortfolioHandler` /
+  `OrderHandler` / `StrategiesHandler` all default `environment="backtest"`, so the compose
+  path reproduces the former explicit construction exactly.
+- **Commission estimator equivalence.** `FeeModelCommissionEstimator(simulated_exchange)`
+  reproduces the deleted `_estimate_commission` closure (same exchange ref, same late-bound
+  `fee_model` read, same `side="buy"/order_type="market"` convention).
+- **Venue sourcing equivalence.** The facade now sources venue handles off
+  `lifecycle.bundle` / `lifecycle.provider`; I confirmed `assemble_venue` returns
+  `(bundle, lifecycle)` with `lifecycle.bundle is bundle` and `lifecycle.provider is
+  provider`, and `account_factory()` is still called exactly once. Paper (connector=None)
+  keeps every `_okx_*` handle `None`, byte-identical to the former guard.
+- **ABC change is safe.** `bind` / `generate_bar_event` became `@abstractmethod` on
+  `BarFeed`; both (and only) concrete subclasses `BacktestBarFeed` / `LiveBarFeed`
+  implement all abstract methods, so no instantiation `TypeError` is introduced.
+- **No broken call sites.** All 4 `EngineContext(...)` sites pass the now-required `feed`;
+  all 3 `compose_engine(...)` callers use the new keyword-only signature; no code imports
+  the dropped live surface from the barrel; no stale `LiveSystemComponents` /
+  `LiveTradingSystem(components,...)` construction remains.
+- **Inertness confirmed at runtime.** Importing `backtest_trading_system` pulls neither
+  `itrader.trading_system.live_trading_system` nor `ccxt`; `venue_spec` resolves and its
+  round-trip identity holds.
+
+No BLOCKER-level correctness, security, or data-loss defects were found in the changed
+lines. The one substantive finding is dead code left behind by SEAM-02.
+
+## Warnings
+
+### WR-01: Dead module-top imports left behind by the SEAM-02 graph deletion
+
+**File:** `itrader/trading_system/live_trading_system.py:3,19,21,22,23,24,25,26,27,29,30`
+**Issue:** SEAM-02 deleted the hand-rolled live handler graph and the `LiveSystemComponents`
+`@dataclass`, but the module-top imports those constructions used were not removed. AST
+analysis confirms 11 phase-introduced unused imports:
+
+- `dataclass` (line 3) — only used by the deleted `LiveSystemComponents`.
+- `EventHandler` (line 19) — deleted inline `EventHandler(...)` construction.
+- `CsvPriceStore` (line 21) — deleted `store = CsvPriceStore()`.
+- `StrategiesHandler` (line 22) — deleted inline `StrategiesHandler(...)`.
+- `SignalStorageFactory` (line 23) — deleted in-memory/live signal-store selection.
+- `ScreenersHandler` (line 24) — deleted `ScreenersHandler(...)` (now built in compose).
+- `OrderHandler` (line 25) — deleted inline `OrderHandler(...)`.
+- `OrderStorageFactory` (line 26) — deleted order-storage selection.
+- `PortfolioHandler` (line 27) — deleted inline `PortfolioHandler(...)`.
+- `ExecutionHandler` (line 29) — deleted inline `ExecutionHandler(...)`.
+- `SimulatedExchange` (line 30) — deleted `isinstance` guard in `_estimate_commission`.
+
+These pass all gates silently (the module is `[[tool.mypy.overrides]] ignore_errors`, and
+Python does not warn on unused imports), so no gate catches them. They are not an inertness
+hazard (every one is a pure/backtest-graph module), but they are dead weight that
+misrepresents the module's real dependencies and is exactly the cleanup SEAM-02 should have
+completed. `Engine` (line 54) and `VenueLifecycle` (line 55) are NOT in this list — they are
+used in string forward-ref annotations under `TYPE_CHECKING` and are correctly retained.
+
+**Fix:** Remove the 11 dead imports listed above. Concretely, delete lines 3 (`from
+dataclasses import dataclass`), 19, 21, 22, 23, 24, 25, 26, 27, 29, 30. Verify with an AST
+unused-import scan (or add pyflakes to the dev deps) after deletion.
+
+## Info
+
+### IN-01: Pre-existing unused imports in a changed file
+
+**File:** `itrader/trading_system/live_trading_system.py:18,48`
+**Issue:** `ConfigurationError` (line 18, imported alongside the used `StateError`) and
+`UniversePollEvent` (line 48, imported alongside the used `EventType` / `ErrorEvent`) are
+unused. These predate Phase 06.1 (confirmed against base `1544027a`), so they are not
+regressions, but they sit in a file this phase touched and could be swept up with WR-01.
+**Fix:** Drop `ConfigurationError` from the `core.exceptions` import (keep `StateError`) and
+`UniversePollEvent` from the `events` import (keep `EventType`, `ErrorEvent`).
+
+### IN-02: `self.store` semantics silently changed from empty-store to `None` on live
+
+**File:** `itrader/trading_system/live_trading_system.py:182`
+**Issue:** The old `build_live_system` set `self.store` to a real (empty, offline)
+`CsvPriceStore()`; it is now `engine.store`, which is `None` on live (D-02, intentional and
+documented). No live-path code reads `self.store` (verified — it is assigned and never
+dereferenced internally, and `wire_universe` / `SessionInitializer` read only `engine.feed`),
+so this is safe within the codebase. Flagging only because `store` is a public attribute:
+any external consumer (web layer / script) that does `live_system.store.read_bars(...)` would
+now raise `AttributeError: 'NoneType'` instead of returning empty data. No in-repo caller
+does this, and the empty old store was itself useless, so the change is defensible.
+**Fix:** No code change required. If external read compatibility is ever a concern, document
+on the public attribute that `LiveTradingSystem.store` is `None` (the live feed reads no
+store), or expose it as a property that raises a clear typed error.
+
+---
+
+_Reviewed: 2026-07-14_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: standard_

--- a/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-REVIEW.md
+++ b/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-REVIEW.md
@@ -19,7 +19,8 @@ findings:
   warning: 1
   info: 2
   total: 3
-status: issues_found
+status: resolved
+resolution: "WR-01 + IN-01 fixed in-phase (dead-import sweep); IN-02 accepted (intentional, no code change)"
 ---
 
 # Phase 06.1: Code Review Report
@@ -27,7 +28,7 @@ status: issues_found
 **Reviewed:** 2026-07-14
 **Depth:** standard
 **Files Reviewed:** 10
-**Status:** issues_found
+**Status:** resolved (WR-01 + IN-01 swept in-phase; IN-02 accepted)
 
 ## Summary
 
@@ -128,8 +129,28 @@ does this, and the empty old store was itself useless, so the change is defensib
 on the public attribute that `LiveTradingSystem.store` is `None` (the live feed reads no
 store), or expose it as a property that raises a clear typed error.
 
+## Resolution (in-phase, by execute-phase orchestrator)
+
+Applied immediately after review since this is the "Seam Cleanup" phase and the findings are
+phase-introduced dead code — leaving them would contradict the phase goal.
+
+- **WR-01 (fixed):** Removed all 11 dead module-top imports from `live_trading_system.py`
+  (`dataclass`, `EventHandler`, `CsvPriceStore`, `StrategiesHandler`, `SignalStorageFactory`,
+  `ScreenersHandler`, `OrderHandler`, `OrderStorageFactory`, `PortfolioHandler`, `ExecutionHandler`,
+  `SimulatedExchange`). Each was independently confirmed dead (word-boundary occurrence scan — the
+  only non-import mentions were in comments/docstrings). `Engine` / `VenueLifecycle` were retained
+  (used in `TYPE_CHECKING` forward-ref annotations).
+- **IN-01 (fixed):** Dropped the two pre-existing unused imports in the same file
+  (`ConfigurationError`, `UniversePollEvent`).
+- **IN-02 (accepted, no code change):** `self.store` → `None` on live is intentional/documented (D-02);
+  no in-repo dereference exists.
+
+**Post-fix gates (all green):** module imports cleanly (no `NameError`), `mypy itrader` clean
+(250 files), full suite **2143 passed / 6 skipped** — byte-identical to the pre-cleanup run.
+
 ---
 
 _Reviewed: 2026-07-14_
 _Reviewer: Claude (gsd-code-reviewer)_
 _Depth: standard_
+_Resolution: execute-phase orchestrator, 2026-07-14_

--- a/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-VERIFICATION.md
+++ b/.planning/phases/06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo/06.1-VERIFICATION.md
@@ -1,0 +1,116 @@
+---
+phase: 06.1-seam-cleanup-make-build-live-system-consume-the-shared-compo
+verified: 2026-07-14T00:00:00Z
+status: passed
+score: 4/4 must-haves verified
+behavior_unverified: 0
+overrides_applied: 0
+---
+
+# Phase 06.1: Seam Cleanup Verification Report
+
+**Phase Goal:** Behavior-preserving cleanup of the interim scaffolding Phase 6 left behind — make
+`build_live_system` consume the shared `compose_engine` (store/feed-agnostic seam) instead of
+hand-rolling a parallel handler graph, collapse the `LiveSystemComponents` bag, de-duplicate the
+`for_exchange` spec-builder, and de-lazy the `trading_system` barrel so pervasive
+lazy-imports-inside-methods move to module top. Live behavior unchanged; backtest byte-exact.
+
+**Verified:** 2026-07-14
+**Status:** passed
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths (ROADMAP Success Criteria)
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | `build_live_system` wires its handler graph by calling `compose_engine` (store/feed injection seam); hand-rolled execution/strategies/order/event handler construction AND the re-inlined `_estimate_commission` closure are gone; backtest oracle byte-exact `134 / 46189.87730727451` with determinism double-run identical | ✓ VERIFIED | `build_live_system` (live_trading_system.py:1537-1544) builds `EngineContext(feed=LiveBarFeed, store=None, environment=…, sql_engine=…)` and calls `engine = compose_engine(ctx, exchange_config=None, results_store=None)`. `grep -n "ExecutionHandler(\|OrderHandler(\|StrategiesHandler(\|EventHandler(\|_estimate_commission"` in `live_trading_system.py` returns 0 matches. `poetry run pytest tests/integration/test_backtest_oracle.py` — 3 passed (byte-exact `check_exact=True`, run independently by this verifier). |
+| 2 | `LiveSystemComponents` is collapsed (20-field `Any` bag replaced by the compose `Engine` + a small venue-extras object, here `VenueLifecycle`); the interim `Engine` reconstruction in `_initialize_live_session` is removed | ✓ VERIFIED | `grep -rn "class LiveSystemComponents" itrader/ tests/` returns 0 hits (only a comment mentioning it was removed). `LiveTradingSystem.__init__` (live_trading_system.py:119-128) is keyword-only pure injection: `engine: Engine`, `lifecycle: Optional[VenueLifecycle]`, `system_db_backend`, `halt_record_store`, `exchange`, `status_callback` — handlers/feed/storages sourced directly off `engine.*` (lines 167-180). `_initialize_live_session` (line 897-968) reads `engine = self._engine`; `grep -nE "(^|[^A-Za-z])Engine\(" live_trading_system.py \| grep -v SqlEngine` returns 0 — no compose `Engine(...)` construction anywhere in the file. |
+| 3 | `for_exchange` and `build_live_system` share ONE spec-builder — the `SimpleNamespace` fake-spec and the twice-written `{'okx':'okx','paper':'okx'}` default-provider map exist in exactly ONE place (the new `venue_spec.py`) | ✓ VERIFIED | `itrader/trading_system/venue_spec.py` defines a frozen `VenueSpec` dataclass + `build_venue_spec(...)`, the sole home of `{'okx': 'okx', 'paper': 'okx'}`. `grep -rn "'okx': 'okx', 'paper': 'okx'" itrader/` shows exactly ONE hit (`venue_spec.py:82`). Both `for_exchange` (line 282) and `build_live_system` (line 1607) call `build_venue_spec(...)`. `tests/unit/trading_system/test_venue_spec.py` — 12 passed (independently run), asserting default-map behavior + `for_exchange`-vs-`build_live_system` spec equality across `{okx, paper, binance}`. No `SimpleNamespace` import remains in `live_trading_system.py`. |
+| 4 | The `trading_system` barrel no longer eagerly imports the live module onto the backtest import graph; pure imports moved to module top; `tests/integration/test_okx_inertness.py` green (no ccxt.pro/SQL on the backtest import path) | ✓ VERIFIED | `itrader/trading_system/__init__.py` exports `BacktestTradingSystem` + `build_backtest_system` ONLY (`__all__` has 2 entries, no live symbols); `grep -c "live_trading_system" itrader/trading_system/__init__.py` == 0. Pure imports (`SessionInitializer`, `EngineContext`, `UniverseHandlerConfig`, `build_venue_spec`) sit at module top of `live_trading_system.py` (lines 21, 30-33); heavy imports (`LiveBarFeed`, `SqlSettings`, `SqlEngine`, `ConnectorProvider`, `okx_plugin`, `assemble_venue`, `LiveRunner`) remain lazy inside `build_live_system`'s body (verified by reading the function, lines 1426-1699). `poetry run pytest tests/integration/test_okx_inertness.py` — 4 passed (independently run), including the new `"itrader.trading_system.live_trading_system" not in sys.modules` assertion (test_okx_inertness.py:110). |
+
+**Score:** 4/4 truths verified (0 present, behavior-unverified)
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `itrader/trading_system/engine_context.py` | `EngineContext` with `feed` (required) + `store` (Optional=None), TYPE_CHECKING forward-refs | ✓ VERIFIED | Field order `bus, config, environment, feed, store, sql_engine` confirmed; docstring amends LR-14 per D-01. |
+| `itrader/trading_system/compose.py` | spec-free `compose_engine(ctx, *, exchange_config=None, results_store=None)` | ✓ VERIFIED | Signature confirmed; `spec.` reads == 0; `CsvPriceStore(`/`BacktestBarFeed(` construction == 0; `FeeModelCommissionEstimator` present. |
+| `itrader/trading_system/live_trading_system.py` | `build_live_system` consuming `compose_engine`; `LiveSystemComponents` deleted; pure-injection facade `__init__` | ✓ VERIFIED | Confirmed above (truths 1, 2). |
+| `itrader/trading_system/venue_spec.py` | frozen `VenueSpec` dataclass + `build_venue_spec(...)` shared builder | ✓ VERIFIED | New file, pure (no venue/ccxt/SQL imports), `mypy --strict` clean. |
+| `tests/unit/trading_system/test_venue_spec.py` | `for_exchange`-vs-`build_live_system` spec-equality unit test | ✓ VERIFIED | 12 tests, run independently, all pass. |
+| `itrader/trading_system/__init__.py` | backtest-only barrel (live export dropped) | ✓ VERIFIED | Exports `BacktestTradingSystem` + `build_backtest_system` only. |
+| `tests/integration/test_okx_inertness.py` | no-live-module-import assertion added | ✓ VERIFIED | Assertion present at line 110; test green. |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|-----|-----|--------|---------|
+| `build_backtest_system` / legacy `BacktestTradingSystem.__init__` | `compose_engine` | `EngineContext(feed=…, store=…)` → `compose_engine(ctx, exchange_config=…, results_store=…)` | ✓ WIRED | Confirmed in `backtest_trading_system.py:155-176` (legacy arm) and `:478-499` (factory). Oracle byte-exact proves the shared-path regression edge is closed. |
+| `build_live_system` | `compose_engine` | `EngineContext(feed=LiveBarFeed, store=None, environment=probe-result)` → `compose_engine(ctx)` | ✓ WIRED | `live_trading_system.py:1537-1544`; both the Postgres and in-memory fallback arms select only `environment`/`sql_engine` and route through the same call. |
+| `for_exchange` / `build_live_system` | `assemble_venue` | `build_venue_spec(...)` → `VenueSpec` → `assemble_venue(ctx, venue_spec, …)` | ✓ WIRED | `live_trading_system.py:282` and `:1607-1617`; `assemble_venue` reads `spec.execution_venue`/`.data_provider`/`.account_id` structurally (duck-typed `Any` param), satisfied by the frozen `VenueSpec`. |
+| `LiveTradingSystem.__init__` | compose `Engine` / `VenueLifecycle` | direct keyword injection, handlers sourced off `engine.*`, venue handles off `lifecycle.bundle.*` | ✓ WIRED | Lines 119-203; the streaming-venue `connector is not None` guard preserved so paper keeps `_okx_*` fields `None`. |
+
+### Behavioral Spot-Checks / Test Execution (independently run by this verifier)
+
+| Check | Command | Result | Status |
+|-------|---------|--------|--------|
+| Backtest oracle byte-exact | `poetry run pytest tests/integration/test_backtest_oracle.py -q` | 3 passed | ✓ PASS |
+| OKX import-inertness | `poetry run pytest tests/integration/test_okx_inertness.py -q` | 4 passed | ✓ PASS |
+| VenueSpec equality unit test | `poetry run pytest tests/unit/trading_system/test_venue_spec.py -q` | 12 passed | ✓ PASS |
+| mypy --strict | `poetry run mypy itrader` | Success: no issues found in 250 source files | ✓ PASS |
+| Full suite | `poetry run pytest tests -q` | 2143 passed, 6 skipped (all OKX-credential-gated, expected) | ✓ PASS |
+| No `LiveSystemComponents` class anywhere | `grep -rn "class LiveSystemComponents" itrader/ tests/` | 0 hits | ✓ PASS |
+| Default-provider map appears exactly once repo-wide | `grep -rn "'okx': 'okx', 'paper': 'okx'" itrader/` | 1 hit (`venue_spec.py:82`) | ✓ PASS |
+| No compose `Engine(` construction in live module | `grep -nE "(^|[^A-Za-z])Engine\(" live_trading_system.py \| grep -v SqlEngine` | 0 hits | ✓ PASS |
+
+### Requirements Coverage
+
+Per the phase's explicit ROADMAP note, SEAM-01..04 are phase-local requirements defined in
+`06.1-SPEC.md` and are deliberately NOT part of the central `.planning/REQUIREMENTS.md`
+traceability set — verified against `06.1-SPEC.md` acceptance criteria instead.
+
+| Requirement | Source Plan(s) | Description | Status | Evidence |
+|-------------|-----------------|--------------|--------|----------|
+| SEAM-01 | 06.1-01, 06.1-02 | Live consumes `compose_engine` (oracle-gated centerpiece) | ✓ SATISFIED | Truth 1 above; oracle byte-exact; hand-rolled construction + `_estimate_commission` deleted. |
+| SEAM-02 | 06.1-02 | Collapse `LiveSystemComponents` + interim `Engine` | ✓ SATISFIED | Truth 2 above; pure-injection facade confirmed. |
+| SEAM-03 | 06.1-03 | One shared spec-builder | ✓ SATISFIED | Truth 3 above; `venue_spec.py` is the sole home of the map; unit test proves identity. |
+| SEAM-04 | 06.1-04 | De-lazy the barrel + hoist pure imports | ✓ SATISFIED | Truth 4 above; barrel backtest-only; inertness green including new assertion. |
+
+No orphaned requirements — all four SEAM IDs are declared across the 4 plans' `requirements:`
+frontmatter and match the ROADMAP's `**Requirements**: SEAM-01, SEAM-02, SEAM-03, SEAM-04` line.
+
+### Anti-Patterns Found
+
+None. Scanned all phase-touched files (`engine_context.py`, `compose.py`,
+`backtest_trading_system.py`, `backtest_runner.py`, `live_trading_system.py`, `venue_spec.py`,
+`trading_system/__init__.py`, `price_handler/feed/base.py`, `test_okx_inertness.py`,
+`test_venue_spec.py`) for `TBD`/`FIXME`/`XXX`/`TODO`/`HACK`/`PLACEHOLDER` — zero matches. The
+code-review pass (`06.1-REVIEW.md`) independently found and fixed 11 dead module-top imports
+(WR-01) + 2 pre-existing unused imports (IN-01) in `live_trading_system.py`; this verifier
+confirmed the dead-import sweep commit (`2ee6dd53`) landed — none of the deleted symbols
+(`dataclass`, `EventHandler`, `CsvPriceStore`, `StrategiesHandler`, `SignalStorageFactory`,
+`ScreenersHandler`, `OrderHandler`, `OrderStorageFactory`, `PortfolioHandler`,
+`ExecutionHandler`, `SimulatedExchange`, `ConfigurationError`, `UniversePollEvent`) appear in the
+current module-top import list.
+
+### Human Verification Required
+
+None. This is a construction/wiring-only refactor (no UI, no visual behavior, no real-time
+external-service surface) whose acceptance criteria are all grep/test-verifiable and were
+independently re-run by this verifier with matching results.
+
+### Gaps Summary
+
+No gaps found. All 4 ROADMAP success criteria are independently verified against the actual
+source (not just SUMMARY claims): the code was read directly, key greps were re-run, and the
+oracle/inertness/venue-spec/mypy/full-suite gates were re-executed by this verifier (not merely
+cited from SUMMARY.md) with results matching the phase's claims exactly (oracle byte-exact,
+inertness 4/4, venue-spec 12/12, mypy 250 files clean, full suite 2143 passed / 6 skipped).
+
+---
+
+_Verified: 2026-07-14_
+_Verifier: Claude (gsd-verifier)_

--- a/itrader/price_handler/feed/base.py
+++ b/itrader/price_handler/feed/base.py
@@ -17,12 +17,19 @@ FR7 — loud typed errors, never silent ``None``: accessors raise
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from datetime import datetime, timedelta
+from typing import Any, TYPE_CHECKING
 
 import pandas as pd
 
 from itrader.core.bar import Bar
 
 from .cache_registration import RawBarConsumer, derive
+
+if TYPE_CHECKING:
+    # String-only forward-refs for the ``generate_bar_event`` signature — keeps the
+    # base feed module's runtime imports unchanged (the events package is pure, but
+    # guarding it costs nothing and preserves the import surface exactly).
+    from itrader.events_handler.events import BarEvent, TimeEvent
 
 
 def assert_update_trigger(base_timeframe: timedelta,
@@ -180,6 +187,57 @@ class BarFeed(ABC):
             One immutable ``Bar`` per ticker that has a base bar stamped
             exactly ``time``. Tickers with no bar at ``time`` are ABSENT
             from the dict (sparse universe, D-15) — never ``None`` values.
+        """
+        pass
+
+    # -- Run-path event-sink binding (wiring time) ----------------------------
+
+    @abstractmethod
+    def bind(self, global_queue: Any, membership: list[str]) -> None:
+        """Bind the run-path event sink + membership set (wiring time).
+
+        Called once by the shared universe wiring (``wire_universe``) after
+        membership is derived. Declared on the base so the SHARED wiring seam can
+        call ``feed.bind`` uniformly across modes (``BacktestBarFeed`` enqueues via
+        the bound sink or returns the ``BarEvent`` when ``global_queue`` is ``None``;
+        ``LiveBarFeed`` binds the same sink for ``update()`` to ``put`` bars). The
+        ``global_queue`` type is left loose (``Any``) because the concrete feeds bind
+        different transports (an ``EventBus`` in backtest, a ``queue.Queue`` in live).
+
+        Parameters
+        ----------
+        global_queue : Any
+            The event sink the feed enqueues bar events onto, or ``None`` for the
+            backtest return-contract.
+        membership : list[str]
+            The derived tradable symbol set (used for the missing-ticker warning).
+        """
+        pass
+
+    # -- TIME-route bar-event factory (D-20/D-15) -----------------------------
+
+    @abstractmethod
+    def generate_bar_event(self, time_event: "TimeEvent") -> "BarEvent | None":
+        """Return the ``BarEvent`` for the tick at ``time_event``, or ``None``.
+
+        The TIME-route bar-event factory (D-20/D-15). Declared on the base so the
+        shared ``compose_engine`` seam can pass ``feed.generate_bar_event`` to the
+        ``EventHandler`` uniformly across modes (compose reads the base ``BarFeed``
+        type off ``ctx.feed``, not a concretion). ``BacktestBarFeed`` builds the
+        event from the pinned bar grid; ``LiveBarFeed`` is a DORMANT no-op — live
+        emits ``BarEvent``s directly via ``update()``, so its TIME route is
+        reserved-but-inert (D-02/D-05).
+
+        Parameters
+        ----------
+        time_event : TimeEvent
+            The tick the bar event is produced for (the pinned bar-date grid stamp
+            in backtest; unused by the dormant live override).
+
+        Returns
+        -------
+        BarEvent | None
+            The bar event for the tick, or ``None`` when there is no bar to emit.
         """
         pass
 

--- a/itrader/trading_system/__init__.py
+++ b/itrader/trading_system/__init__.py
@@ -2,11 +2,15 @@ from .backtest_trading_system import (
     BacktestTradingSystem,
     build_backtest_system,
 )
-from .live_trading_system import LiveTradingSystem, build_live_system
 
+# D-12 (SEAM-04): the live surface (``LiveTradingSystem`` / ``build_live_system``) is
+# DROPPED from this barrel entirely — no eager import, no PEP 562 ``__getattr__``
+# re-export. Importing the ``trading_system`` barrel must NOT pull the live module onto
+# the backtest import graph (that eager import was the root cause of the pervasive
+# lazy-imports-inside-methods needed to keep ``test_okx_inertness.py`` green). Live
+# consumers import from the live submodule directly (see the ``LiveTradingSystem``
+# module docstring for the canonical submodule import path).
 __all__ = [
     'BacktestTradingSystem',
     'build_backtest_system',
-    'LiveTradingSystem',
-    'build_live_system',
 ]

--- a/itrader/trading_system/backtest_runner.py
+++ b/itrader/trading_system/backtest_runner.py
@@ -21,12 +21,14 @@ Indentation: TABS (``trading_system/`` package convention).
 
 from datetime import datetime
 from functools import reduce
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, cast
 
 import pandas as pd
 
 from itrader.core.exceptions import ConfigurationError
 from itrader.logger import get_itrader_logger
+from itrader.price_handler.feed.bar_feed import BacktestBarFeed
+from itrader.price_handler.store.base import PriceStore
 from itrader.trading_system.compose import Engine
 from itrader.trading_system.universe_wiring import wire_universe
 
@@ -68,24 +70,32 @@ class BacktestRunner:
 		# derived from strategy tickers => is_ready always True at the readiness
 		# gate), proven by the byte-exact oracle double-run on this plan.
 		wire_universe(engine)
+		# BacktestRunner is backtest-only: the shared Engine holder's store/feed are
+		# widened to the base ``Optional[PriceStore]`` / ``BarFeed`` (D-04, so the
+		# mode-agnostic seam can also produce a live Engine), but on THIS path they
+		# are always the concrete backtest backends. Narrow them for the
+		# backtest-specific reads (store symbols/index) + ``precompute`` (a
+		# BacktestBarFeed-only capability the live feed does not carry).
+		store = cast(PriceStore, engine.store)
+		feed = cast(BacktestBarFeed, engine.feed)
 		# Ping clock derived from the store's bar index (T-06-16). WR-07: fail
 		# loudly on an empty store, and derive the grid from the UNION of every
 		# symbol's index so a sparse multi-symbol universe never silently drops
 		# bars. For the single-symbol golden run the reduce returns that one index
 		# UNCHANGED (no union call), so the tick grid stays byte-identical.
-		symbols = engine.store.symbols()
+		symbols = store.symbols()
 		if not symbols:
 			raise ConfigurationError(
 				reason=(
 					"Backtest store has no symbols — cannot derive the ping clock "
 					"(empty data directory or bad store path)"))
 		ping_grid = reduce(
-			pd.Index.union, (engine.store.index(s) for s in symbols))
+			pd.Index.union, (store.index(s) for s in symbols))
 		engine.time_generator.set_dates(ping_grid)
 		# M5-03: resample ONCE at run-init per registered strategy declaration —
 		# the per-tick window path is then a pure positional slice.
 		for strategy in engine.strategies_handler.strategies:
-			engine.feed.precompute(strategy.tickers, strategy.timeframe)
+			feed.precompute(strategy.tickers, strategy.timeframe)
 
 	def _run_backtest(self, on_tick: Optional[Callable[[Any, Any], None]] = None) -> None:
 		"""Poll the events queue per tick and dispatch each event (fail-fast).

--- a/itrader/trading_system/backtest_trading_system.py
+++ b/itrader/trading_system/backtest_trading_system.py
@@ -33,6 +33,9 @@ from itrader import config, idgen
 from itrader.config import ExchangeConfig, OrderConfig, get_exchange_preset
 from itrader.core.exceptions import ConfigurationError
 from itrader.events_handler.bus import FifoEventBus
+from itrader.outils.time_parser import to_timedelta
+from itrader.price_handler.feed.bar_feed import BacktestBarFeed
+from itrader.price_handler.store.csv_store import CsvPriceStore
 from itrader.reporting.frames import build_equity_curve, build_trade_log
 from itrader.reporting.summary import print_metrics_summary
 from itrader.results.records import PortfolioRecord, RunRecord
@@ -145,16 +148,31 @@ class BacktestTradingSystem(object):
 				portfolios=[],
 				exchange=exchange_config,
 			)
+			# 06.1-01 (D-01/D-04): store + feed CONSTRUCTION moved out of the spec-free
+			# compose seam onto the factory/legacy arm — built with the SAME argument
+			# values compose used (data/start/end/timeframe off the synthesized spec,
+			# empties->None) so the run stays byte-identical, then injected onto ctx.
+			store = CsvPriceStore(
+				csv_paths=spec.data or None,
+				start_date=spec.start or None,
+				end_date=spec.end or None)
+			feed = BacktestBarFeed(store, to_timedelta(spec.timeframe))
 			# The handler now OWNS its bus (FifoEventBus — byte-exact FIFO, D-07) and
 			# its storage (from environment='backtest'); config is carried, sql_engine
-			# is None (SQL-import-inert, GATE-01).
+			# is None (SQL-import-inert, GATE-01). feed rides required on ctx, store real.
 			ctx = EngineContext(
 				bus=FifoEventBus(),
 				config=config,
 				environment='backtest',
+				feed=feed,
+				store=store,
 				sql_engine=None,
 			)
-			self.engine = compose_engine(ctx, spec)
+			# 06.1-01 (D-04): spec-free compose — pass exchange_config/results_store
+			# explicitly (the legacy arm has no results store). exchange_config is the
+			# seeded ExchangeConfig riding on spec.exchange.
+			self.engine = compose_engine(
+				ctx, exchange_config=spec.exchange, results_store=None)
 			self.runner = BacktestRunner(self.engine)
 
 		self.logger.info('Trading system initialised')
@@ -453,13 +471,31 @@ def build_backtest_system(spec: SystemSpec) -> BacktestTradingSystem:
 	#    it on the spec, e.g. ``SqlResultsStore(SqlEngine(SqlSettings.results_default()),
 	#    strict_persist=SqlSettings.results_default().strict_persist)`` with the SQL
 	#    surface imported on THAT path only — never here.
+	# 06.1-01 (D-01/D-04): build the store + feed read-models HERE (the spec-free
+	# compose seam no longer constructs them) with the SAME argument values compose
+	# used off the spec (data/start/end/timeframe, empties->None) — byte-identical —
+	# and inject them onto ctx (feed required, store real in backtest).
+	store = CsvPriceStore(
+		csv_paths=spec.data or None,
+		start_date=spec.start or None,
+		end_date=spec.end or None)
+	feed = BacktestBarFeed(store, to_timedelta(spec.timeframe))
 	ctx = EngineContext(
 		bus=FifoEventBus(),
 		config=config,
 		environment='backtest',
+		feed=feed,
+		store=store,
 		sql_engine=None,
 	)
-	engine = compose_engine(ctx, spec)
+	# 06.1-01 (D-04): spec-free compose — pass exchange_config (the seeded
+	# ExchangeConfig on spec.exchange) + the OPTIONAL results_store explicitly. The
+	# e2e ScenarioSpec is the SystemSpec alias and carries results_store; getattr
+	# keeps a duck-typed spec absent-field safe (-> None -> store-free/byte-exact).
+	engine = compose_engine(
+		ctx,
+		exchange_config=spec.exchange,
+		results_store=getattr(spec, 'results_store', None))
 	runner = BacktestRunner(engine)
 
 	# 4. Add strategies/portfolios in SPEC ORDER (Trap 6 — get_active_portfolios

--- a/itrader/trading_system/compose.py
+++ b/itrader/trading_system/compose.py
@@ -38,16 +38,14 @@ from itrader.events_handler.full_event_handler import EventHandler
 from itrader.execution_handler.execution_handler import ExecutionHandler
 from itrader.execution_handler.exchanges.simulated import SimulatedExchange
 from itrader.order_handler.order_handler import OrderHandler
-from itrader.outils.time_parser import to_timedelta
 from itrader.portfolio_handler.portfolio_handler import PortfolioHandler
-from itrader.price_handler.feed.bar_feed import BacktestBarFeed
-from itrader.price_handler.store.csv_store import CsvPriceStore
+from itrader.price_handler.feed.base import BarFeed
+from itrader.price_handler.store.base import PriceStore
 from itrader.results import ResultsStore
 from itrader.screeners_handler.screeners_handler import ScreenersHandler
 from itrader.strategy_handler.strategies_handler import StrategiesHandler
 from itrader.trading_system.engine_context import EngineContext
 from itrader.trading_system.simulation.time_generator import TimeGenerator
-from itrader.trading_system.system_spec import SystemSpec
 from itrader.universe import Universe
 
 
@@ -90,8 +88,13 @@ class Engine:
 
 	global_queue: "EventBus"
 	clock: BacktestClock
-	store: CsvPriceStore
-	feed: BacktestBarFeed
+	# D-04/D-01: widened to the BASE store/feed types so live's ``store=None`` +
+	# ``LiveBarFeed`` satisfy ``mypy --strict`` (backtest injects the concrete
+	# ``CsvPriceStore`` + ``BacktestBarFeed``, a safe subtype). No default here:
+	# ``compose_engine`` always passes both explicitly off ``ctx``, and a default
+	# would break the dataclass required-field ordering that follows.
+	store: Optional[PriceStore]
+	feed: BarFeed
 	strategies_handler: StrategiesHandler
 	screeners_handler: ScreenersHandler
 	portfolio_handler: PortfolioHandler
@@ -111,58 +114,57 @@ class Engine:
 	results_store: Optional[ResultsStore] = None
 
 
-def compose_engine(ctx: "EngineContext", spec: "SystemSpec") -> Engine:
-	"""Wire the shared component graph from an infra ``ctx`` + a declarative ``spec`` (D-01/D-04).
+def compose_engine(
+	ctx: "EngineContext", *,
+	exchange_config: Optional[Any] = None,
+	results_store: Optional["ResultsStore"] = None) -> Engine:
+	"""Wire the shared component graph from a SPEC-FREE infra ``ctx`` (D-01/D-04).
 
-	End-state two-arg seam (CTX-01/D-01): the shared event transport is
-	``ctx.bus`` (the internal FIFO buffer the seam used to construct is DELETED —
-	the composition root owns the bus now), and the run-mode infra knobs
-	(``ctx.environment`` / ``ctx.sql_engine``) select the handler-OWNED storage
-	backends. The declarative ``spec`` supplies the WHAT-to-run inputs (D-02).
+	Spec-free seam (D-04, the Phase-06.1 centerpiece): ``compose_engine`` no longer
+	takes a ``spec``. The store/feed READ-MODELS ride on ``ctx`` (``ctx.store`` /
+	``ctx.feed``, D-01) — the mode factory selects and injects them — so compose
+	no longer reads ``data`` / ``start`` / ``end`` / ``timeframe`` (those only ever
+	built the store/feed) and no longer constructs a ``CsvPriceStore`` /
+	``BacktestBarFeed`` itself. The only two remaining inputs are HOW/WHERE to
+	execute + persist, so they become explicit keyword params, NOT a spec read:
+	``exchange_config`` (the already-seeded ``ExchangeConfig``, ``None`` for live's
+	default) and ``results_store`` (the OPTIONAL sink, ``None`` on the oracle path).
+	The WHAT-to-run description (strategies / portfolios / dates / ticker) stays
+	FACTORY-LOCAL and never crosses this shared seam — backtest keeps its
+	``SystemSpec``, live keeps a tiny venue-spec object.
 
-	A1 spec-read constraint (D-04): the body reads ONLY the six permitted spec
-	fields — ``data`` / ``start`` / ``end`` / ``timeframe`` / ``exchange`` /
-	``results_store`` (empties mapped to ``None``) — it NEVER reads the
-	ticker / starting_cash / strategies / portfolios fields (the legacy arm passes
-	placeholders for those). The ``order_config`` stays handler-owned
+	The shared event transport is ``ctx.bus`` (the composition root owns the bus),
+	and the run-mode infra knobs (``ctx.environment`` / ``ctx.sql_engine``) select
+	the handler-OWNED storage backends. The ``order_config`` stays handler-owned
 	(``OrderConfig.default()``, D-04 lean).
 
 	Parameters
 	----------
 	ctx : EngineContext
-		The frozen infra bundle: ``bus`` (the shared transport injected into every
-		handler + the ``Engine`` holder), ``config`` (carried, unread until P9),
-		``environment`` (selects handler-owned storage backends), ``sql_engine``
-		(``None`` for backtest — keeps the path SQL-import-inert, GATE-01).
-	spec : SystemSpec
-		The declarative run description. Only the six A1 fields are read here; the
-		FACTORY (never this seam) reads the strategies / portfolios fields (Trap 6).
-		``spec.exchange`` is an already-seeded ``ExchangeConfig`` by the time compose
-		is called (both arms seed it, D-13/Trap 1).
+		The frozen mode-injection bundle: ``bus`` (the shared transport injected into
+		every handler + the ``Engine`` holder), ``config`` (carried, unread until P9),
+		``environment`` (selects handler-owned storage backends), ``feed`` (the REQUIRED
+		per-mode read-model), ``store`` (REAL in backtest / ``None`` in live, D-02),
+		``sql_engine`` (``None`` for backtest — keeps the path SQL-import-inert, GATE-01).
+	exchange_config : Optional[Any]
+		The already-seeded ``ExchangeConfig`` threaded into the ``ExecutionHandler``
+		(the complete symbol set folded in by the factory, D-13/Trap 1). ``None`` yields
+		the ``ExecutionHandler`` default (live's behavior today — no change).
+	results_store : Optional[ResultsStore]
+		The OPTIONAL results sink forwarded onto the ``Engine`` holder (RESULT-01/D-04).
+		``None`` on the oracle path keeps it store-free AND SQL-import-inert (GATE-01).
 	"""
-	# A1 kwargs->spec fold (D-04): map only the six permitted fields, empties->None
-	# so today's exact values are preserved byte-identically.
-	csv_paths = spec.data or None
-	start_date = spec.start or None
-	end_date = spec.end or None
-	timeframe = spec.timeframe
-	exchange_config = spec.exchange
-	# getattr (NOT spec.results_store): the e2e ScenarioSpec is duck-typed into
-	# this seam by name and has no such field — absent -> None -> store-free/byte-exact.
-	results_store = getattr(spec, "results_store", None)
+	# D-01/D-04: store + feed are INJECTED on ctx by the mode factory — compose reads
+	# them uniformly (backtest: real CsvPriceStore + BacktestBarFeed; live: store=None
+	# + LiveBarFeed). The construction MOVED to the factory so the seam is store/feed-
+	# agnostic and never reads a backtest-shaped run description.
+	store = ctx.store
+	feed = ctx.feed
 
 	# Determinism seam (D-09/D-10): the injected BacktestClock staged on the
 	# determinism seam (no domain consumer yet — result determinism comes from
 	# passing the bar time explicitly to record_metrics in the runner).
 	clock = BacktestClock()
-
-	# Store + look-ahead-safe feed read-model. csv_paths passes straight through;
-	# None falls back to the single-golden-ticker default (byte-identical).
-	store = CsvPriceStore(
-		csv_paths=csv_paths,
-		start_date=start_date,
-		end_date=end_date or None)
-	feed = BacktestBarFeed(store, to_timedelta(timeframe))
 
 	# ScreenersHandler is a deferred subsystem (ignore_errors override).
 	screeners_handler = ScreenersHandler(ctx.bus, feed)  # type: ignore[no-untyped-call]

--- a/itrader/trading_system/engine_context.py
+++ b/itrader/trading_system/engine_context.py
@@ -1,26 +1,38 @@
-"""The frozen ``EngineContext`` infra bundle threaded into ``compose_engine`` (BUS-04/D-05).
+"""The frozen ``EngineContext`` mode-injection bundle threaded into ``compose_engine`` (BUS-04/D-05, D-01).
 
-``EngineContext`` is the small, mode-agnostic INFRASTRUCTURE bundle the composition
-root hands to ``compose_engine(ctx, spec)`` (CTX-01/D-01). It carries the shared
-event-bus transport plus the run-mode infra knobs (``config`` / ``environment`` /
-``sql_engine``) — the WHAT-to-run description lives on the separate ``SystemSpec``
-(D-02). The two-object split keeps the seam honest: infra on ``ctx``, declarative
-run description on ``spec``.
+``EngineContext`` is the small, mode-agnostic bundle the composition root hands to
+``compose_engine(ctx)`` (CTX-01/D-01). It carries the shared event-bus transport,
+the run-mode infra knobs (``config`` / ``environment``), AND the per-mode BACKENDS
+the mode-specific factory selects and injects (``feed`` / ``store`` / ``sql_engine``).
+The WHAT-to-run description stays factory-local — backtest keeps its ``SystemSpec``,
+live keeps a tiny venue spec — and never crosses this seam (D-02/D-04). ``ctx`` is the
+one place the mode factory differentiates and injects components per trading-system mode.
 
-Design invariants (D-05, LR-14):
+Design invariants (D-05, LR-14 — **consciously amended by D-01**):
 
-* **Exactly four fields, in order** — ``bus`` / ``config`` / ``environment`` /
-  ``sql_engine``. P3/P4/P9 only TIGHTEN the loose types (``config: Any`` narrows to
-  the concrete ``SystemConfig`` in P9; ``sql_engine`` is narrowed HERE in P3 from
-  ``Optional[Any]`` to the concrete ``Optional[SqlEngine]`` via a TYPE_CHECKING
-  forward-ref) — they NEVER widen a type and NEVER add a field. The shape is frozen here.
-* **Infra-only.** ``bus`` is the transport, ``config`` is carried but UNREAD on the
-  backtest path until P9, ``environment`` selects handler-owned storage backends,
-  ``sql_engine`` is ``None`` for backtest (keeps the path SQL-import-inert, GATE-01).
-* **Import-inert.** Only stdlib + the ``EventBus`` Protocol from
-  ``events_handler.bus`` are pulled (bus.py imports only stdlib + ``core.enums.event``,
-  so there is no import cycle). If a cycle ever appears, fall back to a
-  ``TYPE_CHECKING``-only import of ``EventBus`` and annotate the field ``"EventBus"``.
+* **LR-14 amendment (D-01).** The original invariant pinned ``EngineContext`` to
+  "exactly four fields (``bus`` / ``config`` / ``environment`` / ``sql_engine``) …
+  NEVER add a field. The shape is frozen here." Phase 06.1 (D-01) deliberately amends
+  that: ``feed`` (required) and ``store`` (Optional) are added because ``ctx`` IS the
+  mode-injection seam — ``sql_engine`` already rides here real-in-live / ``None``-in-
+  backtest, and ``store`` follows the IDENTICAL idiom real-in-backtest / ``None``-in-live
+  (D-02). Field types still only TIGHTEN downstream (``config: Any`` narrows to the
+  concrete ``SystemConfig`` in P9), never widen.
+* **Field order — required before defaulted.** ``bus`` / ``config`` / ``environment`` /
+  ``feed`` (all required) precede ``store`` / ``sql_engine`` (both default ``None``) so
+  the frozen dataclass does not raise "non-default argument follows default argument".
+* **Mode-injected backends.** ``feed`` is the required per-mode read-model
+  (``BacktestBarFeed`` in backtest, ``LiveBarFeed`` in live). ``store`` is the canonical
+  price store — REAL in backtest (``CsvPriceStore``), ``None`` in live (``LiveBarFeed``
+  reads no store, D-02) — the identical real/None idiom as ``sql_engine`` (``None`` for
+  backtest, keeps the path SQL-import-inert, GATE-01).
+* **Import-inert.** Only stdlib + the ``EventBus`` Protocol from ``events_handler.bus``
+  are pulled at runtime. The ``feed`` / ``store`` / ``sql_engine`` annotations are BASE
+  types resolved under ``TYPE_CHECKING`` only (D-03) — a real import of ``SqlEngine`` /
+  the concrete feed/store would pull SQLAlchemy or the concretions onto the backtest
+  import path and break GATE-01. Guarded string forward-refs keep them unevaluated at
+  runtime. If a cycle ever appears for ``EventBus`` too, fall back to a
+  ``TYPE_CHECKING``-only import and annotate the field ``"EventBus"``.
 
 Indentation: TABS (``trading_system/`` package convention).
 """
@@ -37,11 +49,17 @@ if TYPE_CHECKING:
 	# path and break GATE-01 inertness. Guarded + string forward-ref keeps the
 	# annotation unevaluated at runtime while narrowing the type for mypy.
 	from itrader.storage.engine import SqlEngine
+	# D-01/D-03: the new ``feed`` / ``store`` annotations forward-ref the BASE
+	# feed/store types under the SAME TYPE_CHECKING guard — the base modules are
+	# pure (no ccxt/SQL), and the CONCRETE ``LiveBarFeed`` is lazy-imported only
+	# inside the live factory. Guarded so ``engine_context`` stays import-inert.
+	from itrader.price_handler.feed.base import BarFeed
+	from itrader.price_handler.store.base import PriceStore
 
 
 @dataclass(frozen=True)
 class EngineContext:
-	"""Frozen infra bundle handed to ``compose_engine(ctx, spec)`` (D-05).
+	"""Frozen mode-injection bundle handed to ``compose_engine(ctx)`` (D-05, D-01).
 
 	Parameters
 	----------
@@ -55,6 +73,18 @@ class EngineContext:
 	environment : str
 		The run-mode selector (``"backtest"`` here) the handlers use to pick their
 		own storage backends (CTX-02 handler-owned storage).
+	feed : BarFeed
+		The REQUIRED per-mode market-data read-model the factory injects
+		(``BacktestBarFeed`` in backtest, ``LiveBarFeed`` in live). D-01: ``compose_engine``
+		reads ``ctx.feed`` uniformly rather than constructing a ``BacktestBarFeed`` itself,
+		so the seam is store/feed-agnostic. Annotated against the BASE ``BarFeed`` via a
+		TYPE_CHECKING forward-ref (D-03) — no concretion is pulled onto the import graph.
+	store : Optional[PriceStore]
+		The canonical price store — REAL in backtest (``CsvPriceStore``), ``None`` in
+		live (``LiveBarFeed`` reads no store, D-02). The IDENTICAL real/None idiom as
+		``sql_engine`` (real-in-live / None-in-backtest): ``ctx`` is where the mode
+		factory selects per-mode backends. Base-typed ``Optional["PriceStore"]`` via a
+		TYPE_CHECKING forward-ref (D-03), default ``None`` so live omits it.
 	sql_engine : Optional[SqlEngine]
 		The durable SQL engine handle, ``None`` for backtest — keeps the backtest
 		path SQL-import-inert (GATE-01). P3 (CTX-04) narrows this from the former
@@ -66,4 +96,6 @@ class EngineContext:
 	bus: EventBus
 	config: Any
 	environment: str
+	feed: "BarFeed"
+	store: Optional["PriceStore"] = None
 	sql_engine: Optional["SqlEngine"] = None

--- a/itrader/trading_system/live_trading_system.py
+++ b/itrader/trading_system/live_trading_system.py
@@ -30,7 +30,18 @@ from itrader.execution_handler.execution_handler import ExecutionHandler
 from itrader.execution_handler.exchanges.simulated import SimulatedExchange
 from itrader.trading_system.alert_sink import LogAlertSink
 from itrader.trading_system.venue_spec import build_venue_spec
+# 06.1-04 (SEAM-04/D-13): pure imports HOISTED to module top. Safe now because the
+# barrel drop (06.1-04 Task 1, D-12) removed this module from the backtest import graph,
+# so their module-top execution never touches the backtest path. session_initializer /
+# engine_context / universe_handler are all pure (no ccxt.pro/SQL/venue substrate) — the
+# P6 register-vs-build inertness block in test_okx_inertness proves importing this module
+# pulls no heavy backend. The genuinely-HEAVY imports (LiveBarFeed / SqlSettings / SQL
+# spine / ConnectorProvider / okx_plugin / assemble_venue / LiveRunner) STAY lazy inside
+# build_live_system's body (D-13).
+from itrader.trading_system.session_initializer import SessionInitializer
+from itrader.trading_system.engine_context import EngineContext
 from itrader.universe import Universe
+from itrader.universe.universe_handler import UniverseHandlerConfig
 
 from itrader.logger import get_itrader_logger
 from itrader.events_handler.bus import PriorityEventBus
@@ -912,12 +923,11 @@ class LiveTradingSystem:
         self.logger.info('Initializing live trading session')
 
         try:
-            # LAZY imports (mirror the donor's lazy live imports) so the backtest
-            # import path never pulls these onto its graph — the recurring inertness
-            # gate (tests/integration/test_okx_inertness.py).
+            # 06.1-04 (D-13): SessionInitializer / UniverseHandlerConfig hoisted to
+            # module top (the barrel drop removed this module from the backtest import
+            # graph, so their module-top import no longer touches the backtest path).
+            # ``config`` stays lazy here — it is read only inside this body.
             from itrader import config as _system_config
-            from itrader.trading_system.session_initializer import SessionInitializer
-            from itrader.universe.universe_handler import UniverseHandlerConfig
 
             # 06.1-02 (D-10): read the REAL compose Engine injected at construction
             # (build_live_system now calls compose_engine and injects the result). The
@@ -1529,11 +1539,11 @@ def build_live_system(
     # arm -> InMemoryOrderStorage). Live keeps exchange_config=None (the ExecutionHandler
     # default today — byte-preserving) and results_store=None. compose_engine reuses the
     # FeeModelCommissionEstimator admission adapter, retiring the re-inlined commission
-    # closure. compose_engine/EngineContext are PURE imports, taken lazily here to mirror
-    # the module's lazy-import discipline (inertness gate).
+    # closure. compose_engine is a PURE import, taken lazily here to mirror the module's
+    # lazy-import discipline (inertness gate). 06.1-04 (D-13): EngineContext is now
+    # hoisted to module top (pure — off the backtest graph after the barrel drop).
     from itrader import config as _system_config
     from itrader.trading_system.compose import compose_engine
-    from itrader.trading_system.engine_context import EngineContext
 
     ctx = EngineContext(
         bus=global_queue,

--- a/itrader/trading_system/live_trading_system.py
+++ b/itrader/trading_system/live_trading_system.py
@@ -1616,10 +1616,15 @@ def build_live_system(
             data_registry.register(_name, _plugin)
 
     # (2) D-23: the infra ctx wires live onto the PriorityEventBus (not the raw queue).
+    # 06.1-01 (D-01/D-02): the shared EngineContext now carries feed (required) + store
+    # (Optional). Live injects the LiveBarFeed and store=None (LiveBarFeed reads no
+    # store) — a construction-site fix only; the hand-rolled handler graph below is
+    # untouched this plan (the compose-consumption rewire is plan 06.1-02).
     ctx = EngineContext(
         bus=global_queue,
         config=_system_config,
         environment='live',
+        feed=feed, store=None,
         sql_engine=system_db_backend,
     )
     venue_spec = SimpleNamespace(

--- a/itrader/trading_system/live_trading_system.py
+++ b/itrader/trading_system/live_trading_system.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime, UTC
 from decimal import Decimal
 from types import SimpleNamespace
-from typing import Optional, Dict, Any, Callable
+from typing import Optional, Dict, Any, Callable, TYPE_CHECKING
 
 # D-14 (V17-11): bound on the pause-window protective-order replay queue. During a
 # pause/halt, system-generated protective orders (bracket children, OCO/orphan
@@ -35,6 +35,13 @@ from itrader.universe import Universe
 from itrader.logger import get_itrader_logger
 from itrader.events_handler.bus import PriorityEventBus
 from itrader.events_handler.events import EventType, ErrorEvent, UniversePollEvent
+
+if TYPE_CHECKING:
+    # Pure forward-refs for the pure-injection facade signature (06.1-02/D-10) — under
+    # TYPE_CHECKING so importing this module pulls neither onto the graph (compose is a
+    # pure import; VenueLifecycle is import-inert). The facade module is mypy ignore_errors.
+    from itrader.trading_system.compose import Engine
+    from itrader.venues.lifecycle import VenueLifecycle
 
 # RUN-01/RUN-02 (D-06): the live drain-loop timing knobs. Formerly loose
 # ``__init__`` params (``queue_timeout``/``max_idle_time``); the pure-injection
@@ -100,39 +107,6 @@ _EXTERNALLY_ADMISSIBLE = frozenset({EventType.SIGNAL, EventType.STRATEGY_COMMAND
 # imported above; the ``SystemStatus.X`` usages below resolve unchanged.
 
 
-@dataclass
-class LiveSystemComponents:
-    """The pre-built live component graph injected into the facade (RUN-01/D-09).
-
-    ``build_live_system`` owns ALL live wiring and packs the resulting handlers /
-    storages / feed / venue bundle into this bundle; ``LiveTradingSystem.__init__``
-    is PURE INJECTION — it stores these fields verbatim and holds NO wiring logic
-    (the live analog of ``compose_engine -> Engine`` feeding ``BacktestRunner``).
-    Fields are loose (``Any``) — the facade module is mypy ``ignore_errors`` (D-live).
-    """
-
-    exchange: str
-    global_queue: Any
-    store: Any
-    feed: Any
-    screeners_handler: Any
-    portfolio_handler: Any
-    strategies_handler: Any
-    order_handler: Any
-    execution_handler: Any
-    event_handler: Any
-    signal_store: Any
-    system_db_backend: Any
-    halt_record_store: Any
-    order_storage: Any
-    venue_bundle: Any
-    venue_lifecycle: Any
-    okx_connector: Any
-    okx_exchange: Any
-    okx_data_provider: Any
-    venue_account: Any
-
-
 class LiveTradingSystem:
     """
     Encapsulates the settings and components for carrying out live trading.
@@ -144,21 +118,26 @@ class LiveTradingSystem:
     
     def __init__(
         self,
-        components: "LiveSystemComponents",
         *,
+        engine: "Engine",
+        lifecycle: "Optional[VenueLifecycle]" = None,
+        system_db_backend: Optional[Any] = None,
+        halt_record_store: Optional[Any] = None,
+        exchange: str,
         status_callback: Optional[Callable[[SystemStatus, Dict[str, Any]], None]] = None,
     ):
-        """Pure-injection facade constructor (RUN-01/RUN-03/D-09).
+        """Pure-injection facade constructor (RUN-01/RUN-03/D-09/D-10).
 
-        ``build_live_system`` owns ALL live wiring and hands in the pre-built
-        ``LiveSystemComponents`` graph; this constructor holds NO wiring logic — it
-        stores the injected components and initialises fresh per-instance RUNTIME
-        state (status/locks/flags/stats). Mirrors ``compose_engine -> Engine ->
-        BacktestRunner`` (the injected engine is the source of truth; the holder is
-        thin). ``status_callback`` is the sole surviving loose param; the former
-        ``exchange``/``to_sql``/``queue_timeout``/``max_idle_time`` params are SHED
-        (``exchange`` now rides on the components; the two loop knobs are injected
-        into the ``LiveRunner`` by the factory).
+        DIRECT pure injection over the pre-built collaborators — NO ``components``
+        bag: the compose ``engine`` (the single source of truth for the handler
+        graph + its handler-owned storages + ``store=None``), the single
+        ``VenueLifecycle`` holder (D-07 — the venue/connector cluster, sourced off it
+        with the paper ``connector``-None guard, D-08), and the SEPARATE SQL spine +
+        halt store (D-09 — storage/durable infra, NOT venue/connector). ``exchange``
+        (the venue-name string) + ``status_callback`` are the remaining loose params.
+        Holds NO wiring logic; initialises fresh per-instance RUNTIME state
+        (status/locks/flags/stats). Mirrors ``compose_engine -> Engine ->
+        BacktestRunner`` (the injected engine is the source of truth; the holder is thin).
 
         D-03 boundary honesty: the ~200-line facade is a P7-EXIT gate (P7 owns the
         ~500 lines of safety/reconcile/stream extraction). The interim P6 facade is
@@ -166,35 +145,62 @@ class LiveTradingSystem:
 
         Parameters
         ----------
-        components : LiveSystemComponents
-            The pre-built live component graph (handlers/storages/feed/venue bundle).
+        engine : Engine
+            The compose ``Engine`` — the wired handler graph (+ handler-owned storages,
+            ``store=None`` on live). Source of truth for ``_initialize_live_session``.
+        lifecycle : VenueLifecycle, optional
+            The single venue/connector holder ``assemble_venue`` returns (D-07). ``None``
+            when the venue is unregistered; paper carries a lifecycle with ``connector=None``.
+        system_db_backend, halt_record_store : optional
+            The SEPARATE SQL spine + durable halt-record store (D-09) — storage/durable
+            infra, never folded into the venue holder.
+        exchange : str
+            The venue-name string (``spec.execution_venue``-derived).
         status_callback : callable, optional
             Callback to notify status changes to external systems.
         """
         self.logger = get_itrader_logger().bind(component="LiveTradingSystem")
         self.status_callback = status_callback
 
-        # -- Injected component graph (build_live_system owns its construction) --
-        self.exchange = components.exchange
-        self.global_queue = components.global_queue
-        self.store = components.store
-        self.feed = components.feed
-        self.screeners_handler = components.screeners_handler
-        self.portfolio_handler = components.portfolio_handler
-        self.strategies_handler = components.strategies_handler
-        self.order_handler = components.order_handler
-        self.execution_handler = components.execution_handler
-        self.event_handler = components.event_handler
-        self._signal_store = components.signal_store
-        self._system_db_backend: Optional[Any] = components.system_db_backend
-        self._halt_record_store: Optional[Any] = components.halt_record_store
-        self._order_storage = components.order_storage
-        self._venue_bundle: Optional[Any] = components.venue_bundle
-        self._venue_lifecycle: Optional[Any] = components.venue_lifecycle
-        self._okx_connector: Optional[Any] = components.okx_connector
-        self._okx_exchange: Optional[Any] = components.okx_exchange
-        self._okx_data_provider: Optional[Any] = components.okx_data_provider
-        self._venue_account: Optional[Any] = components.venue_account
+        # -- Injected compose Engine: the SINGLE source of truth for the handler graph;
+        #    handlers/feed/storages are sourced OFF it (no duplicate fields, D-10). --
+        self._engine = engine
+        self.exchange = exchange
+        self.global_queue = engine.global_queue
+        # D-02: engine.store is None on live — HELD, never read as a real store.
+        self.store = engine.store
+        self.feed = engine.feed
+        self.screeners_handler = engine.screeners_handler
+        self.portfolio_handler = engine.portfolio_handler
+        self.strategies_handler = engine.strategies_handler
+        self.order_handler = engine.order_handler
+        self.execution_handler = engine.execution_handler
+        self.event_handler = engine.event_handler
+        self._signal_store = engine.strategies_handler.signal_store
+        self._order_storage = engine.order_handler.storage
+
+        # -- SQL spine + halt store: SEPARATE infra handles (D-09, NOT venue/connector). --
+        self._system_db_backend: Optional[Any] = system_db_backend
+        self._halt_record_store: Optional[Any] = halt_record_store
+
+        # -- Venue/connector handles sourced off the SINGLE VenueLifecycle holder
+        #    (D-07/D-08). The ``lifecycle.bundle.connector``-is-not-None guard is the
+        #    streaming-venue discriminator: paper (connector=None) keeps every ``_okx_*``
+        #    handle None — byte-identical to build_live_system's former guard. The
+        #    safety/reconcile/stream method bodies that read these fields stay UNCHURNED
+        #    (P7 extracts from a known baseline, D-08). --
+        self._venue_lifecycle: Optional[Any] = lifecycle
+        self._venue_bundle: Optional[Any] = (
+            lifecycle.bundle if lifecycle is not None else None)
+        self._okx_connector: Optional[Any] = (
+            lifecycle.bundle.connector if lifecycle is not None else None)
+        self._okx_exchange: Optional[Any] = None
+        self._venue_account: Optional[Any] = None
+        self._okx_data_provider: Optional[Any] = None
+        if lifecycle is not None and lifecycle.bundle.connector is not None:
+            self._okx_exchange = lifecycle.bundle.exchange
+            self._venue_account = lifecycle.bundle.account_factory()
+            self._okx_data_provider = lifecycle.provider
 
         # -- Fresh per-instance RUNTIME state (NOT wiring) ----------------------
         # System status tracking
@@ -1555,30 +1561,27 @@ def build_live_system(
     )
     engine = compose_engine(ctx, exchange_config=None, results_store=None)
 
-    # Source the graph OFF the engine — NO hand-rolled parallel construction. compose
-    # already wired portfolio_handler.set_order_storage(order_handler.storage) and the
-    # FeeModelCommissionEstimator admission gate (D-05), so the former inline commission
-    # closure + the duplicate set_order_storage call are gone.
-    store = engine.store
-    screeners_handler = engine.screeners_handler
-    portfolio_handler = engine.portfolio_handler
+    # compose already wired portfolio_handler.set_order_storage(order_handler.storage) and
+    # the FeeModelCommissionEstimator admission gate (D-05), so the former inline commission
+    # closure + the duplicate set_order_storage call are gone. build_live_system only needs
+    # the three handles its remaining venue + post-facade wiring touches; the facade sources
+    # the FULL graph (+ storages, store=None) off the engine in __init__ (D-10), so no
+    # duplicate locals are threaded through here.
     execution_handler = engine.execution_handler
-    strategies_handler = engine.strategies_handler
-    order_handler = engine.order_handler
+    portfolio_handler = engine.portfolio_handler
     event_handler = engine.event_handler
-    order_storage = engine.order_handler.storage
-    signal_store = engine.strategies_handler.signal_store
 
     # ------------------------------------------------------------------
     # Venue wiring (Plan 02-05, D-04 / CONN-04 — relocated P5 D-06 assemble_venue call).
     # The whole OKX/paper venue stack is LAZY-imported here so the BACKTEST import path
     # stays async/ccxt/credential-free (the hot-path inertness gate).
+    # The single VenueLifecycle holder (D-07) + the two streaming handles the post-facade
+    # halt-signal wiring still needs (okx_exchange/okx_connector). The facade __init__
+    # sources ALL venue/connector fields (bundle/account/provider) off the lifecycle (D-08)
+    # — build_live_system no longer field-by-field unpacks it.
+    venue_lifecycle: Optional[Any] = None
     okx_connector: Optional[Any] = None
     okx_exchange: Optional[Any] = None
-    okx_data_provider: Optional[Any] = None
-    venue_account: Optional[Any] = None
-    venue_bundle: Optional[Any] = None
-    venue_lifecycle: Optional[Any] = None
 
     from itrader.connectors.provider import ConnectorProvider
     from itrader.venues.assemble import assemble_venue
@@ -1630,49 +1633,36 @@ def build_live_system(
     if exchange in exec_registry:
         bundle, venue_lifecycle = assemble_venue(
             ctx, venue_spec, connectors, exec_registry, data_registry)
-        venue_bundle = bundle
         provider = venue_lifecycle.provider
 
         # bundle.connector is the STREAMING-venue discriminator (okx present, paper None).
-        # A paper (connector=None) bundle has no streaming okx exchange/account; its data
-        # provider is still wired to the feed below (the injected TEST 'replay' provider in
-        # tests, or the OKX data provider in production paper — D-21).
+        # A paper (connector=None) bundle has no streaming okx exchange; its data provider
+        # is still wired to the feed below (the injected TEST 'replay' provider in tests, or
+        # the OKX data provider in production paper — D-21). The facade __init__ sources
+        # _venue_bundle/_venue_account/_okx_data_provider off the lifecycle (D-08); only the
+        # streaming-venue execution_handler registration + the halt-signal handles stay here.
         okx_connector = bundle.connector
         if bundle.connector is not None:
             okx_exchange = bundle.exchange
             execution_handler.exchanges[exchange] = bundle.exchange
-            venue_account = bundle.account_factory()
-            okx_data_provider = provider
 
         # (4) UNIFORM provider->feed wiring (D-10) that needs NO facade method.
         feed.set_provider(provider)
         provider.set_bar_sink(feed.update)
         provider.set_global_queue(global_queue)
 
-    # Construct the facade via PURE INJECTION (RUN-03/D-09).
-    components = LiveSystemComponents(
-        exchange=exchange,
-        global_queue=global_queue,
-        store=store,
-        feed=feed,
-        screeners_handler=screeners_handler,
-        portfolio_handler=portfolio_handler,
-        strategies_handler=strategies_handler,
-        order_handler=order_handler,
-        execution_handler=execution_handler,
-        event_handler=event_handler,
-        signal_store=signal_store,
+    # Construct the facade via DIRECT PURE INJECTION (RUN-03/D-09/D-10): the compose Engine
+    # is the single source of truth for the handler graph; the VenueLifecycle is the single
+    # venue/connector holder (D-07); the SQL spine + halt store stay SEPARATE infra handles
+    # (D-09). No LiveSystemComponents bag — the facade sources everything off these directly.
+    facade = LiveTradingSystem(
+        engine=engine,
+        lifecycle=venue_lifecycle,
         system_db_backend=system_db_backend,
         halt_record_store=halt_record_store,
-        order_storage=order_storage,
-        venue_bundle=venue_bundle,
-        venue_lifecycle=venue_lifecycle,
-        okx_connector=okx_connector,
-        okx_exchange=okx_exchange,
-        okx_data_provider=okx_data_provider,
-        venue_account=venue_account,
+        exchange=exchange,
+        status_callback=status_callback,
     )
-    facade = LiveTradingSystem(components, status_callback=status_callback)
 
     # Facade-dependent wiring (references the constructed facade's own gate methods).
     # The provider halt-signal + stream-state listeners for a registered venue, and the

--- a/itrader/trading_system/live_trading_system.py
+++ b/itrader/trading_system/live_trading_system.py
@@ -1,6 +1,5 @@
 import threading
 from collections import deque
-from dataclasses import dataclass
 from datetime import datetime, UTC
 from decimal import Decimal
 from typing import Optional, Dict, Any, Callable, TYPE_CHECKING
@@ -15,19 +14,9 @@ from typing import Optional, Dict, Any, Callable, TYPE_CHECKING
 _DEFERRED_PROTECTIVE_REPLAY_MAX = 1000
 
 from itrader.core.enums import ErrorSeverity, HaltReason, OrderCommand, SystemStatus, VALID_STATUS_TRANSITIONS
-from itrader.core.exceptions import ConfigurationError, StateError
-from itrader.events_handler.full_event_handler import EventHandler
+from itrader.core.exceptions import StateError
 from itrader.outils.time_parser import to_timedelta
-from itrader.price_handler.store.csv_store import CsvPriceStore
-from itrader.strategy_handler.strategies_handler import StrategiesHandler
-from itrader.strategy_handler.storage import SignalStorageFactory
-from itrader.screeners_handler.screeners_handler import ScreenersHandler
-from itrader.order_handler.order_handler import OrderHandler
-from itrader.order_handler.storage import OrderStorageFactory
-from itrader.portfolio_handler.portfolio_handler import PortfolioHandler
 from itrader.portfolio_handler.reconcile import is_within_single_unit_tolerance
-from itrader.execution_handler.execution_handler import ExecutionHandler
-from itrader.execution_handler.exchanges.simulated import SimulatedExchange
 from itrader.trading_system.alert_sink import LogAlertSink
 from itrader.trading_system.venue_spec import build_venue_spec
 # 06.1-04 (SEAM-04/D-13): pure imports HOISTED to module top. Safe now because the
@@ -45,7 +34,7 @@ from itrader.universe.universe_handler import UniverseHandlerConfig
 
 from itrader.logger import get_itrader_logger
 from itrader.events_handler.bus import PriorityEventBus
-from itrader.events_handler.events import EventType, ErrorEvent, UniversePollEvent
+from itrader.events_handler.events import EventType, ErrorEvent
 
 if TYPE_CHECKING:
     # Pure forward-refs for the pure-injection facade signature (06.1-02/D-10) — under

--- a/itrader/trading_system/live_trading_system.py
+++ b/itrader/trading_system/live_trading_system.py
@@ -3,7 +3,6 @@ from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, UTC
 from decimal import Decimal
-from types import SimpleNamespace
 from typing import Optional, Dict, Any, Callable, TYPE_CHECKING
 
 # D-14 (V17-11): bound on the pause-window protective-order replay queue. During a
@@ -30,6 +29,7 @@ from itrader.portfolio_handler.reconcile import is_within_single_unit_tolerance
 from itrader.execution_handler.execution_handler import ExecutionHandler
 from itrader.execution_handler.exchanges.simulated import SimulatedExchange
 from itrader.trading_system.alert_sink import LogAlertSink
+from itrader.trading_system.venue_spec import build_venue_spec
 from itrader.universe import Universe
 
 from itrader.logger import get_itrader_logger
@@ -277,12 +277,11 @@ class LiveTradingSystem:
         for a bespoke spec, or a ``data_plugins`` map for a TEST-only data provider
         injection (the paper↔replay pairing now lives ONLY in the test fixture, D-21).
         """
-        data_provider = overrides.pop('data_provider', None) or {
-            'okx': 'okx', 'paper': 'okx'}.get(exchange, 'okx')
         data_plugins = overrides.pop('data_plugins', None)
-        spec = SimpleNamespace(
-            execution_venue=exchange,
-            data_provider=data_provider,
+        # build_venue_spec owns the {okx,paper}->okx default-provider map (D-11 — one home).
+        spec = build_venue_spec(
+            exchange,
+            data_provider=overrides.pop('data_provider', None),
             account_id=overrides.pop('account_id', None),
         )
         return build_live_system(
@@ -1602,13 +1601,13 @@ def build_live_system(
     # venue assembly — the venue plugins read ctx.bus / ctx.config.stream (they never read
     # ctx.environment / ctx.store / ctx.sql_engine), so the arm-dependent environment is
     # transparent to venue assembly (D-23: live drains the PriorityEventBus ctx.bus wires).
-    venue_spec = SimpleNamespace(
-        execution_venue=exchange,
-        # D-21: production paper re-points to the OKX live data feed (the offline replay
-        # feed left production for tests/). A TEST fixture injects a 'replay' plugin via
-        # data_plugins and passes data_provider='replay' explicitly; production never does.
-        data_provider=(getattr(spec, 'data_provider', None) or {
-            'okx': 'okx', 'paper': 'okx'}.get(exchange, 'okx')),
+    # D-21: production paper re-points to the OKX live data feed (the offline replay
+    # feed left production for tests/). A TEST fixture injects a 'replay' plugin via
+    # data_plugins and passes data_provider='replay' explicitly; production never does.
+    # build_venue_spec owns the {okx,paper}->okx default-provider map (D-11 — one home).
+    venue_spec = build_venue_spec(
+        exchange,
+        data_provider=getattr(spec, 'data_provider', None),
         account_id=getattr(spec, 'account_id', None),
     )
 

--- a/itrader/trading_system/live_trading_system.py
+++ b/itrader/trading_system/live_trading_system.py
@@ -917,30 +917,14 @@ class LiveTradingSystem:
             # import path never pulls these onto its graph — the recurring inertness
             # gate (tests/integration/test_okx_inertness.py).
             from itrader import config as _system_config
-            from itrader.core.clock import BacktestClock
-            from itrader.trading_system.compose import Engine
             from itrader.trading_system.session_initializer import SessionInitializer
-            from itrader.trading_system.simulation.time_generator import TimeGenerator
             from itrader.universe.universe_handler import UniverseHandlerConfig
 
-            # INTERIM Engine holder (behavior-preserving): the facade still wires its
-            # own handlers directly this plan, so it assembles the compose ``Engine``
-            # holder from them for ``SessionInitializer`` / ``wire_universe``. ``clock``
-            # + ``time_generator`` are inert placeholders the live path never reads (only
-            # the handlers + feed + queue are consumed); 06-06's ``build_live_system``
-            # replaces this with the real ``compose_engine`` ``Engine``.
-            engine = Engine(
-                global_queue=self.global_queue,
-                clock=BacktestClock(),
-                store=self.store,
-                feed=self.feed,
-                strategies_handler=self.strategies_handler,
-                screeners_handler=self.screeners_handler,
-                portfolio_handler=self.portfolio_handler,
-                execution_handler=self.execution_handler,
-                order_handler=self.order_handler,
-                event_handler=self.event_handler,
-                time_generator=TimeGenerator())
+            # 06.1-02 (D-10): read the REAL compose Engine injected at construction
+            # (build_live_system now calls compose_engine and injects the result). The
+            # interim hand-assembled Engine holder (with its placeholder clock /
+            # time_generator) is gone — self._engine IS the compose graph.
+            engine = self._engine
 
             # The uniformly-resolved venue exchange (D-11): the OKX exchange when
             # present, else the paper 'simulated' exchange (permissive validate_symbol /

--- a/itrader/trading_system/live_trading_system.py
+++ b/itrader/trading_system/live_trading_system.py
@@ -1474,12 +1474,12 @@ def build_live_system(
     # strict FIFO, so live behavior is unchanged in P6). LiveRunner drains it; CONTROL
     # routes are NOT registered (their P7/P9 consumers don't exist yet).
     global_queue = PriorityEventBus()
-    store = CsvPriceStore()
     # Phase 3 (FEED-05): LiveBarFeed is the live driver — LAZY-imported here so the
-    # BACKTEST import path never pulls live_bar_feed (inertness gate).
+    # BACKTEST import path never pulls live_bar_feed (inertness gate). D-02: live carries
+    # store=None (the LiveBarFeed reads no store); the whole handler graph — screeners
+    # included — now comes from compose_engine below, so no store/screeners are built here.
     from itrader.price_handler.feed.live_bar_feed import LiveBarFeed
     feed = LiveBarFeed(provider=None, base_timeframe=to_timedelta('1d'))
-    screeners_handler = ScreenersHandler(global_queue, feed)
 
     # ------------------------------------------------------------------
     # v1.6 operational store live-drive (05-06, RECON-04, D-10/D-11).
@@ -1498,78 +1498,76 @@ def build_live_system(
             "ITRADER_DATABASE_URL unset) — using in-memory order + signal storage "
             "(orders/signals will NOT survive a restart)"
         )
-        order_storage = OrderStorageFactory.create('backtest')
-        signal_store = SignalStorageFactory.create_in_memory()
+        # 06.1-02 (SEAM-01/D-05): the arm now selects ONLY the environment string + the
+        # shared SQL spine — compose_engine's handler-OWNED storage init derives the
+        # concrete backends from (environment, sql_engine). 'backtest' with sql_engine=None
+        # yields the in-memory order + signal stores byte-identical to the former explicit
+        # fallback construction (OrderStorageFactory.create('backtest') / create_in_memory()).
+        environment = 'backtest'
         system_db_backend: Optional[Any] = None
     else:
         # CR-01/RECON-04: honor the unified ITRADER_DATABASE_* Postgres surface — one
         # SqlEngine drives the whole v1.6 operational store (same source Alembic uses).
         from itrader.config.sql import SqlDriver, SqlSettings
         from itrader.storage import SqlEngine
-        from itrader.order_handler.storage.cached_sql_storage import (
-            CachedSqlOrderStorage,
-        )
-        from itrader.order_handler.storage.sql_storage import SqlOrderStorage
 
+        # 06.1-02 (SEAM-01/D-05): 'live' + the shared SqlEngine drive compose's
+        # handler-OWNED storage to the SAME durable path the former explicit construction
+        # built — orders via CachedSqlOrderStorage(SqlOrderStorage(backend)) (store-first
+        # working set, rehydrate() on restart), the signal store live-driven over the same
+        # spine (see OrderStorageFactory / SignalStorageFactory '.create('live', ...)').
         backend = SqlEngine(SqlSettings(driver=SqlDriver.POSTGRESQL_PSYCOPG2))
-        # D-10: store-first working set (persist-then-acknowledge) via the CachedSql
-        # wrapper over the untouched SqlOrderStorage; rehydrate() rebuilds it on restart.
-        order_storage = CachedSqlOrderStorage(SqlOrderStorage(backend))
+        environment = 'live'
         system_db_backend = backend
-        # D-11: signal store live-driven on the async/best-effort path over the SAME spine.
-        signal_store = SignalStorageFactory.create('live', sql_engine=backend)
-
-    # 05.2-05 (D-07): durable portfolio ledger when the Postgres spine is present.
-    if system_db_backend is not None:
-        portfolio_handler = PortfolioHandler(
-            global_queue, environment='live', sql_engine=system_db_backend)
-    else:
-        portfolio_handler = PortfolioHandler(global_queue)
 
     # 05.2-06 (D-10 / ARCH-4 Layer 2): durable halt-record store over the shared spine
     # (survives a process restart) — None on the in-memory fallback (degrade cleanly).
+    # D-09: the SQL spine (system_db_backend) + halt_record_store stay SEPARATE facade/
+    # infra handles — NOT folded into the venue holder (folding would recreate the bag).
     if system_db_backend is not None:
         from itrader.storage.halt_record_store import HaltRecordStore
         halt_record_store: Optional[Any] = HaltRecordStore(system_db_backend)
     else:
         halt_record_store = None
 
-    # Execution handler BEFORE the order handler (admission commission estimator, D-04).
-    execution_handler = ExecutionHandler(global_queue)
-    simulated_exchange = execution_handler.exchanges.get('simulated')
+    # ------------------------------------------------------------------
+    # 06.1-02 (SEAM-01 live consumption / D-05): obtain the live handler graph from the
+    # now spec-free compose_engine instead of hand-rolling a parallel copy. The shared
+    # EngineContext is the mode-injection seam: feed=the LiveBarFeed, store=None (the
+    # LiveBarFeed reads no store, D-02), and environment + sql_engine reflect the
+    # credential-probe arm so compose's handler-OWNED storage init lands the identical
+    # durable path (Postgres arm -> CachedSqlOrderStorage over the SQL spine; in-memory
+    # arm -> InMemoryOrderStorage). Live keeps exchange_config=None (the ExecutionHandler
+    # default today — byte-preserving) and results_store=None. compose_engine reuses the
+    # FeeModelCommissionEstimator admission adapter, retiring the re-inlined commission
+    # closure. compose_engine/EngineContext are PURE imports, taken lazily here to mirror
+    # the module's lazy-import discipline (inertness gate).
+    from itrader import config as _system_config
+    from itrader.trading_system.compose import compose_engine
+    from itrader.trading_system.engine_context import EngineContext
 
-    def _estimate_commission(quantity: Decimal, price: Decimal) -> Decimal:
-        if not isinstance(simulated_exchange, SimulatedExchange):
-            return Decimal("0")
-        return simulated_exchange.fee_model.calculate_fee(
-            quantity, price, side="buy", order_type="market")
-
-    # Plan 02-03 (D-09/D-14): thread the portfolio's margin settings into the order
-    # domain (mirrors compose_engine). SHORT-01/D-07: thread the shorts-enabling flags.
-    _trading_rules = portfolio_handler.config_data.trading_rules
-    strategies_handler = StrategiesHandler(
-        global_queue, feed, signal_store,
-        allow_short_selling=_trading_rules.allow_short_selling,
-        enable_margin=_trading_rules.enable_margin)
-
-    order_handler = OrderHandler(
-        global_queue, portfolio_handler, order_storage,
-        commission_estimator=_estimate_commission,
-        enable_margin=_trading_rules.enable_margin,
-        portfolio_max_leverage=_trading_rules.max_leverage)
-    # LIQ-03 (04-03): live-parity injection of the SAME order_storage into the portfolio
-    # handler so a BAR-route liquidation registers its Order in the shared mirror.
-    portfolio_handler.set_order_storage(order_storage)
-
-    event_handler = EventHandler(
-        strategies_handler,
-        screeners_handler,
-        portfolio_handler,
-        order_handler,
-        execution_handler,
-        feed.generate_bar_event,
-        global_queue,
+    ctx = EngineContext(
+        bus=global_queue,
+        config=_system_config,
+        environment=environment,
+        feed=feed, store=None,
+        sql_engine=system_db_backend,
     )
+    engine = compose_engine(ctx, exchange_config=None, results_store=None)
+
+    # Source the graph OFF the engine — NO hand-rolled parallel construction. compose
+    # already wired portfolio_handler.set_order_storage(order_handler.storage) and the
+    # FeeModelCommissionEstimator admission gate (D-05), so the former inline commission
+    # closure + the duplicate set_order_storage call are gone.
+    store = engine.store
+    screeners_handler = engine.screeners_handler
+    portfolio_handler = engine.portfolio_handler
+    execution_handler = engine.execution_handler
+    strategies_handler = engine.strategies_handler
+    order_handler = engine.order_handler
+    event_handler = engine.event_handler
+    order_storage = engine.order_handler.storage
+    signal_store = engine.strategies_handler.signal_store
 
     # ------------------------------------------------------------------
     # Venue wiring (Plan 02-05, D-04 / CONN-04 — relocated P5 D-06 assemble_venue call).
@@ -1582,9 +1580,7 @@ def build_live_system(
     venue_bundle: Optional[Any] = None
     venue_lifecycle: Optional[Any] = None
 
-    from itrader import config as _system_config
     from itrader.connectors.provider import ConnectorProvider
-    from itrader.trading_system.engine_context import EngineContext
     from itrader.venues.assemble import assemble_venue
     from itrader.venues.okx_plugin import (
         OkxConnectorPlugin,
@@ -1615,18 +1611,10 @@ def build_live_system(
         for _name, _plugin in data_plugins.items():
             data_registry.register(_name, _plugin)
 
-    # (2) D-23: the infra ctx wires live onto the PriorityEventBus (not the raw queue).
-    # 06.1-01 (D-01/D-02): the shared EngineContext now carries feed (required) + store
-    # (Optional). Live injects the LiveBarFeed and store=None (LiveBarFeed reads no
-    # store) — a construction-site fix only; the hand-rolled handler graph below is
-    # untouched this plan (the compose-consumption rewire is plan 06.1-02).
-    ctx = EngineContext(
-        bus=global_queue,
-        config=_system_config,
-        environment='live',
-        feed=feed, store=None,
-        sql_engine=system_db_backend,
-    )
+    # (2) The shared mode-injection EngineContext built above (06.1-02) is REUSED for
+    # venue assembly — the venue plugins read ctx.bus / ctx.config.stream (they never read
+    # ctx.environment / ctx.store / ctx.sql_engine), so the arm-dependent environment is
+    # transparent to venue assembly (D-23: live drains the PriorityEventBus ctx.bus wires).
     venue_spec = SimpleNamespace(
         execution_venue=exchange,
         # D-21: production paper re-points to the OKX live data feed (the offline replay

--- a/itrader/trading_system/venue_spec.py
+++ b/itrader/trading_system/venue_spec.py
@@ -1,0 +1,87 @@
+"""Live-only venue-selection spec + its single shared builder (SEAM-03, D-11).
+
+After D-04 made ``compose_engine`` SPEC-FREE, the ONLY "spec" the live path still
+needs is the venue-selection trio that ``assemble_venue`` reads:
+``execution_venue`` / ``data_provider`` / ``account_id``. This module promotes that
+duck-typed ``SimpleNamespace`` into a small typed value object.
+
+Locked decision for this module:
+
+* **D-11 — a small live-only ``VenueSpec`` for ``assemble_venue``, NOT a compose
+  spec.** A frozen ``VenueSpec`` carrying exactly ``execution_venue`` /
+  ``data_provider`` / ``account_id`` (3 fields, genuinely venue-scoped, not
+  backtest-shaped) feeds ``assemble_venue`` ONLY — it NEVER crosses into
+  ``compose_engine`` (compose is spec-free since D-04). ONE shared builder
+  (``build_venue_spec``) produces it and is the SOLE home of the
+  ``{'okx':'okx','paper':'okx'}`` default-provider map; BOTH ``for_exchange`` and
+  ``build_live_system`` call it, killing the twice-written ``SimpleNamespace`` +
+  default-map. A typed dataclass (frozen ``__eq__``) is preferred over the
+  duck-typed ``SimpleNamespace`` — mypy-friendly, self-documenting, and the free
+  equality lets the SEAM-03 unit test prove ``for_exchange`` and
+  ``build_live_system`` produce IDENTICAL specs.
+
+Import-inert by construction: this module is PURE (strings + a dataclass) — it
+imports NO venue substrate / ccxt / SQL, so it never touches the backtest import
+graph and stays ``mypy --strict`` clean.
+
+Indentation: TABS (``trading_system/`` package convention; mirrors the sibling
+``system_spec.py``).
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class VenueSpec:
+	"""The live venue-selection trio ``assemble_venue`` reads (D-11).
+
+	Exactly the three fields ``assemble_venue`` consumes off ``spec`` —
+	``execution_venue`` (selects the ``ExecutionVenueRegistry`` plugin),
+	``data_provider`` (selects the ``DataProviderRegistry`` plugin), and
+	``account_id`` (keys the ``ConnectorProvider`` memo). Frozen so equality is
+	free — two specs built from the same inputs compare equal, which is the
+	load-bearing SEAM-03 invariant (``for_exchange`` == ``build_live_system``).
+
+	It feeds ``assemble_venue`` ONLY — never ``compose_engine`` (spec-free since
+	D-04).
+	"""
+
+	execution_venue: str
+	data_provider: str
+	account_id: Optional[str] = None
+
+
+def build_venue_spec(
+	execution_venue: str,
+	*,
+	data_provider: Optional[str] = None,
+	account_id: Optional[str] = None,
+) -> VenueSpec:
+	"""Build the live ``VenueSpec``, applying the default-provider map (D-11).
+
+	The SOLE home of the ``{'okx':'okx','paper':'okx'}`` default-provider map: when
+	``data_provider`` is not given, it is derived from ``execution_venue`` (``okx``
+	for the okx venue, the OKX live feed for paper (D-21), else ``okx``). An explicit
+	``data_provider`` override is honored verbatim. BOTH ``for_exchange`` and
+	``build_live_system`` call this builder so the map + spec construction exist in
+	exactly ONE location.
+
+	Parameters
+	----------
+	execution_venue :
+		The venue-name string selecting the execution plugin.
+	data_provider :
+		An explicit data-provider override; when ``None`` the default-provider map
+		is applied over ``execution_venue``.
+	account_id :
+		The connector-memo key; ``None`` defers to the plugins' ``"default"``
+		fallback (``assemble_venue`` does NOT re-default it).
+	"""
+	resolved_provider = data_provider or {
+		'okx': 'okx', 'paper': 'okx'}.get(execution_venue, 'okx')
+	return VenueSpec(
+		execution_venue=execution_venue,
+		data_provider=resolved_provider,
+		account_id=account_id,
+	)

--- a/tests/integration/test_okx_inertness.py
+++ b/tests/integration/test_okx_inertness.py
@@ -359,10 +359,18 @@ def test_production_build_live_system_registers_no_replay_data_provider() -> Non
     the paper→okx system would require credentials, but the registration/selection SOURCE is
     the load-bearing invariant. A future edit that re-registers ``'replay'`` in production (or
     re-points the paper map back to ``'replay'``) reddens this loudly.
+
+    SEAM-03/D-11: the ``{'okx':'okx','paper':'okx'}`` default-provider map was centralized
+    into the shared ``build_venue_spec`` builder (``trading_system/venue_spec.py``) — its
+    SOLE home — which BOTH ``for_exchange`` and ``build_live_system`` call. The paper→okx
+    selection invariant is therefore asserted against ``build_venue_spec``'s source now (the
+    inline ``SimpleNamespace`` + map in ``build_live_system`` was deleted); the registration
+    assertions still inspect ``build_live_system`` where ``data_registry.register`` lives.
     """
     import inspect
 
     from itrader.trading_system import live_trading_system as _lts
+    from itrader.trading_system import venue_spec as _venue_spec
 
     source = inspect.getsource(_lts.build_live_system)
 
@@ -374,11 +382,13 @@ def test_production_build_live_system_registers_no_replay_data_provider() -> Non
         "production build_live_system must register NO 'replay' data provider — the replay "
         "harness left itrader for tests/ (D-18); a test fixture injects it via data_plugins"
     )
-    # The paper venue selects the OKX live data feed (D-21), never the replay feed.
-    assert "'paper': 'okx'" in source or '"paper": "okx"' in source, (
-        "production build_live_system must map paper→'okx' (the OKX live data feed, D-21)"
+    # The paper venue selects the OKX live data feed (D-21), never the replay feed. Since
+    # SEAM-03/D-11 the default-provider map lives in the shared build_venue_spec builder.
+    builder_source = inspect.getsource(_venue_spec.build_venue_spec)
+    assert "'paper': 'okx'" in builder_source or '"paper": "okx"' in builder_source, (
+        "build_venue_spec must map paper→'okx' (the OKX live data feed, D-21/D-11)"
     )
-    assert "'paper': 'replay'" not in source and '"paper": "replay"' not in source, (
-        "production build_live_system must NOT map paper→'replay' (the replay feed left "
-        "production for the test fixture, D-21)"
+    assert "'paper': 'replay'" not in builder_source and '"paper": "replay"' not in builder_source, (
+        "build_venue_spec must NOT map paper→'replay' (the replay feed left production for "
+        "the test fixture, D-21)"
     )

--- a/tests/integration/test_okx_inertness.py
+++ b/tests/integration/test_okx_inertness.py
@@ -117,12 +117,24 @@ assert "sql" not in _cfg.__dict__, (
 # import failure mode, GATE-01 lineage).
 from itrader.events_handler.bus import FifoEventBus
 from itrader.trading_system.engine_context import EngineContext
+# 06.1-01 (D-01/D-03): the EngineContext now carries a REQUIRED ``feed`` + Optional
+# ``store``. The probe builds a PURE BacktestBarFeed over a CsvPriceStore — both are
+# already on the backtest import graph, so the register-vs-build inertness assertion
+# below (no ccxt.pro/SQL pulled, `sql` cached_property unresolved) still holds.
+from itrader.price_handler.store.csv_store import CsvPriceStore
+from itrader.price_handler.feed.bar_feed import BacktestBarFeed
+from itrader.outils.time_parser import to_timedelta
 _bus = FifoEventBus()
-_ctx = EngineContext(bus=_bus, config=_cfg, environment="backtest", sql_engine=None)
+_store = CsvPriceStore()
+_feed = BacktestBarFeed(_store, to_timedelta("1d"))
+_ctx = EngineContext(
+    bus=_bus, config=_cfg, environment="backtest",
+    feed=_feed, store=_store, sql_engine=None)
 _heavy = [name for name in ("sqlalchemy", "ccxt") if name in sys.modules]
 assert not _heavy, (
     "P2 register-vs-build inertness violation: constructing FifoEventBus/"
-    "EngineContext(sql_engine=None) pulled a heavy backend: " + repr(_heavy)
+    "EngineContext(feed=BacktestBarFeed, sql_engine=None) pulled a heavy backend: "
+    + repr(_heavy)
 )
 assert "sql" not in _cfg.__dict__, (
     "P2 register-vs-build inertness violation: building the EngineContext resolved "

--- a/tests/integration/test_okx_inertness.py
+++ b/tests/integration/test_okx_inertness.py
@@ -98,6 +98,21 @@ assert not leaked, (
     "stack: " + repr(leaked) + " (must be lazy-imported inside the live path only)"
 )
 
+# Phase 06.1 (SEAM-04, D-12): the trading_system barrel DROPPED the live surface
+# entirely — importing the backtest root (above) pulls ONLY the backtest composition
+# root, so the live module itself must be ABSENT from sys.modules at this point. Before
+# the barrel drop, `trading_system/__init__.py` eagerly imported LiveTradingSystem /
+# build_live_system, silently dragging the whole live module onto the backtest import
+# graph (the root cause of the pervasive lazy-imports-inside-methods). The later
+# explicit `from itrader.trading_system.live_trading_system import build_live_system`
+# (in the P6 register-vs-build block below) runs AFTER this assertion and legitimately
+# pulls the module for the register-vs-build check — it does not weaken this guard.
+assert "itrader.trading_system.live_trading_system" not in sys.modules, (
+    "SEAM-04/D-12 INERTNESS VIOLATION: importing the backtest root pulled "
+    "itrader.trading_system.live_trading_system onto the backtest import graph — the "
+    "trading_system barrel must NOT re-import (or re-export) the live module (D-12)"
+)
+
 # Phase 1 (CFG-02, D-05/D-06 register-vs-build): importing itrader runs
 # SystemConfig.default() (itrader/__init__.py). The lazy `sql` cached_property must
 # stay UNRESOLVED at import — its absence from the singleton's __dict__ proves zero

--- a/tests/unit/trading_system/test_venue_spec.py
+++ b/tests/unit/trading_system/test_venue_spec.py
@@ -1,0 +1,102 @@
+"""SEAM-03/D-11 — the shared ``build_venue_spec`` builder + the for_exchange↔build_live_system identity.
+
+After D-04 made ``compose_engine`` spec-free, the ONLY "spec" the live path still needs is
+the venue-selection trio ``assemble_venue`` reads (``execution_venue`` / ``data_provider`` /
+``account_id``). SEAM-03/D-11 centralizes that into ONE typed ``VenueSpec`` + ONE shared
+``build_venue_spec`` builder — the SOLE home of the ``{'okx':'okx','paper':'okx'}``
+default-provider map — that BOTH ``for_exchange`` and ``build_live_system`` call.
+
+The load-bearing SEAM-03 invariant this test guards: ``for_exchange('X')`` and a direct
+``build_live_system(spec)`` produce IDENTICAL ``VenueSpec``s across the venue set, so the two
+entry points CANNOT DRIFT. The assertion is on the SPEC the two paths build (via
+``VenueSpec.__eq__``), NOT a live facade — CI-safe (no OKX credentials, no venue connect).
+
+Modelling the two entry points faithfully (without standing up a facade):
+
+* **for_exchange path** — for a venue ``V`` with no explicit overrides, ``for_exchange`` calls
+  ``build_venue_spec(V, data_provider=None, account_id=None)`` → the default-map resolves the
+  provider. That resolved ``VenueSpec`` is what it hands to ``build_live_system``.
+* **build_live_system path** — it reads the incoming spec's fields and re-calls
+  ``build_venue_spec(V, data_provider=spec.data_provider, account_id=spec.account_id)``. Because
+  ``build_venue_spec`` is idempotent (re-resolving an already-resolved provider is stable), the
+  spec it feeds ``assemble_venue`` equals the one ``for_exchange`` built.
+
+Package-less test dir (no ``__init__.py``) to avoid the full-suite package collision; the
+folder-derived ``unit`` marker is auto-applied (nothing marked by hand). Indentation: 4-SPACE.
+"""
+
+import pytest
+
+from itrader.trading_system.venue_spec import VenueSpec, build_venue_spec
+
+
+# The venue set: the two mapped venues (okx, paper) + one "other" that falls through to 'okx'.
+_VENUE_SET = ['okx', 'paper', 'binance']
+
+# The default-provider map's expected resolution ('okx'->'okx', 'paper'->'okx', other->'okx').
+_EXPECTED_PROVIDER = {'okx': 'okx', 'paper': 'okx', 'binance': 'okx'}
+
+
+@pytest.mark.parametrize('venue', _VENUE_SET)
+def test_build_venue_spec_applies_default_provider_map(venue: str) -> None:
+    """build_venue_spec resolves the default provider from the {okx,paper}->okx map (D-11)."""
+    spec = build_venue_spec(venue)
+
+    assert isinstance(spec, VenueSpec)
+    assert spec.execution_venue == venue
+    assert spec.data_provider == _EXPECTED_PROVIDER[venue]
+    assert spec.account_id is None
+
+
+@pytest.mark.parametrize('venue', _VENUE_SET)
+def test_build_venue_spec_honors_explicit_overrides(venue: str) -> None:
+    """An explicit data_provider / account_id override wins over the default map (D-11)."""
+    spec = build_venue_spec(venue, data_provider='replay', account_id='acct-7')
+
+    assert spec.execution_venue == venue
+    assert spec.data_provider == 'replay'  # explicit override, NOT the default map
+    assert spec.account_id == 'acct-7'
+
+
+@pytest.mark.parametrize('venue', _VENUE_SET)
+def test_for_exchange_and_build_live_system_produce_identical_specs(venue: str) -> None:
+    """SEAM-03 identity: the two live entry points build EQUAL VenueSpecs (D-11).
+
+    Models both paths through the shared builder with matching inputs and asserts equality
+    via ``VenueSpec.__eq__`` — the invariant that the twice-written spec cannot drift.
+    """
+    # for_exchange path: no explicit overrides -> the default map resolves the provider.
+    for_exchange_spec = build_venue_spec(
+        venue, data_provider=None, account_id=None)
+
+    # build_live_system path: consumes the incoming spec's already-resolved fields and
+    # re-builds through the SAME builder (idempotent re-resolution).
+    build_live_system_spec = build_venue_spec(
+        venue,
+        data_provider=getattr(for_exchange_spec, 'data_provider', None),
+        account_id=getattr(for_exchange_spec, 'account_id', None),
+    )
+
+    assert for_exchange_spec == build_live_system_spec
+    assert build_live_system_spec.data_provider == _EXPECTED_PROVIDER[venue]
+
+
+@pytest.mark.parametrize('venue', _VENUE_SET)
+def test_identity_holds_under_explicit_provider_override(venue: str) -> None:
+    """The identity also holds when for_exchange carries an explicit data_provider (D-11).
+
+    A bespoke ``for_exchange(V, data_provider='replay')`` spec, once consumed by
+    ``build_live_system``, is re-built identically (the explicit provider survives the
+    round-trip unchanged).
+    """
+    for_exchange_spec = build_venue_spec(
+        venue, data_provider='replay', account_id='acct-9')
+    build_live_system_spec = build_venue_spec(
+        venue,
+        data_provider=getattr(for_exchange_spec, 'data_provider', None),
+        account_id=getattr(for_exchange_spec, 'account_id', None),
+    )
+
+    assert for_exchange_spec == build_live_system_spec
+    assert build_live_system_spec.data_provider == 'replay'
+    assert build_live_system_spec.account_id == 'acct-9'


### PR DESCRIPTION
This pull request updates the project planning documentation to mark Phase 6.1 ("Seam Cleanup") as complete and adds detailed breakdowns of the work performed during this phase. It also refreshes project state tracking to reflect the completion of Phase 6.1 and the transition to Phase 7. The most important changes are summarized below.

**Phase 6.1 Completion and Documentation Updates:**

* Marked Phase 6.1 ("Seam Cleanup") as completed in `.planning/ROADMAP.md`, including the completion date and progress updates in the summary table. [[1]](diffhunk://#diff-50b07cc2a4b37b50419fd3b063aea1f5d1fe2a2b90a47254943677108d0008bbL108-R108) [[2]](diffhunk://#diff-50b07cc2a4b37b50419fd3b063aea1f5d1fe2a2b90a47254943677108d0008bbL404-R409)
* Replaced the placeholder "Plans: TBD" with a list of four completed plan documents detailing the sub-tasks and deliverables for Phase 6.1.

**Project State Tracking:**

* Updated `.planning/STATE.md` to reflect the completion of Phase 6.1, including new timestamps, last activity descriptions, and the current focus shifting to Phase 7. [[1]](diffhunk://#diff-10c47d0e33270cc4a979d56198376cf3a9df6cc3a3c397ef7d5131afda869b40L8-R11) [[2]](diffhunk://#diff-10c47d0e33270cc4a979d56198376cf3a9df6cc3a3c397ef7d5131afda869b40L29-R29) [[3]](diffhunk://#diff-10c47d0e33270cc4a979d56198376cf3a9df6cc3a3c397ef7d5131afda869b40L39-R39)
* Added detailed records of the work done in each 6.1 sub-phase, including technical highlights and task/file counts, to the project state and progress sections. [[1]](diffhunk://#diff-10c47d0e33270cc4a979d56198376cf3a9df6cc3a3c397ef7d5131afda869b40R166-R170) [[2]](diffhunk://#diff-10c47d0e33270cc4a979d56198376cf3a9df6cc3a3c397ef7d5131afda869b40R224-R227)

**Session Continuity and Resume Point:**

* Updated session continuity information to record the completion of 06.1-04-PLAN.md and set the resume file for the next session to the Phase 6.1 context document.